### PR TITLE
[codex] Document non-canonical canary guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ always use `dsa110_continuum.*` imports; do not add new `dsa110_contimg` referen
 ## Verified working state
 
 run_pipeline.py produces a calibrated image of 3C454.3 at 12.5 Jy/beam.
-Test data: 2026-01-25 HDF5 files at /data/incoming/ on H17.
+Test data: HDF5 files in date-keyed subdirectories under /data/incoming/ on H17.
 
 ## Data flow
 
@@ -100,7 +100,7 @@ scripts/stack_lightcurves.py   Stack per-epoch CSVs into combined multi-epoch li
 scripts/variability_metrics.py Compute Mooley eta/Vs/m variability metrics
 scripts/verify_sources.py      Verify source fluxes against expected values
 scripts/validate_date.py       Run validation checks on a single date's pipeline outputs
-scripts/run_canary.sh          Canary test: end-to-end pipeline on reference date (2026-01-25)
+scripts/run_canary.sh          QA smoke test against a pre-existing reference FITS tile
 
 ## Key paths (H17)
 


### PR DESCRIPTION
## Summary

- removes `2026-01-25` from the general `CLAUDE.md` verified-state guidance
- describes H17 test data by layout instead of privileging one date
- reframes `run_canary.sh` as a QA smoke against a pre-existing reference tile

## Context

This is a small slice of #30. The WIP branch preserved broader agent-context docs, but this PR only lands the already-reviewed canary-date wording cleanup.

## Validation

- documentation-only change; no tests run

Refs #30