### PR TITLE
Document calibration runner helpers for FIELD direction columns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,10 @@ pipeline logic.
 - FIELD direction columns may appear as either rows-first `(nfields, 1, 2)` or
   CASA column-major `(nfields, 2, 1)` arrays; calibration code should normalize
   both shapes when reading or updating `PHASE_DIR`/`REFERENCE_DIR`.
+- Fresh converted MS FIELD direction columns can appear as `(nfields, 2, 1)`
+  via the CASA table adapter; code touching `PHASE_DIR` or `REFERENCE_DIR`
+  should use calibration runner helpers instead of hard-coded `(nfields, 1, 2)`
+  indexing.
 
 ## Cursor Cloud specific instructions
 


### PR DESCRIPTION
## Summary

Adds a complementary Learned Workspace Facts entry to \`AGENTS.md\`
pointing contributors at the calibration runner helpers
(\`_extract_field_ra_dec\` / \`_set_field_ra_dec\`, landed in PR #8) as
the canonical way to read or write FIELD::PHASE_DIR / FIELD::REFERENCE_DIR
on a fresh converted MS, instead of hard-coded \`(nfields, 1, 2)\`
indexing.

## Context

PR #11 already added a *descriptive* FIELD-shape bullet ("both shapes can
appear; code should normalize both shapes"). This PR adds a *prescriptive*
companion bullet that names the remediation: **use the runner helpers**.

Together the two bullets form a problem-statement / action-guidance pair:

- PR #11's bullet: tells contributors **what they might encounter**.
- This PR's bullet: tells contributors **what to do about it**.

Both bullets remain in place after this PR merges; no replacement.

## Scope

- \`AGENTS.md\` only.
- Single commit, +4 lines, no replacement of any existing content.
- New bullet positioned immediately after PR #11's bullet so the
  problem/action pair reads as a coherent unit.

## Verification

- Branched from current \`origin/main\` (\`8971f37\`).
- \`git diff --stat origin/main HEAD\` reports exactly \`AGENTS.md | 4 ++++  1 file changed, 4 insertions(+)\`.
- \`git diff --name-only origin/main HEAD\` returns only \`AGENTS.md\`.
- No file mode changes; no other files dirty.