### PR TITLE
Fix skymodel phase direction extraction

### DIFF
--- a/dsa110_continuum/calibration/skymodels.py
+++ b/dsa110_continuum/calibration/skymodels.py
@@ -23,11 +23,11 @@ import logging
 import os
 import shutil
 import subprocess
-from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+from dsa110_continuum.calibration.runner import _extract_field_ra_dec
 
 logger = logging.getLogger(__name__)
 
@@ -245,7 +245,6 @@ def make_unified_skymodel(
     import numpy as np
     import pandas as pd
     from astropy.coordinates import SkyCoord
-
     from dsa110_continuum.catalog.query import query_sources
 
     # Helper to standardize DataFrame
@@ -735,7 +734,8 @@ def predict_from_skymodel_wsclean(
     dec0_deg = None
     try:
         with casatables.table(f"{ms_path}::FIELD", readonly=True) as field_tb:
-            phase_dir = field_tb.getcol("PHASE_DIR")  # Shape: (nfields, 1, 2)
+            phase_dir = field_tb.getcol("PHASE_DIR")
+            phase_ra_rad, phase_dec_rad = _extract_field_ra_dec(phase_dir)
             nfields = len(phase_dir)
             if nfields == 0:
                 raise ValueError(
@@ -770,15 +770,15 @@ def predict_from_skymodel_wsclean(
                 )
                 field_idx = 0
 
-            ra0_rad = phase_dir[field_idx, 0, 0]
-            dec0_rad = phase_dir[field_idx, 0, 1]
+            ra0_rad = phase_ra_rad[field_idx]
+            dec0_rad = phase_dec_rad[field_idx]
             ra0_deg = np.degrees(ra0_rad)
             dec0_deg = np.degrees(dec0_rad)
 
             # Error if fields have divergent phase centers (WSClean uses a single image)
             if nfields > 1:
-                all_ra_deg = np.degrees(phase_dir[:, 0, 0])
-                all_dec_deg = np.degrees(phase_dir[:, 0, 1])
+                all_ra_deg = np.degrees(phase_ra_rad)
+                all_dec_deg = np.degrees(phase_dec_rad)
                 ra_spread = np.ptp(all_ra_deg)
                 dec_spread = np.ptp(all_dec_deg)
                 if ra_spread > 0.01 or dec_spread > 0.01:

--- a/tests/test_skymodel_phase_dir.py
+++ b/tests/test_skymodel_phase_dir.py
@@ -1,0 +1,81 @@
+"""Regression tests for WSClean skymodel phase-center selection."""
+
+import numpy as np
+
+
+def test_predict_uses_dec_from_casa_column_major_phase_dir(tmp_path, monkeypatch):
+    """CASA-backed PHASE_DIR shape should feed the correct Dec to WSClean."""
+    from dsa110_continuum.adapters import casa_tables
+    from dsa110_continuum.calibration import skymodels
+
+    phase_dir = np.array([
+        [[np.radians(180.0)], [np.radians(22.0)]],
+        [[np.radians(180.0)], [np.radians(22.0)]],
+    ])
+    commands = []
+
+    class FakeSkyModel:
+        Ncomponents = 1
+
+    class FakeTable:
+        def __init__(self, path):
+            self.path = path
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def close(self):
+            return None
+
+        def colnames(self):
+            if self.path.endswith("::SPECTRAL_WINDOW"):
+                return ["CHAN_FREQ", "TOTAL_BANDWIDTH"]
+            if self.path.endswith("::FIELD"):
+                return ["PHASE_DIR"]
+            return ["MODEL_DATA", "CORRECTED_DATA"]
+
+        def nrows(self):
+            return 0
+
+        def getcol(self, name):
+            if self.path.endswith("::SPECTRAL_WINDOW") and name == "CHAN_FREQ":
+                return np.array([[1.4e9, 1.41e9]])
+            if self.path.endswith("::FIELD") and name == "PHASE_DIR":
+                return phase_dir
+            raise KeyError(name)
+
+    def fake_table(path, *args, **kwargs):
+        return FakeTable(path)
+
+    def fake_write_source_list(sky_model, txt_path, freq_ghz):
+        with open(txt_path, "w", encoding="utf-8") as f:
+            f.write("# fake source list\n")
+
+    def fake_run(cmd, check, timeout, capture_output):
+        commands.append(list(cmd))
+        if "-draw-model" in cmd:
+            name_idx = cmd.index("-name") + 1
+            term_path = f"{cmd[name_idx]}-term-0.fits"
+            with open(term_path, "w", encoding="utf-8") as f:
+                f.write("fake fits")
+
+    monkeypatch.setattr(casa_tables, "table", fake_table)
+    monkeypatch.setattr(skymodels, "write_wsclean_source_list", fake_write_source_list)
+    monkeypatch.setattr(skymodels.subprocess, "run", fake_run)
+
+    skymodels.predict_from_skymodel_wsclean(
+        "fake.ms",
+        FakeSkyModel(),
+        field="0~1",
+        wsclean_path="/bin/true",
+        temp_dir=str(tmp_path),
+        cleanup=False,
+    )
+
+    draw_cmd = next(cmd for cmd in commands if "-draw-model" in cmd)
+    centre_idx = draw_cmd.index("-draw-centre")
+    assert draw_cmd[centre_idx + 1] == "12h0m0.000s"
+    assert draw_cmd[centre_idx + 2] == "+22d0m0.000s"


### PR DESCRIPTION
## Summary

- Reuse the robust FIELD::PHASE_DIR shape helper from the CASA shape fix in WSClean skymodel prediction.
- Correctly handles CASA column-major FIELD direction arrays when choosing the phase center for `-draw-centre`.
- Adds a regression test that mocks CASA table reads and WSClean subprocess calls, verifying Dec is passed correctly for CASA-shaped PHASE_DIR.

## Verification

- `PYTHONPATH=/workspace /opt/miniforge/envs/casa6/bin/python -m pytest tests/test_silent_failures.py -q` -> 14 passed
- `ruff check dsa110_continuum/calibration/skymodels.py tests/test_silent_failures.py` -> All checks passed
