### PR TITLE
feat(monitors): add HDF5 pointing metadata to live dashboards

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -118,7 +118,7 @@ jobs:
           set -euo pipefail
           rm -rf "${MONITOR_OUT_DIR}"
           mkdir -p "${MONITOR_OUT_DIR}"
-          dsacamera-incoming-scan --root "${{ matrix.source_root }}" --out "${MONITOR_OUT_DIR}"
+          dsacamera-incoming-scan --root "${{ matrix.source_root }}" --out "${MONITOR_OUT_DIR}" --pointing-timeseries --pointing-timeseries-max-files 5000
 
       - name: Validate monitor artifact contract
         shell: bash

--- a/tools/dsacamera-monitor/README.md
+++ b/tools/dsacamera-monitor/README.md
@@ -9,7 +9,7 @@ This repository was split out from `dsa110-FLITS`; the CLI was renamed from `dsa
 `manifest.json` is **schema version 2** (v1 is still valid for old snapshots). Key fields:
 
 | Field | Description |
-|--------|-------------|
+| -------- | ----------- |
 | `schema_version` | Integer (currently `2`) |
 | `generated_at` | ISO8601 UTC when the scan finished |
 | `source_root` | Directory that was scanned |
@@ -21,7 +21,7 @@ This repository was split out from `dsa110-FLITS`; the CLI was renamed from `dsa
 | `by_beam` | `{ beam, count, bytes }[]` sorted by beam id |
 | `gaps` | `{ start, end, days }` ranges with zero files between first/last day with data |
 | `freshness` | Earliest/latest timestamp from filenames; mtime range when not `no_stat` |
-| `pointing` | When metadata scan is on: global Dec min/max, unique rounded strips, file counts |
+| `pointing` | When metadata scan is on: global Dec min/max, unique rounded strip count, and file counters |
 | `pointing_timeseries` | When `--pointing-timeseries` is used: `{ file, row_count, truncated }` pointing at `pointing_timeseries.json` |
 
 Filenames must match:
@@ -51,7 +51,7 @@ python -m dsacamera_monitor.scan --root /data/incoming --out /path/to/out
 - Writes `/path/to/out/manifest.json` and copies static assets from `dsacamera_monitor/site/` into `out/`.
 - By default each matching `.hdf5` is opened once to read phase-center **Declination** from UVH5 headers (cheap metadata only; no visibilities). Use `--no-hdf5-metadata` to skip that (faster on huge trees, no Dec in manifest).
 - Optional `--pointing-timeseries` writes `pointing_timeseries.json` (per file: median time, RA, Dec) with rows capped by `--pointing-timeseries-max-files` (default 5000). RA may be derived from `ha_phase_center` + LST at median time, matching the main pipeline’s HDF5 convention.
-- **Performance:** the scan is O(number of files): one `h5py.File` open per file for metadata. On slow NFS, prefer cron spacing or metadata-off for smoke tests.
+- **Performance:** metadata extraction is O(number of files) and uses one `h5py.File` open per file (Dec and optional timeseries fields are extracted in that single pass). On slow NFS, prefer cron spacing or metadata-off for smoke tests.
 - Open `out/index.html` in a browser (or serve the directory with any static file server).
 
 ### Fast count-only (no `stat`)

--- a/tools/dsacamera-monitor/README.md
+++ b/tools/dsacamera-monitor/README.md
@@ -6,19 +6,23 @@ This repository was split out from `dsa110-FLITS`; the CLI was renamed from `dsa
 
 ## Manifest schema
 
-`manifest.json` is **schema version 1**. Key fields:
+`manifest.json` is **schema version 2** (v1 is still valid for old snapshots). Key fields:
 
 | Field | Description |
 |--------|-------------|
-| `schema_version` | Integer (currently `1`) |
+| `schema_version` | Integer (currently `2`) |
 | `generated_at` | ISO8601 UTC when the scan finished |
 | `source_root` | Directory that was scanned |
 | `options.no_stat` | If true, sizes and mtime freshness were not collected |
+| `options.hdf5_metadata` | If false (`--no-hdf5-metadata`), HDF5 files are not opened; no `pointing` block |
+| `options.pointing_timeseries` | If true, `pointing_timeseries.json` may be emitted (see below) |
 | `totals` | `file_count`, `total_bytes` (bytes zero when `no_stat`) |
-| `by_day` | `{ date, count, bytes }[]` sorted by date |
+| `by_day` | `{ date, count, bytes, dec_deg_min?, dec_deg_max?, dec_unique_count? }[]` |
 | `by_beam` | `{ beam, count, bytes }[]` sorted by beam id |
 | `gaps` | `{ start, end, days }` ranges with zero files between first/last day with data |
 | `freshness` | Earliest/latest timestamp from filenames; mtime range when not `no_stat` |
+| `pointing` | When metadata scan is on: global Dec min/max, unique rounded strips, file counts |
+| `pointing_timeseries` | When `--pointing-timeseries` is used: `{ file, row_count, truncated }` pointing at `pointing_timeseries.json` |
 
 Filenames must match:
 
@@ -45,6 +49,9 @@ python -m dsacamera_monitor.scan --root /data/incoming --out /path/to/out
 ```
 
 - Writes `/path/to/out/manifest.json` and copies static assets from `dsacamera_monitor/site/` into `out/`.
+- By default each matching `.hdf5` is opened once to read phase-center **Declination** from UVH5 headers (cheap metadata only; no visibilities). Use `--no-hdf5-metadata` to skip that (faster on huge trees, no Dec in manifest).
+- Optional `--pointing-timeseries` writes `pointing_timeseries.json` (per file: median time, RA, Dec) with rows capped by `--pointing-timeseries-max-files` (default 5000). RA may be derived from `ha_phase_center` + LST at median time, matching the main pipeline’s HDF5 convention.
+- **Performance:** the scan is O(number of files): one `h5py.File` open per file for metadata. On slow NFS, prefer cron spacing or metadata-off for smoke tests.
 - Open `out/index.html` in a browser (or serve the directory with any static file server).
 
 ### Fast count-only (no `stat`)

--- a/tools/dsacamera-monitor/dsacamera_monitor/__init__.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/__init__.py
@@ -1,5 +1,5 @@
 """Static dashboard tooling for DSA-110 /data/incoming HDF5 inventory."""
 
-MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 2
 
 __all__ = ["MANIFEST_SCHEMA_VERSION"]

--- a/tools/dsacamera-monitor/dsacamera_monitor/gaps.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/gaps.py
@@ -45,7 +45,7 @@ def compute_gaps(
 
 
 def gaps_from_by_day_rows(by_day: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Helper for tests: derive gaps from manifest-style by_day rows."""
+    """Build a gap list from manifest-style by_day rows (test helper)."""
     days_with_files: set[date] = set()
     for row in by_day:
         days_with_files.add(date.fromisoformat(row["date"]))

--- a/tools/dsacamera-monitor/dsacamera_monitor/hdf5_pointing.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/hdf5_pointing.py
@@ -1,8 +1,4 @@
-"""Read phase-center metadata from DSA-110 UVH5/HDF5 without loading visibilities.
-
-Key paths match dsa110_continuum.pointing.transit_selection.get_pointing_from_hdf5
-and dsa110_continuum.pointing.utils.read_uvh5_dec_fast.
-"""
+"""Read phase-center metadata from DSA-110 UVH5/HDF5 without loading visibilities."""
 
 from __future__ import annotations
 
@@ -12,30 +8,31 @@ from typing import Any
 
 # OVRO / DSA-110 (WGS84), same as dsa110_continuum simulation.harness
 _OVRO_LON_DEG = -118.2825
+_OVRO_LAT_DEG = 37.2339
+_OVRO_ALT_M = 1222.0
+DEC_ROUND_DIGITS = 3
 
-_DEC_ROUND = 3
+try:
+    from astropy import units as u
+    from astropy.coordinates import EarthLocation
+    from astropy.time import Time
+    from astropy.utils import iers
+
+    # Keep metadata scans independent of network/IERS download state.
+    iers.conf.auto_download = False
+    _OVRO_LOCATION = EarthLocation.from_geodetic(
+        lon=_OVRO_LON_DEG * u.deg, lat=_OVRO_LAT_DEG * u.deg, height=_OVRO_ALT_M * u.m
+    )
+except Exception:  # pragma: no cover - astropy import/runtime failure handled in scan path
+    u = None
+    Time = None
+    _OVRO_LOCATION = None
 
 
 def read_phase_center_dec_deg(path: Path) -> float | None:
     """Return phase-center declination in degrees, or None if missing/unreadable."""
-    try:
-        import h5py
-        import numpy as np
-
-        with h5py.File(path, "r") as h:
-            dec_rad = None
-            if "Header/extra_keywords/phase_center_dec" in h:
-                dec_rad = h["Header/extra_keywords/phase_center_dec"][()]
-            elif "Header/phase_center_app_dec" in h:
-                dec_rad = h["Header/phase_center_app_dec"][()]
-            elif "Header/phase_center_dec" in h:
-                dec_rad = h["Header/phase_center_dec"][()]
-            if dec_rad is None:
-                return None
-            v = float(np.asarray(dec_rad).reshape(-1)[0])
-            return float(np.degrees(v))
-    except Exception:
-        return None
+    meta = read_pointing_metadata(path)
+    return meta["dec_deg"] if meta["dec_status"] == "ok" else None
 
 
 def _ha_to_deg(ha_val: float) -> float | None:
@@ -67,65 +64,113 @@ def read_time_median_jd(path: Path) -> float | None:
         return None
 
 
-def read_pointing_ra_dec_deg(path: Path) -> tuple[float | None, float | None]:
-    """RA/Dec in degrees from headers; RA may be derived from HA + LST at median time."""
+def _extract_float(h5_obj: Any, key: str) -> float | None:
+    import numpy as np
+
+    if key not in h5_obj:
+        return None
+    return float(np.asarray(h5_obj[key][()]).reshape(-1)[0])
+
+
+def read_pointing_metadata(path: Path) -> dict[str, Any]:
+    """Read Dec/RA/mid-time from one HDF5 open.
+
+    Returns status-bearing metadata so callers can distinguish missing keys from read failures.
+    """
+    meta: dict[str, Any] = {
+        "filename": path.name,
+        "t_mid_utc": None,
+        "ra_deg": None,
+        "dec_deg": None,
+        "dec_status": "missing",  # one of: ok, missing, read_failed
+        "pointing_status": "missing",  # one of: ok, missing, read_failed
+        "error": None,
+    }
     try:
         import h5py
         import numpy as np
-        from astropy import units as u
-        from astropy.coordinates import EarthLocation
-        from astropy.time import Time
+    except (ImportError, ModuleNotFoundError) as exc:
+        meta["dec_status"] = "read_failed"
+        meta["pointing_status"] = "read_failed"
+        meta["error"] = f"{type(exc).__name__}: {exc}"
+        return meta
 
+    try:
         with h5py.File(path, "r") as h:
-            ra_deg: float | None = None
-            dec_deg: float | None = None
+            try:
+                dec_rad = _extract_float(h, "Header/extra_keywords/phase_center_dec")
+                if dec_rad is None:
+                    dec_rad = _extract_float(h, "Header/phase_center_app_dec")
+                if dec_rad is None:
+                    dec_rad = _extract_float(h, "Header/phase_center_dec")
+                if dec_rad is not None:
+                    meta["dec_deg"] = float(np.degrees(dec_rad))
+                    meta["dec_status"] = "ok"
+            except (KeyError, ValueError, TypeError) as exc:
+                meta["dec_status"] = "read_failed"
+                meta["error"] = f"{type(exc).__name__}: {exc}"
 
-            if "Header/extra_keywords/phase_center_dec" in h:
-                v = h["Header/extra_keywords/phase_center_dec"][()]
-                dec_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
-            elif "Header/phase_center_app_dec" in h:
-                v = h["Header/phase_center_app_dec"][()]
-                dec_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
+            try:
+                # Direct RA keys first.
+                ra_rad = _extract_float(h, "Header/extra_keywords/phase_center_ra")
+                if ra_rad is None:
+                    ra_rad = _extract_float(h, "Header/phase_center_app_ra")
+                if ra_rad is None:
+                    ra_rad = _extract_float(h, "Header/phase_center_ra")
+                if ra_rad is not None:
+                    meta["ra_deg"] = float(np.degrees(ra_rad))
 
-            if "Header/extra_keywords/phase_center_ra" in h:
-                v = h["Header/extra_keywords/phase_center_ra"][()]
-                ra_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
-            elif "Header/phase_center_app_ra" in h:
-                v = h["Header/phase_center_app_ra"][()]
-                ra_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
-
-            if ra_deg is None and "Header/extra_keywords/ha_phase_center" in h and "Header/time_array" in h:
-                ha_val = float(h["Header/extra_keywords/ha_phase_center"][()])
-                ha_deg = _ha_to_deg(ha_val)
-                time_array = h["Header/time_array"][()]
-                if ha_deg is not None and time_array is not None and len(time_array) > 0:
+                time_array = h["Header/time_array"][()] if "Header/time_array" in h else None
+                if time_array is not None and len(time_array) > 0 and Time is not None:
                     mid_jd = float(np.median(time_array))
                     obs_time = Time(mid_jd, format="jd", scale="utc")
-                    loc = EarthLocation.from_geodetic(
-                        lon=_OVRO_LON_DEG * u.deg, lat=37.2339 * u.deg, height=1222.0 * u.m
-                    )
-                    lst = obs_time.sidereal_time("mean", longitude=loc.lon).to(u.deg).value
-                    ra_deg = (lst - ha_deg) % 360.0
+                    meta["t_mid_utc"] = obs_time.isot + "Z"
 
-            return ra_deg, dec_deg
-    except Exception:
-        return None, None
+                # HA fallback if direct RA is missing.
+                if (
+                    meta["ra_deg"] is None
+                    and "Header/extra_keywords/ha_phase_center" in h
+                    and time_array is not None
+                    and len(time_array) > 0
+                ):
+                    ha_val = float(h["Header/extra_keywords/ha_phase_center"][()])
+                    ha_deg = _ha_to_deg(ha_val)
+                    if ha_deg is not None and Time is not None and _OVRO_LOCATION is not None:
+                        mid_jd = float(np.median(time_array))
+                        obs_time = Time(mid_jd, format="jd", scale="utc")
+                        lst = obs_time.sidereal_time("mean", longitude=_OVRO_LOCATION.lon).to(u.deg).value
+                        meta["ra_deg"] = (lst - ha_deg) % 360.0
+
+                if meta["ra_deg"] is not None or meta["t_mid_utc"] is not None:
+                    meta["pointing_status"] = "ok"
+                elif "Header/time_array" in h or "Header/extra_keywords/ha_phase_center" in h:
+                    meta["pointing_status"] = "read_failed"
+                    if meta["error"] is None:
+                        meta["error"] = "Could not derive RA/time from available header keys"
+            except (KeyError, ValueError, TypeError, RuntimeError) as exc:
+                meta["pointing_status"] = "read_failed"
+                if meta["error"] is None:
+                    meta["error"] = f"{type(exc).__name__}: {exc}"
+    except OSError as exc:
+        meta["dec_status"] = "read_failed"
+        meta["pointing_status"] = "read_failed"
+        meta["error"] = f"{type(exc).__name__}: {exc}"
+
+    return meta
+
+
+def read_pointing_ra_dec_deg(path: Path) -> tuple[float | None, float | None]:
+    """RA/Dec in degrees from headers; RA may be derived from HA + LST at median time."""
+    meta = read_pointing_metadata(path)
+    return meta["ra_deg"], meta["dec_deg"]
 
 
 def read_pointing_row(path: Path) -> dict[str, Any]:
     """One manifest row: filename, ISO UTC at median JD, ra_deg, dec_deg (nullable)."""
-    from astropy.time import Time
-
-    ra, dec = read_pointing_ra_dec_deg(path)
-    t_mid: str | None = None
-    mid_jd = read_time_median_jd(path)
-    if mid_jd is not None:
-        t = Time(mid_jd, format="jd", scale="utc")
-        t_mid = t.isot + "Z"  # UTC, ISO-8601-like
-
+    meta = read_pointing_metadata(path)
     return {
         "filename": path.name,
-        "t_mid_utc": t_mid,
-        "ra_deg": ra,
-        "dec_deg": dec,
+        "t_mid_utc": meta["t_mid_utc"],
+        "ra_deg": meta["ra_deg"],
+        "dec_deg": meta["dec_deg"],
     }

--- a/tools/dsacamera-monitor/dsacamera_monitor/hdf5_pointing.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/hdf5_pointing.py
@@ -1,0 +1,131 @@
+"""Read phase-center metadata from DSA-110 UVH5/HDF5 without loading visibilities.
+
+Key paths match dsa110_continuum.pointing.transit_selection.get_pointing_from_hdf5
+and dsa110_continuum.pointing.utils.read_uvh5_dec_fast.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import Any
+
+# OVRO / DSA-110 (WGS84), same as dsa110_continuum simulation.harness
+_OVRO_LON_DEG = -118.2825
+
+_DEC_ROUND = 3
+
+
+def read_phase_center_dec_deg(path: Path) -> float | None:
+    """Return phase-center declination in degrees, or None if missing/unreadable."""
+    try:
+        import h5py
+        import numpy as np
+
+        with h5py.File(path, "r") as h:
+            dec_rad = None
+            if "Header/extra_keywords/phase_center_dec" in h:
+                dec_rad = h["Header/extra_keywords/phase_center_dec"][()]
+            elif "Header/phase_center_app_dec" in h:
+                dec_rad = h["Header/phase_center_app_dec"][()]
+            elif "Header/phase_center_dec" in h:
+                dec_rad = h["Header/phase_center_dec"][()]
+            if dec_rad is None:
+                return None
+            v = float(np.asarray(dec_rad).reshape(-1)[0])
+            return float(np.degrees(v))
+    except Exception:
+        return None
+
+
+def _ha_to_deg(ha_val: float) -> float | None:
+    import numpy as np
+
+    if abs(ha_val) <= 2 * math.pi + 1e-6:
+        return float(np.degrees(ha_val))
+    if abs(ha_val) <= 24.0:
+        return float(ha_val * 15.0)
+    if abs(ha_val) <= 360.0:
+        return float(ha_val)
+    return None
+
+
+def read_time_median_jd(path: Path) -> float | None:
+    """Return median JD from ``Header/time_array`` if present."""
+    try:
+        import h5py
+        import numpy as np
+
+        with h5py.File(path, "r") as h:
+            if "Header/time_array" not in h:
+                return None
+            ta = h["Header/time_array"][()]
+            if ta is None or len(ta) == 0:
+                return None
+            return float(np.median(ta))
+    except Exception:
+        return None
+
+
+def read_pointing_ra_dec_deg(path: Path) -> tuple[float | None, float | None]:
+    """RA/Dec in degrees from headers; RA may be derived from HA + LST at median time."""
+    try:
+        import h5py
+        import numpy as np
+        from astropy import units as u
+        from astropy.coordinates import EarthLocation
+        from astropy.time import Time
+
+        with h5py.File(path, "r") as h:
+            ra_deg: float | None = None
+            dec_deg: float | None = None
+
+            if "Header/extra_keywords/phase_center_dec" in h:
+                v = h["Header/extra_keywords/phase_center_dec"][()]
+                dec_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
+            elif "Header/phase_center_app_dec" in h:
+                v = h["Header/phase_center_app_dec"][()]
+                dec_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
+
+            if "Header/extra_keywords/phase_center_ra" in h:
+                v = h["Header/extra_keywords/phase_center_ra"][()]
+                ra_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
+            elif "Header/phase_center_app_ra" in h:
+                v = h["Header/phase_center_app_ra"][()]
+                ra_deg = float(np.degrees(float(np.asarray(v).reshape(-1)[0])))
+
+            if ra_deg is None and "Header/extra_keywords/ha_phase_center" in h and "Header/time_array" in h:
+                ha_val = float(h["Header/extra_keywords/ha_phase_center"][()])
+                ha_deg = _ha_to_deg(ha_val)
+                time_array = h["Header/time_array"][()]
+                if ha_deg is not None and time_array is not None and len(time_array) > 0:
+                    mid_jd = float(np.median(time_array))
+                    obs_time = Time(mid_jd, format="jd", scale="utc")
+                    loc = EarthLocation.from_geodetic(
+                        lon=_OVRO_LON_DEG * u.deg, lat=37.2339 * u.deg, height=1222.0 * u.m
+                    )
+                    lst = obs_time.sidereal_time("mean", longitude=loc.lon).to(u.deg).value
+                    ra_deg = (lst - ha_deg) % 360.0
+
+            return ra_deg, dec_deg
+    except Exception:
+        return None, None
+
+
+def read_pointing_row(path: Path) -> dict[str, Any]:
+    """One manifest row: filename, ISO UTC at median JD, ra_deg, dec_deg (nullable)."""
+    from astropy.time import Time
+
+    ra, dec = read_pointing_ra_dec_deg(path)
+    t_mid: str | None = None
+    mid_jd = read_time_median_jd(path)
+    if mid_jd is not None:
+        t = Time(mid_jd, format="jd", scale="utc")
+        t_mid = t.isot + "Z"  # UTC, ISO-8601-like
+
+    return {
+        "filename": path.name,
+        "t_mid_utc": t_mid,
+        "ra_deg": ra,
+        "dec_deg": dec,
+    }

--- a/tools/dsacamera-monitor/dsacamera_monitor/manifest.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/manifest.py
@@ -1,4 +1,4 @@
-"""Manifest schema for DSA-110 incoming HDF5 inventory (v2 with optional pointing)."""
+"""Manifest schema for DSA-110 incoming HDF5 inventory (schema v2)."""
 
 from __future__ import annotations
 
@@ -61,6 +61,8 @@ class ScanAccum:
     total_bytes: int = 0
     files_with_dec: int = 0
     files_dec_missing: int = 0
+    files_dec_read_failed: int = 0
+    files_pointing_read_failed: int = 0
     global_dec_min: float | None = None
     global_dec_max: float | None = None
     global_decs_rounded: set[float] = field(default_factory=set)
@@ -77,7 +79,7 @@ def build_manifest(
     pointing_timeseries: bool = False,
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Assemble the manifest dict from scan aggregates (schema v2 when hdf5_metadata)."""
+    """Assemble the schema-v2 manifest dict from scan aggregates."""
     gen = generated_at or datetime.now(timezone.utc)
     if gen.tzinfo is None:
         gen = gen.replace(tzinfo=timezone.utc)
@@ -161,10 +163,11 @@ def build_manifest(
         manifest["pointing"] = {
             "dec_deg_min": accum.global_dec_min,
             "dec_deg_max": accum.global_dec_max,
-            "dec_unique": sorted(accum.global_decs_rounded),
             "unique_strip_count": len(accum.global_decs_rounded),
             "files_with_dec": accum.files_with_dec,
             "files_dec_missing": accum.files_dec_missing,
+            "files_dec_read_failed": accum.files_dec_read_failed,
+            "files_pointing_read_failed": accum.files_pointing_read_failed,
             "sampled": False,
         }
     if pointing_timeseries and accum.timeseries_rows:

--- a/tools/dsacamera-monitor/dsacamera_monitor/manifest.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/manifest.py
@@ -1,4 +1,4 @@
-"""Manifest schema v1 for DSA-110 incoming HDF5 inventory."""
+"""Manifest schema for DSA-110 incoming HDF5 inventory (v2 with optional pointing)."""
 
 from __future__ import annotations
 
@@ -9,7 +9,6 @@ from typing import Any
 
 from dsacamera_monitor import MANIFEST_SCHEMA_VERSION
 from dsacamera_monitor.gaps import compute_gaps
-
 
 FILENAME_PATTERN = (
     r"^(?P<ymd>\d{4}-\d{2}-\d{2})T(?P<hms>\d{2}:\d{2}:\d{2})_sb(?P<beam>\d+)\.hdf5$"
@@ -31,18 +30,27 @@ def try_parse_filename(name: str) -> tuple[datetime, int] | None:
 
 @dataclass
 class DayAgg:
+    """Per-calendar-day aggregates (file sizes and optional Dec from HDF5)."""
+
     count: int = 0
     bytes: int = 0
+    dec_min: float | None = None
+    dec_max: float | None = None
+    decs_rounded: set[float] = field(default_factory=set)
 
 
 @dataclass
 class BeamAgg:
+    """Per-beam (subband) file aggregates."""
+
     count: int = 0
     bytes: int = 0
 
 
 @dataclass
 class ScanAccum:
+    """Full scan result before JSON serialization."""
+
     by_day: dict[date, DayAgg] = field(default_factory=dict)
     by_beam: dict[int, BeamAgg] = field(default_factory=dict)
     latest_filename_dt: datetime | None = None
@@ -51,6 +59,13 @@ class ScanAccum:
     earliest_mtime: datetime | None = None
     file_count: int = 0
     total_bytes: int = 0
+    files_with_dec: int = 0
+    files_dec_missing: int = 0
+    global_dec_min: float | None = None
+    global_dec_max: float | None = None
+    global_decs_rounded: set[float] = field(default_factory=set)
+    timeseries_rows: list[dict[str, Any]] = field(default_factory=list)
+    timeseries_truncated: bool = False
 
 
 def build_manifest(
@@ -58,9 +73,11 @@ def build_manifest(
     source_root: str,
     accum: ScanAccum,
     no_stat: bool,
+    hdf5_metadata: bool = False,
+    pointing_timeseries: bool = False,
     generated_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Assemble the version-1 manifest dict from scan aggregates."""
+    """Assemble the manifest dict from scan aggregates (schema v2 when hdf5_metadata)."""
     gen = generated_at or datetime.now(timezone.utc)
     if gen.tzinfo is None:
         gen = gen.replace(tzinfo=timezone.utc)
@@ -73,6 +90,10 @@ def build_manifest(
             row["bytes"] = agg.bytes
         else:
             row["bytes"] = 0
+        if hdf5_metadata and agg.decs_rounded:
+            row["dec_deg_min"] = agg.dec_min
+            row["dec_deg_max"] = agg.dec_max
+            row["dec_unique_count"] = len(agg.decs_rounded)
         by_day_rows.append(row)
 
     days_with_files = set(accum.by_day.keys())
@@ -116,11 +137,17 @@ def build_manifest(
         ),
     }
 
+    options: dict[str, Any] = {
+        "no_stat": no_stat,
+        "hdf5_metadata": hdf5_metadata,
+        "pointing_timeseries": pointing_timeseries,
+    }
+
     manifest: dict[str, Any] = {
         "schema_version": MANIFEST_SCHEMA_VERSION,
         "generated_at": gen.isoformat().replace("+00:00", "Z"),
         "source_root": source_root,
-        "options": {"no_stat": no_stat},
+        "options": options,
         "totals": {
             "file_count": accum.file_count,
             "total_bytes": accum.total_bytes if not no_stat else 0,
@@ -130,4 +157,20 @@ def build_manifest(
         "gaps": gap_list,
         "freshness": freshness,
     }
+    if hdf5_metadata:
+        manifest["pointing"] = {
+            "dec_deg_min": accum.global_dec_min,
+            "dec_deg_max": accum.global_dec_max,
+            "dec_unique": sorted(accum.global_decs_rounded),
+            "unique_strip_count": len(accum.global_decs_rounded),
+            "files_with_dec": accum.files_with_dec,
+            "files_dec_missing": accum.files_dec_missing,
+            "sampled": False,
+        }
+    if pointing_timeseries and accum.timeseries_rows:
+        manifest["pointing_timeseries"] = {
+            "file": "pointing_timeseries.json",
+            "row_count": len(accum.timeseries_rows),
+            "truncated": accum.timeseries_truncated,
+        }
     return manifest

--- a/tools/dsacamera-monitor/dsacamera_monitor/scan.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/scan.py
@@ -7,9 +7,10 @@ import json
 import os
 import shutil
 import sys
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
+from dsacamera_monitor.hdf5_pointing import read_phase_center_dec_deg, read_pointing_row
 from dsacamera_monitor.manifest import (
     BeamAgg,
     DayAgg,
@@ -19,7 +20,33 @@ from dsacamera_monitor.manifest import (
 )
 
 
-def scan_directory(root: Path, *, no_stat: bool) -> ScanAccum:
+def _record_dec(accum: ScanAccum, day: date, dec: float) -> None:
+    dr = round(dec, 3)
+    accum.global_decs_rounded.add(dr)
+    if accum.global_dec_min is None:
+        accum.global_dec_min = dec
+        accum.global_dec_max = dec
+    else:
+        accum.global_dec_min = min(accum.global_dec_min, dec)
+        accum.global_dec_max = max(accum.global_dec_max, dec)
+    dagg = accum.by_day[day]
+    dagg.decs_rounded.add(dr)
+    if dagg.dec_min is None:
+        dagg.dec_min = dec
+        dagg.dec_max = dec
+    else:
+        dagg.dec_min = min(dagg.dec_min, dec)
+        dagg.dec_max = max(dagg.dec_max, dec)
+
+
+def scan_directory(
+    root: Path,
+    *,
+    no_stat: bool,
+    hdf5_metadata: bool = True,
+    pointing_timeseries: bool = False,
+    pointing_timeseries_max_files: int = 5000,
+) -> ScanAccum:
     """Single pass over directory entries; only matching *.hdf5 names are counted."""
     accum = ScanAccum()
     with os.scandir(root) as it:
@@ -34,6 +61,7 @@ def scan_directory(root: Path, *, no_stat: bool) -> ScanAccum:
                 continue
             dt_utc, beam = parsed
             day = dt_utc.date()
+            full_path = Path(entry.path)
 
             if day not in accum.by_day:
                 accum.by_day[day] = DayAgg()
@@ -67,6 +95,20 @@ def scan_directory(root: Path, *, no_stat: bool) -> ScanAccum:
 
             accum.file_count += 1
 
+            if hdf5_metadata:
+                dec = read_phase_center_dec_deg(full_path)
+                if dec is None:
+                    accum.files_dec_missing += 1
+                else:
+                    accum.files_with_dec += 1
+                    _record_dec(accum, day, dec)
+
+                if pointing_timeseries and len(accum.timeseries_rows) < pointing_timeseries_max_files:
+                    accum.timeseries_rows.append(read_pointing_row(full_path))
+
+    if pointing_timeseries and hdf5_metadata and accum.file_count > len(accum.timeseries_rows):
+        accum.timeseries_truncated = True
+
     return accum
 
 
@@ -76,13 +118,24 @@ def build_out(
     out_dir: Path,
     no_stat: bool,
     site_dir: Path | None = None,
+    hdf5_metadata: bool = True,
+    pointing_timeseries: bool = False,
+    pointing_timeseries_max_files: int = 5000,
 ) -> Path:
-    """Scan, write manifest.json, copy static site into out_dir."""
-    accum = scan_directory(root, no_stat=no_stat)
+    """Scan, write manifest.json, optional pointing_timeseries.json, copy static site into out_dir."""
+    accum = scan_directory(
+        root,
+        no_stat=no_stat,
+        hdf5_metadata=hdf5_metadata,
+        pointing_timeseries=pointing_timeseries,
+        pointing_timeseries_max_files=pointing_timeseries_max_files,
+    )
     manifest = build_manifest(
         source_root=str(root.resolve()),
         accum=accum,
         no_stat=no_stat,
+        hdf5_metadata=hdf5_metadata,
+        pointing_timeseries=pointing_timeseries,
     )
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -90,6 +143,12 @@ def build_out(
     with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
         f.write("\n")
+
+    if accum.timeseries_rows:
+        ts_path = out_dir / "pointing_timeseries.json"
+        with open(ts_path, "w", encoding="utf-8") as f:
+            json.dump(accum.timeseries_rows, f, indent=2)
+            f.write("\n")
 
     if site_dir is None:
         site_dir = Path(__file__).resolve().parent / "site"
@@ -105,6 +164,7 @@ def build_out(
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and run a scan; used as setuptools console script."""
     parser = argparse.ArgumentParser(
         description="Scan DSA-110 incoming HDF5 files and build static dashboard output."
     )
@@ -126,6 +186,23 @@ def main(argv: list[str] | None = None) -> int:
         help="Do not stat() files; counts only (bytes and mtime freshness omitted)",
     )
     parser.add_argument(
+        "--no-hdf5-metadata",
+        action="store_true",
+        help="Do not open HDF5 files; skip declination and pointing timeseries",
+    )
+    parser.add_argument(
+        "--pointing-timeseries",
+        action="store_true",
+        help="Emit pointing_timeseries.json (per-file RA/Dec, mid-time); requires HDF5 metadata",
+    )
+    parser.add_argument(
+        "--pointing-timeseries-max-files",
+        type=int,
+        default=5000,
+        metavar="N",
+        help="Cap rows in pointing_timeseries.json (default: 5000)",
+    )
+    parser.add_argument(
         "--site",
         type=Path,
         default=None,
@@ -138,8 +215,26 @@ def main(argv: list[str] | None = None) -> int:
         print(f"error: not a directory: {root}", file=sys.stderr)
         return 1
 
-    build_out(root=root, out_dir=args.out, no_stat=args.no_stat, site_dir=args.site)
+    hdf5_metadata = not args.no_hdf5_metadata
+    pointing_ts = bool(args.pointing_timeseries) and hdf5_metadata
+    if args.pointing_timeseries and not hdf5_metadata:
+        print(
+            "warning: --pointing-timeseries ignored because --no-hdf5-metadata was set",
+            file=sys.stderr,
+        )
+
+    build_out(
+        root=root,
+        out_dir=args.out,
+        no_stat=args.no_stat,
+        site_dir=args.site,
+        hdf5_metadata=hdf5_metadata,
+        pointing_timeseries=pointing_ts,
+        pointing_timeseries_max_files=max(1, args.pointing_timeseries_max_files),
+    )
     print(f"Wrote {args.out / 'manifest.json'}")
+    if pointing_ts:
+        print(f"Wrote {args.out / 'pointing_timeseries.json'}")
     return 0
 
 

--- a/tools/dsacamera-monitor/dsacamera_monitor/scan.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/scan.py
@@ -10,7 +10,7 @@ import sys
 from datetime import date, datetime, timezone
 from pathlib import Path
 
-from dsacamera_monitor.hdf5_pointing import read_phase_center_dec_deg, read_pointing_row
+from dsacamera_monitor.hdf5_pointing import DEC_ROUND_DIGITS, read_pointing_metadata
 from dsacamera_monitor.manifest import (
     BeamAgg,
     DayAgg,
@@ -21,7 +21,7 @@ from dsacamera_monitor.manifest import (
 
 
 def _record_dec(accum: ScanAccum, day: date, dec: float) -> None:
-    dr = round(dec, 3)
+    dr = round(dec, DEC_ROUND_DIGITS)
     accum.global_decs_rounded.add(dr)
     if accum.global_dec_min is None:
         accum.global_dec_min = dec
@@ -96,15 +96,28 @@ def scan_directory(
             accum.file_count += 1
 
             if hdf5_metadata:
-                dec = read_phase_center_dec_deg(full_path)
-                if dec is None:
-                    accum.files_dec_missing += 1
-                else:
+                meta = read_pointing_metadata(full_path)
+                if meta["dec_status"] == "ok":
+                    dec = meta["dec_deg"]
+                    assert dec is not None
                     accum.files_with_dec += 1
                     _record_dec(accum, day, dec)
+                elif meta["dec_status"] == "missing":
+                    accum.files_dec_missing += 1
+                else:
+                    accum.files_dec_read_failed += 1
 
                 if pointing_timeseries and len(accum.timeseries_rows) < pointing_timeseries_max_files:
-                    accum.timeseries_rows.append(read_pointing_row(full_path))
+                    accum.timeseries_rows.append(
+                        {
+                            "filename": meta["filename"],
+                            "t_mid_utc": meta["t_mid_utc"],
+                            "ra_deg": meta["ra_deg"],
+                            "dec_deg": meta["dec_deg"],
+                        }
+                    )
+                if meta["pointing_status"] == "read_failed":
+                    accum.files_pointing_read_failed += 1
 
     if pointing_timeseries and hdf5_metadata and accum.file_count > len(accum.timeseries_rows):
         accum.timeseries_truncated = True
@@ -121,7 +134,7 @@ def build_out(
     hdf5_metadata: bool = True,
     pointing_timeseries: bool = False,
     pointing_timeseries_max_files: int = 5000,
-) -> Path:
+) -> tuple[Path, bool]:
     """Scan, write manifest.json, optional pointing_timeseries.json, copy static site into out_dir."""
     accum = scan_directory(
         root,
@@ -144,11 +157,13 @@ def build_out(
         json.dump(manifest, f, indent=2)
         f.write("\n")
 
+    wrote_timeseries = False
     if accum.timeseries_rows:
         ts_path = out_dir / "pointing_timeseries.json"
         with open(ts_path, "w", encoding="utf-8") as f:
             json.dump(accum.timeseries_rows, f, indent=2)
             f.write("\n")
+        wrote_timeseries = True
 
     if site_dir is None:
         site_dir = Path(__file__).resolve().parent / "site"
@@ -160,7 +175,7 @@ def build_out(
             else:
                 shutil.copytree(child, dest, dirs_exist_ok=True)
 
-    return manifest_path
+    return manifest_path, wrote_timeseries
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -223,7 +238,7 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
 
-    build_out(
+    _, wrote_timeseries = build_out(
         root=root,
         out_dir=args.out,
         no_stat=args.no_stat,
@@ -233,7 +248,7 @@ def main(argv: list[str] | None = None) -> int:
         pointing_timeseries_max_files=max(1, args.pointing_timeseries_max_files),
     )
     print(f"Wrote {args.out / 'manifest.json'}")
-    if pointing_ts:
+    if pointing_ts and wrote_timeseries:
         print(f"Wrote {args.out / 'pointing_timeseries.json'}")
     return 0
 

--- a/tools/dsacamera-monitor/dsacamera_monitor/site/index.html
+++ b/tools/dsacamera-monitor/dsacamera_monitor/site/index.html
@@ -20,6 +20,8 @@
     <div class="kpi"><span class="label">Generated (UTC)</span><span class="value" id="kpi-generated">—</span></div>
     <div class="kpi"><span class="label">Filename span (UTC)</span><span class="value" id="kpi-span">—</span></div>
     <div class="kpi"><span class="label">mtime span (UTC)</span><span class="value" id="kpi-mtime">—</span></div>
+    <div class="kpi" id="kpi-dec-wrap" style="display:none"><span class="label">Phase-center Dec (°)</span><span class="value" id="kpi-dec">—</span></div>
+    <div class="kpi" id="kpi-dec-files-wrap" style="display:none"><span class="label">Dec metadata</span><span class="value" id="kpi-dec-files">—</span></div>
   </section>
 
   <section class="panel">
@@ -30,6 +32,19 @@
   <section class="panel">
     <h2>Cumulative files</h2>
     <div class="chart-wrap"><canvas id="chart-cum" height="120"></canvas></div>
+  </section>
+
+  <section class="panel" id="panel-dec-by-day" style="display:none">
+    <h2>Declination by day (phase center)</h2>
+    <p class="hint">Min/max Dec (°) from HDF5 headers per calendar day, when metadata scan is enabled.</p>
+    <div class="chart-wrap"><canvas id="chart-dec" height="120"></canvas></div>
+  </section>
+
+  <section class="panel" id="panel-pointing-series" style="display:none">
+    <h2>Pointing vs time (per file, median integration time)</h2>
+    <p class="hint">From <code>pointing_timeseries.json</code> when generated. RA may be derived from HA + LST.</p>
+    <p class="hint" id="ts-trunc" style="display:none"></p>
+    <div class="chart-wrap"><canvas id="chart-pointing" height="140"></canvas></div>
   </section>
 
   <section class="panel">
@@ -66,7 +81,7 @@
   </section>
 
   <footer class="footer">
-    <p>Schema <span id="schema-ver">—</span> · <span id="opt-no-stat"></span></p>
+    <p>Schema <span id="schema-ver">—</span> · <span id="opt-no-stat"></span> · <span id="opt-hdf5"></span></p>
   </footer>
 
   <script src="js/dashboard.js"></script>

--- a/tools/dsacamera-monitor/dsacamera_monitor/site/js/dashboard.js
+++ b/tools/dsacamera-monitor/dsacamera_monitor/site/js/dashboard.js
@@ -51,6 +51,32 @@ function fillKpis(m) {
   document.getElementById("opt-no-stat").textContent = m.options.no_stat
     ? "Scan used --no-stat (counts only)"
     : "Full stat() for sizes and mtime";
+  let hdf5Line = "—";
+  if (m.options && m.options.hdf5_metadata === false) {
+    hdf5Line = "HDF5 header reads disabled (--no-hdf5-metadata)";
+  } else if (m.pointing) {
+    hdf5Line = "Phase-center Dec (and optional timeseries) from HDF5 headers";
+  } else if (m.schema_version < 2) {
+    hdf5Line = "Schema v1: regenerate with current scanner for Dec metadata";
+  } else {
+    hdf5Line = "No Dec block in this manifest";
+  }
+  document.getElementById("opt-hdf5").textContent = hdf5Line;
+
+  if (m.pointing) {
+    document.getElementById("kpi-dec-wrap").style.display = "block";
+    document.getElementById("kpi-dec-files-wrap").style.display = "block";
+    const a = m.pointing.dec_deg_min;
+    const b = m.pointing.dec_deg_max;
+    document.getElementById("kpi-dec").textContent =
+      a != null && b != null
+        ? `${a.toFixed(3)} → ${b.toFixed(3)} · ${m.pointing.unique_strip_count} distinct (rounded)`
+        : "—";
+    document.getElementById("kpi-dec-files").textContent = `${m.pointing.files_with_dec} with Dec · ${m.pointing.files_dec_missing} missing`;
+  } else {
+    document.getElementById("kpi-dec-wrap").style.display = "none";
+    document.getElementById("kpi-dec-files-wrap").style.display = "none";
+  }
 }
 
 function renderDailyAndCumulative(m) {
@@ -117,6 +143,153 @@ function renderDailyAndCumulative(m) {
     },
     options: chartOpts,
   });
+}
+
+function renderDecByDay(m) {
+  const panel = document.getElementById("panel-dec-by-day");
+  const has =
+    m.pointing && m.by_day && m.by_day.some((r) => r.dec_deg_min != null && r.dec_deg_max != null);
+  if (!has) {
+    panel.style.display = "none";
+    return;
+  }
+  panel.style.display = "block";
+  const labels = m.by_day.map((r) => r.date);
+  const mins = m.by_day.map((r) => (r.dec_deg_min != null ? r.dec_deg_min : null));
+  const maxs = m.by_day.map((r) => (r.dec_deg_max != null ? r.dec_deg_max : null));
+  const decCtx = document.getElementById("chart-dec");
+  const chartOpts = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: true, labels: { color: "#8b949e" } },
+    },
+    scales: {
+      x: {
+        ticks: { maxTicksLimit: 12, color: "#8b949e" },
+        grid: { color: "#30363d" },
+      },
+      y: {
+        title: { display: true, text: "Dec (°)", color: "#8b949e" },
+        ticks: { color: "#8b949e" },
+        grid: { color: "#30363d" },
+      },
+    },
+  };
+  new Chart(decCtx, {
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        {
+          label: "Dec min",
+          data: mins,
+          borderColor: "rgba(240, 136, 62, 1)",
+          backgroundColor: "rgba(240, 136, 62, 0.15)",
+          fill: true,
+          tension: 0.15,
+          pointRadius: 0,
+        },
+        {
+          label: "Dec max",
+          data: maxs,
+          borderColor: "rgba(163, 113, 247, 1)",
+          backgroundColor: "rgba(163, 113, 247, 0.1)",
+          fill: true,
+          tension: 0.15,
+          pointRadius: 0,
+        },
+      ],
+    },
+    options: chartOpts,
+  });
+}
+
+/**
+ * @param {object} m manifest
+ * @param {Array<{ filename: string, t_mid_utc: string|null, ra_deg: number|null, dec_deg: number|null }>|null} rows
+ */
+function renderPointingTimeseries(m, rows) {
+  const panel = document.getElementById("panel-pointing-series");
+  const note = document.getElementById("ts-trunc");
+  if (!rows || !Array.isArray(rows) || rows.length === 0) {
+    panel.style.display = "none";
+    return;
+  }
+  panel.style.display = "block";
+  if (m.pointing_timeseries && m.pointing_timeseries.truncated) {
+    note.style.display = "block";
+    note.textContent = "Rows capped; scan omitted some files (see manifest pointing_timeseries).";
+  } else {
+    note.style.display = "none";
+  }
+  const labels = rows.map((r) => (r.t_mid_utc || r.filename || "—").slice(0, 19));
+  const ra = rows.map((r) => (r.ra_deg != null ? r.ra_deg : null));
+  const dec = rows.map((r) => (r.dec_deg != null ? r.dec_deg : null));
+  const pctx = document.getElementById("chart-pointing");
+  new Chart(pctx, {
+    type: "line",
+    data: {
+      labels,
+      datasets: [
+        {
+          label: "RA (°)",
+          data: ra,
+          borderColor: "rgba(88, 166, 255, 1)",
+          yAxisID: "y",
+          pointRadius: 0,
+          tension: 0.1,
+        },
+        {
+          label: "Dec (°)",
+          data: dec,
+          borderColor: "rgba(240, 136, 62, 1)",
+          yAxisID: "y1",
+          pointRadius: 0,
+          tension: 0.1,
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: { mode: "index", intersect: false },
+      plugins: {
+        legend: { labels: { color: "#8b949e" } },
+      },
+      scales: {
+        x: {
+          ticks: { maxTicksLimit: 16, color: "#8b949e", maxRotation: 60 },
+          grid: { color: "#30363d" },
+        },
+        y: {
+          type: "linear",
+          position: "left",
+          title: { display: true, text: "RA (°)", color: "#8b949e" },
+          ticks: { color: "#8b949e" },
+          grid: { color: "#30363d" },
+        },
+        y1: {
+          type: "linear",
+          position: "right",
+          title: { display: true, text: "Dec (°)", color: "#8b949e" },
+          ticks: { color: "#8b949e" },
+          grid: { drawOnChartArea: false },
+        },
+      },
+    },
+  });
+}
+
+async function loadTimeseriesIfPresent(m) {
+  if (!m.pointing_timeseries || !m.pointing_timeseries.file) {
+    return null;
+  }
+  const res = await fetch(m.pointing_timeseries.file, { cache: "no-store" });
+  if (!res.ok) {
+    return null;
+  }
+  return res.json();
 }
 
 function renderHeatmap(m) {
@@ -236,9 +409,17 @@ function renderBeams(m) {
 
 function main() {
   loadManifest()
-    .then((m) => {
+    .then(async (m) => {
       fillKpis(m);
       renderDailyAndCumulative(m);
+      renderDecByDay(m);
+      let ts = null;
+      try {
+        ts = await loadTimeseriesIfPresent(m);
+      } catch (e) {
+        ts = null;
+      }
+      renderPointingTimeseries(m, ts);
       renderHeatmap(m);
       renderGaps(m);
       renderRecent(m);

--- a/tools/dsacamera-monitor/pyproject.toml
+++ b/tools/dsacamera-monitor/pyproject.toml
@@ -10,7 +10,11 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Jakob Faber" }]
-dependencies = []
+dependencies = [
+    "astropy>=5.0",
+    "h5py>=3.10",
+    "numpy>=1.24",
+]
 
 [project.optional-dependencies]
 dev = ["pytest>=8.0"]

--- a/tools/dsacamera-monitor/scripts/build_github_pages.py
+++ b/tools/dsacamera-monitor/scripts/build_github_pages.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 
 def main() -> int:
+    """Copy static site to a build directory for manual Pages upload."""
     root = Path(__file__).resolve().parent.parent
     site_src = root / "dsacamera_monitor" / "site"
     if not site_src.is_dir():

--- a/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
+++ b/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from dsacamera_monitor.gaps import compute_gaps, gaps_from_by_day_rows
-from dsacamera_monitor.hdf5_pointing import read_phase_center_dec_deg
+from dsacamera_monitor.hdf5_pointing import read_phase_center_dec_deg, read_pointing_ra_dec_deg
 from dsacamera_monitor.manifest import (
     BeamAgg,
     DayAgg,
@@ -116,6 +116,7 @@ def test_scan_directory_with_hdf5_dec(tmp_path: Path) -> None:
     assert accum.file_count == 1
     assert accum.files_with_dec == 1
     assert accum.files_dec_missing == 0
+    assert accum.files_dec_read_failed == 0
     assert accum.global_dec_min is not None and abs(accum.global_dec_min - 40.5) < 1e-6
     assert read_phase_center_dec_deg(p) is not None
 
@@ -127,7 +128,8 @@ def test_build_out_copies_site(tmp_path: Path) -> None:
     src.mkdir()
     (src / "2025-01-01T00:00:00_sb01.hdf5").write_bytes(b"x")
     out = tmp_path / "out"
-    build_out(root=src, out_dir=out, no_stat=True, hdf5_metadata=False)
+    _, wrote_ts = build_out(root=src, out_dir=out, no_stat=True, hdf5_metadata=False)
+    assert wrote_ts is False
     assert (out / "manifest.json").is_file()
     assert (out / "index.html").is_file()
     assert (out / "js" / "dashboard.js").is_file()
@@ -150,7 +152,7 @@ def test_pointing_timeseries_file(tmp_path: Path) -> None:
         f.create_dataset("Header/time_array", data=np.array([2450000.5, 2450000.6]))
 
     out = tmp_path / "out"
-    build_out(
+    _, wrote_ts = build_out(
         root=src,
         out_dir=out,
         no_stat=True,
@@ -158,7 +160,39 @@ def test_pointing_timeseries_file(tmp_path: Path) -> None:
         pointing_timeseries=True,
         pointing_timeseries_max_files=10,
     )
+    assert wrote_ts is True
     assert (out / "pointing_timeseries.json").is_file()
     m = __import__("json").loads((out / "manifest.json").read_text())
     assert m["pointing_timeseries"]["row_count"] == 1
     assert "pointing" in m
+    assert "dec_unique" not in m["pointing"]
+
+
+def test_pointing_fallback_header_keys(tmp_path: Path) -> None:
+    import h5py
+    import numpy as np
+
+    fn = "2025-04-01T00:00:00_sb01.hdf5"
+    p = tmp_path / fn
+    with h5py.File(p, "w") as f:
+        f.create_dataset("Header/phase_center_dec", data=np.float64(np.deg2rad(15.25)))
+        f.create_dataset("Header/phase_center_ra", data=np.float64(np.deg2rad(230.5)))
+        f.create_dataset("Header/time_array", data=np.array([2450100.1, 2450100.2]))
+
+    ra, dec = read_pointing_ra_dec_deg(p)
+    assert ra is not None and abs(ra - 230.5) < 1e-6
+    assert dec is not None and abs(dec - 15.25) < 1e-6
+
+
+def test_scan_counts_read_failures(tmp_path: Path) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    bad = tmp_path / "2025-07-01T00:00:00_sb01.hdf5"
+    bad.write_bytes(b"not hdf5")
+    accum = scan_directory(tmp_path, no_stat=True, hdf5_metadata=True, pointing_timeseries=True)
+    assert accum.file_count == 1
+    assert accum.files_with_dec == 0
+    assert accum.files_dec_missing == 0
+    assert accum.files_dec_read_failed == 1
+    assert accum.files_pointing_read_failed == 1
+    assert len(accum.timeseries_rows) == 1

--- a/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
+++ b/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
@@ -1,3 +1,4 @@
+# ruff: noqa: D103
 """Tests for DSA-110 incoming HDF5 manifest and gap logic."""
 
 from __future__ import annotations
@@ -6,6 +7,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 from dsacamera_monitor.gaps import compute_gaps, gaps_from_by_day_rows
+from dsacamera_monitor.hdf5_pointing import read_phase_center_dec_deg
 from dsacamera_monitor.manifest import (
     BeamAgg,
     DayAgg,
@@ -75,12 +77,15 @@ def test_build_manifest_roundtrip() -> None:
         source_root="/tmp/incoming",
         accum=accum,
         no_stat=False,
+        hdf5_metadata=False,
         generated_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
     )
-    assert m["schema_version"] == 1
+    assert m["schema_version"] == 2
     assert m["totals"]["file_count"] == 2
     assert m["by_day"][0]["date"] == "2025-01-01"
     assert m["gaps"] == []
+    assert "pointing" not in m
+    assert m["options"]["hdf5_metadata"] is False
 
 
 def test_scan_directory(tmp_path: Path) -> None:
@@ -89,10 +94,30 @@ def test_scan_directory(tmp_path: Path) -> None:
     (tmp_path / "2025-01-01T00:00:00_sb01.hdf5").write_bytes(b"x")
     (tmp_path / "2025-01-01T01:00:00_sb02.hdf5").write_bytes(b"yy")
     (tmp_path / "skip.txt").write_text("x")
-    accum = scan_directory(tmp_path, no_stat=False)
+    accum = scan_directory(tmp_path, no_stat=False, hdf5_metadata=False)
     assert accum.file_count == 2
     assert accum.total_bytes == 3
     assert set(accum.by_beam.keys()) == {1, 2}
+
+
+def test_scan_directory_with_hdf5_dec(tmp_path: Path) -> None:
+    import h5py
+    import numpy as np
+    from dsacamera_monitor.scan import scan_directory
+
+    fn = "2025-06-15T10:00:00_sb05.hdf5"
+    p = tmp_path / fn
+    with h5py.File(p, "w") as f:
+        f.create_dataset(
+            "Header/extra_keywords/phase_center_dec",
+            data=np.float64(np.deg2rad(40.5)),
+        )
+    accum = scan_directory(tmp_path, no_stat=True, hdf5_metadata=True)
+    assert accum.file_count == 1
+    assert accum.files_with_dec == 1
+    assert accum.files_dec_missing == 0
+    assert accum.global_dec_min is not None and abs(accum.global_dec_min - 40.5) < 1e-6
+    assert read_phase_center_dec_deg(p) is not None
 
 
 def test_build_out_copies_site(tmp_path: Path) -> None:
@@ -102,7 +127,38 @@ def test_build_out_copies_site(tmp_path: Path) -> None:
     src.mkdir()
     (src / "2025-01-01T00:00:00_sb01.hdf5").write_bytes(b"x")
     out = tmp_path / "out"
-    build_out(root=src, out_dir=out, no_stat=True)
+    build_out(root=src, out_dir=out, no_stat=True, hdf5_metadata=False)
     assert (out / "manifest.json").is_file()
     assert (out / "index.html").is_file()
     assert (out / "js" / "dashboard.js").is_file()
+    man = (out / "manifest.json").read_text()
+    assert '"schema_version": 2' in man
+
+
+def test_pointing_timeseries_file(tmp_path: Path) -> None:
+    import h5py
+    import numpy as np
+    from dsacamera_monitor.scan import build_out
+
+    src = tmp_path / "src"
+    src.mkdir()
+    fn = "2025-03-01T08:00:00_sb00.hdf5"
+    p = src / fn
+    with h5py.File(p, "w") as f:
+        f.create_dataset("Header/extra_keywords/phase_center_dec", data=np.float64(0.7))
+        f.create_dataset("Header/extra_keywords/ha_phase_center", data=np.float64(0.01))
+        f.create_dataset("Header/time_array", data=np.array([2450000.5, 2450000.6]))
+
+    out = tmp_path / "out"
+    build_out(
+        root=src,
+        out_dir=out,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        pointing_timeseries_max_files=10,
+    )
+    assert (out / "pointing_timeseries.json").is_file()
+    m = __import__("json").loads((out / "manifest.json").read_text())
+    assert m["pointing_timeseries"]["row_count"] == 1
+    assert "pointing" in m


### PR DESCRIPTION
## Summary
- extend `dsacamera-monitor` scanner to read phase-center Dec (and optional RA/Dec timeseries) from UVH5/HDF5 headers without touching visibility data
- bump monitor manifest schema to v2 with optional `pointing` and `pointing_timeseries` metadata, plus CLI controls for metadata and caps
- update dashboard UI/charts and docs; wire CI monitor build to emit capped `pointing_timeseries.json`

## Test plan
- [x] `ruff check tools/dsacamera-monitor/`
- [x] `PYTHONPATH=/data/dsa110-continuum python3 -m pytest tools/dsacamera-monitor/tests/ -q`
- [ ] Trigger `docs.yml` on branch and verify `dsacamera`/`h17` pages render new Dec + pointing panels when metadata exists

Made with [Cursor](https://cursor.com)