### PR TITLE
Document FIELD direction column shape variants in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ pipeline logic.
   16.1°); pointing declination is carried from HDF5/UVH5 into the MS during
   conversion, and the batch driver reads Dec from the MS (not by reopening
   HDF5).
+- FIELD direction columns may appear as either rows-first `(nfields, 1, 2)` or
+  CASA column-major `(nfields, 2, 1)` arrays; calibration code should normalize
+  both shapes when reading or updating `PHASE_DIR`/`REFERENCE_DIR`.
 
 ## Cursor Cloud specific instructions
 


### PR DESCRIPTION
## Summary

Adds a 3-line **Learned Workspace Facts** entry to `AGENTS.md` so future
agents and contributors know that calibration code reading or writing
FIELD `PHASE_DIR` / `REFERENCE_DIR` must normalize **both** the rows-first
`(nfields, 1, 2)` shape and the CASA column-major `(nfields, 2, 1)` shape.

This is the durable continual-learning record of the silent-failure bug
fixed by PR #8 (`Fix FIELD phase direction extraction for CASA table shapes`).
The original code assumed the rows-first shape and silently extracted
`[ra, ra]` instead of `[ra, dec]` for every field except field 0 when
CASA returned the column-major shape — a real bug that would only fire
on multi-field MS, never tripped by the single-field 3C454.3 reference
workflow.

## Scope

Single file, single commit, +3 lines:
- `AGENTS.md`: appends one bullet to the existing **Learned Workspace
  Facts** section, immediately after the "windowed mosaic depth" entry
  and before the "Cursor Cloud specific instructions" section.

No code, no test changes. Pure continual-learning documentation.

## Verification

- Branched from `origin/main` (`5dcb02f`).
- `git diff --stat origin/main HEAD` reports exactly `AGENTS.md | 3 +++ 1 file changed, 3 insertions(+)`.
- `git diff --name-only origin/main HEAD` returns only `AGENTS.md`.
- File mode preserved as `100644` (no executable-bit churn).