### PR TITLE
Issue #26: add structured epoch gaincal status and promotion records

### DIFF
--- a/dsa110_continuum/calibration/epoch_gaincal.py
+++ b/dsa110_continuum/calibration/epoch_gaincal.py
@@ -5,23 +5,28 @@ Public API
 select_calibration_tile_from_ms(epoch_ms_paths) -> str
     Return the MS path (from the two central tiles) with the most catalog sources.
 
-calibrate_epoch(epoch_ms_paths, bp_table, work_dir, ...) -> str | None
-    Full 5-step catalog-bootstrap + self-cal gain solve. Returns ap.G table path.
+calibrate_epoch(epoch_ms_paths, bp_table, work_dir, ...) -> EpochGaincalResult
+    Full 5-step catalog-bootstrap + self-cal gain solve. Returns a structured
+    result carrying the ap.G table path (or None) plus the status enum and a
+    human-readable reason. The result distinguishes "low SNR" (operational
+    limit) from "exception / no table" (code-path / data fault) so downstream
+    manifests and promotion records can classify the outcome honestly.
 """
+
 from __future__ import annotations
 
 import logging
 import os
 import shutil
 import subprocess
+from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 
 import numpy as np
-
 from dsa110_continuum.calibration.applycal import apply_to_target
 from dsa110_continuum.calibration.model import count_bright_sources_in_tile
 from dsa110_continuum.calibration.mosaic_constants import (
-    MOSAIC_TILE_COUNT,
     SKYMODEL_MIN_FLUX_MJY,
     SOURCE_QUERY_RADIUS_DEG,
 )
@@ -34,8 +39,48 @@ from dsa110_continuum.calibration.skymodels import (
 log = logging.getLogger(__name__)
 
 
+class EpochGaincalStatus(str, Enum):
+    """Spec-aligned status for one calibrate_epoch invocation.
+
+    LOW_SNR is the operational case where the data could not support a
+    reliable gain solution — empty sky model, p.G flag fraction over the
+    GAINCAL_FLAG_FRACTION_LIMIT, or solver wrote no table because every
+    solution was flagged. SOLVER_NO_TABLE is reserved for the case where
+    CASA reported success but the table file is absent (rare; usually a
+    code/data fault). EXCEPTION captures any uncaught Python exception in
+    the calibrate_epoch try/except — the legacy "code-path fallback".
+
+    Mapping to the spec's epoch_gaincal_state enum (see
+    dsa110_continuum.qa.promotion.derive_epoch_gaincal_state_from_status):
+      SOLVED          -> "solved"
+      LOW_SNR         -> "skipped_or_failed_low_snr"
+      SOLVER_NO_TABLE -> "skipped_or_failed_low_snr"  (no table = all flagged)
+      EXCEPTION       -> "fell_back_to_static_with_reason"
+    """
+
+    SOLVED = "solved"
+    LOW_SNR = "low_snr"
+    SOLVER_NO_TABLE = "solver_no_table"
+    EXCEPTION = "exception"
+
+
+@dataclass(frozen=True)
+class EpochGaincalResult:
+    """Structured outcome of a calibrate_epoch invocation.
+
+    g_table is the path to the solved ap.G table when status == SOLVED;
+    otherwise None and the caller should fall back to the static daily G.
+    reason is a short human-readable string suitable for the manifest gate's
+    reason field (e.g. "p.G flagged 44.4% of solutions (limit 30%)").
+    """
+
+    g_table: str | None
+    status: EpochGaincalStatus
+    reason: str | None = None
+
+
 _WSCLEAN_FLAG_FRACTION_LIMIT = 0.60  # skip WSClean self-cal if MS is more flagged than this
-GAINCAL_FLAG_FRACTION_LIMIT  = 0.30  # abort epoch gaincal if p.G table is more flagged than this
+GAINCAL_FLAG_FRACTION_LIMIT = 0.30  # abort epoch gaincal if p.G table is more flagged than this
 
 
 def _ms_flag_fraction(ms_path: str) -> float:
@@ -154,7 +199,7 @@ def calibrate_epoch(
     source_radius_deg: float = SOURCE_QUERY_RADIUS_DEG,
     wsclean_niter: int = 1000,
     wsclean_threshold_sigma: float = 3.0,
-) -> str | None:
+) -> EpochGaincalResult:
     """Derive per-epoch gain solutions using catalog bootstrap + one self-cal round.
 
     Workflow
@@ -199,8 +244,12 @@ def calibrate_epoch(
 
     Returns
     -------
-    str or None
-        Path to the solved ap.G table, or None if any step failed.
+    EpochGaincalResult
+        ``g_table`` is the ap.G table path when ``status == SOLVED``, else
+        ``None`` and the caller should fall back to the static daily G.
+        ``reason`` is a short human-readable string suitable for the manifest
+        gate's reason field. Status distinguishes operational SNR-floor
+        failures from code-path exceptions.
     """
     from dsa110_continuum.calibration.casa_service import CASAService
 
@@ -215,16 +264,16 @@ def calibrate_epoch(
             source_radius_deg=source_radius_deg,
         )
         stem = Path(central_raw_ms).stem
-        meridian_ms   = str(work / f"{stem}_meridian.ms")
+        meridian_ms = str(work / f"{stem}_meridian.ms")
         precond_table = str(work / f"{stem}.precond.G")
-        p_table       = str(work / f"{stem}.p.G")
-        ap_table      = str(work / f"{stem}.ap.G")
+        p_table = str(work / f"{stem}.p.G")
+        ap_table = str(work / f"{stem}.ap.G")
         wsclean_prefix = str(work / f"{stem}_model")
 
         # Return cached result if the ap.G table already exists
         if os.path.exists(ap_table):
             log.info("Epoch gaincal [%s]: cached ap.G found — reusing %s", stem, ap_table)
-            return ap_table
+            return EpochGaincalResult(ap_table, EpochGaincalStatus.SOLVED, "cached ap.G reused")
 
         # ── 1. Phaseshift to median meridian ──────────────────────────────────
         if not os.path.exists(meridian_ms):
@@ -248,6 +297,7 @@ def calibrate_epoch(
             _svc.flagdata(vis=meridian_ms, autocorr=True, flagbackup=False)
             try:
                 from dsa110_continuum.calibration.flagging import flag_rfi as _flag_rfi
+
                 log.info("Epoch gaincal [%s]: AOFlagger RFI flagging", stem)
                 _flag_rfi(meridian_ms, backend="aoflagger")
                 log.info("Epoch gaincal [%s]: AOFlagger complete", stem)
@@ -255,23 +305,33 @@ def calibrate_epoch(
                 log.warning(
                     "Epoch gaincal [%s]: AOFlagger unavailable (%s) — "
                     "falling back to CASA tfcrop+rflag",
-                    stem, _aof_err,
+                    stem,
+                    _aof_err,
                 )
                 _svc.flagdata(
-                    vis=meridian_ms, mode="tfcrop", datacolumn="data",
-                    timecutoff=4.0, freqcutoff=4.0,
-                    extendflags=False, flagbackup=False,
+                    vis=meridian_ms,
+                    mode="tfcrop",
+                    datacolumn="data",
+                    timecutoff=4.0,
+                    freqcutoff=4.0,
+                    extendflags=False,
+                    flagbackup=False,
                 )
                 _svc.flagdata(
-                    vis=meridian_ms, mode="rflag", datacolumn="data",
-                    timedevscale=4.0, freqdevscale=4.0,
-                    extendflags=False, flagbackup=False,
+                    vis=meridian_ms,
+                    mode="rflag",
+                    datacolumn="data",
+                    timedevscale=4.0,
+                    freqdevscale=4.0,
+                    extendflags=False,
+                    flagbackup=False,
                 )
                 log.info("Epoch gaincal [%s]: CASA tfcrop+rflag complete", stem)
         except Exception as _flag_err:
             log.warning(
                 "Epoch gaincal [%s]: pre-calibration flagging failed (%s) — continuing",
-                stem, _flag_err,
+                stem,
+                _flag_err,
             )
 
         # ── 2. Initialise MODEL_DATA column before any applycal ──────────────
@@ -281,10 +341,12 @@ def calibrate_epoch(
         log.info("Epoch gaincal [%s]: initialising MODEL_DATA column", stem)
         try:
             from dsa110_continuum.adapters import casa_tables as _ct
+
             with _ct.table(meridian_ms, readonly=True, ack=False) as _t:
                 _has_model = "MODEL_DATA" in _t.colnames()
             if not _has_model:
                 from dsa110_continuum.calibration.casa_service import CASAService as _CS
+
                 _CS().clearcal(vis=meridian_ms, addmodel=True)
         except Exception as _e:
             log.warning("Epoch gaincal [%s]: MODEL_DATA init failed (%s) — continuing", stem, _e)
@@ -307,7 +369,11 @@ def calibrate_epoch(
                 "Epoch gaincal [%s]: catalog sky model is empty — cannot calibrate",
                 stem,
             )
-            return None
+            return EpochGaincalResult(
+                None,
+                EpochGaincalStatus.LOW_SNR,
+                "catalog sky model is empty (no bright sources within search radius)",
+            )
         log.info("Epoch gaincal [%s]: sky model has %d components", stem, sky.Ncomponents)
         predict_from_skymodel_wsclean(meridian_ms, sky)
 
@@ -346,7 +412,8 @@ def calibrate_epoch(
             if os.path.exists(precond_table):
                 log.info(
                     "Epoch gaincal [%s]: pre-conditioner solve SUCCESS → %s",
-                    stem, Path(precond_table).name,
+                    stem,
+                    Path(precond_table).name,
                 )
             else:
                 log.warning(
@@ -357,7 +424,8 @@ def calibrate_epoch(
         except Exception as _precond_err:
             log.warning(
                 "Epoch gaincal [%s]: pre-conditioner solve failed (%s) — continuing",
-                stem, _precond_err,
+                stem,
+                _precond_err,
             )
 
         # Build the optional precond chain used in all downstream gaintable lists.
@@ -374,15 +442,18 @@ def calibrate_epoch(
         if _precond:
             try:
                 from dsa110_continuum.adapters import casa_tables as _ct2
-                with _ct2.table(f"{meridian_ms}::SPECTRAL_WINDOW",
-                                readonly=True, ack=False) as _tspw:
+
+                with _ct2.table(
+                    f"{meridian_ms}::SPECTRAL_WINDOW", readonly=True, ack=False
+                ) as _tspw:
                     _n_spw = _tspw.nrows()
                 _precond_spwmap: list[list[int]] = [[0] * _n_spw]
             except Exception as _spw_err:
                 log.warning(
                     "Epoch gaincal [%s]: could not determine SPW count for precond "
                     "spwmap (%s) — SPWs 1+ may be flagged in downstream solves",
-                    stem, _spw_err,
+                    stem,
+                    _spw_err,
                 )
                 _precond_spwmap = []
         else:
@@ -401,11 +472,15 @@ def calibrate_epoch(
             gaintype="G",
             gaintable=[bp_table, *_precond],
             interp=["nearest", *_precond_interp],
-            **( {"spwmap": [[], *_precond_spwmap]} if _precond_spwmap else {} ),
+            **({"spwmap": [[], *_precond_spwmap]} if _precond_spwmap else {}),
         )
         if not os.path.exists(p_table):
             log.error("Epoch gaincal [%s]: phase-only solve produced no table", stem)
-            return None
+            return EpochGaincalResult(
+                None,
+                EpochGaincalStatus.SOLVER_NO_TABLE,
+                "phase-only gaincal produced no table (likely all solutions flagged at minsnr=3.0)",
+            )
 
         # ── 6b. Flag-fraction monitor on p.G table ────────────────────────────
         # Read the CASA FLAG column from the cal table directly.  CASA often
@@ -417,28 +492,35 @@ def calibrate_epoch(
         # BP-only, which is the correct survey-pipeline behaviour for faint fields.
         try:
             import casatools as _cto
+
             _tb = _cto.table()
             _tb.open(p_table)
-            _p_flags = _tb.getcol("FLAG")   # shape: (n_pol, n_spw, n_rows) — booleans
+            _p_flags = _tb.getcol("FLAG")  # shape: (n_pol, n_spw, n_rows) — booleans
             _tb.close()
             _p_flag_frac = float(_p_flags.sum()) / float(_p_flags.size)
             log.info(
                 "Epoch gaincal [%s]: p.G flagged fraction = %.1f%%",
-                stem, _p_flag_frac * 100,
+                stem,
+                _p_flag_frac * 100,
             )
             if _p_flag_frac > GAINCAL_FLAG_FRACTION_LIMIT:
-                log.warning(
-                    "Epoch gaincal [%s]: p.G flagged %.1f%% of solutions "
-                    "(limit %.0f%%) — SNR too low for reliable gain cal. "
-                    "Returning None; pipeline will apply bandpass-only.",
-                    stem, _p_flag_frac * 100, GAINCAL_FLAG_FRACTION_LIMIT * 100,
+                _reason = (
+                    f"p.G flagged {_p_flag_frac * 100:.1f}% of solutions "
+                    f"(limit {GAINCAL_FLAG_FRACTION_LIMIT * 100:.0f}%) — "
+                    f"SNR too low for reliable gain cal"
                 )
-                return None
+                log.warning(
+                    "Epoch gaincal [%s]: %s. Returning None; pipeline will apply bandpass-only.",
+                    stem,
+                    _reason,
+                )
+                return EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, _reason)
         except Exception as _frac_err:
             log.warning(
                 "Epoch gaincal [%s]: could not read p.G flag fraction (%s) — "
                 "proceeding with ap solve",
-                stem, _frac_err,
+                stem,
+                _frac_err,
             )
 
         # Apply BP + precond (if present) + p.G before WSClean imaging
@@ -457,14 +539,17 @@ def calibrate_epoch(
         _flag_frac = _ms_flag_fraction(meridian_ms)
         log.info(
             "Epoch gaincal [%s]: MS flag fraction before WSClean = %.1f%%",
-            stem, 100 * _flag_frac,
+            stem,
+            100 * _flag_frac,
         )
         wsclean_exec = shutil.which("wsclean")
         if _flag_frac >= _WSCLEAN_FLAG_FRACTION_LIMIT:
             log.warning(
                 "Epoch gaincal [%s]: %.1f%% of data flagged (≥%.0f%% limit) — "
                 "skipping WSClean self-cal, re-predicting catalog model for ap solve",
-                stem, 100 * _flag_frac, 100 * _WSCLEAN_FLAG_FRACTION_LIMIT,
+                stem,
+                100 * _flag_frac,
+                100 * _WSCLEAN_FLAG_FRACTION_LIMIT,
             )
             predict_from_skymodel_wsclean(meridian_ms, sky)
         elif not wsclean_exec:
@@ -477,13 +562,22 @@ def calibrate_epoch(
         else:
             cmd = [
                 wsclean_exec,
-                "-niter", str(wsclean_niter),
-                "-auto-threshold", str(wsclean_threshold_sigma),
-                "-save-model-column", "MODEL_DATA",
-                "-name", wsclean_prefix,
-                "-size", "1024", "1024",
-                "-scale", "6arcsec",
-                "-weight", "briggs", "0.5",
+                "-niter",
+                str(wsclean_niter),
+                "-auto-threshold",
+                str(wsclean_threshold_sigma),
+                "-save-model-column",
+                "MODEL_DATA",
+                "-name",
+                wsclean_prefix,
+                "-size",
+                "1024",
+                "1024",
+                "-scale",
+                "6arcsec",
+                "-weight",
+                "briggs",
+                "0.5",
                 "-no-update-model-required",
                 meridian_ms,
             ]
@@ -512,18 +606,22 @@ def calibrate_epoch(
             gaintype="G",
             gaintable=[bp_table, *_precond, p_table],
             interp=["nearest", *_precond_interp, "linear"],
-            **( {"spwmap": [[], *_precond_spwmap, []]} if _precond_spwmap else {} ),
+            **({"spwmap": [[], *_precond_spwmap, []]} if _precond_spwmap else {}),
         )
         if not os.path.exists(ap_table):
             log.error("Epoch gaincal [%s]: ap solve produced no table", stem)
-            return None
+            return EpochGaincalResult(
+                None,
+                EpochGaincalStatus.SOLVER_NO_TABLE,
+                "amplitude+phase gaincal produced no table (likely all solutions flagged at minsnr=3.0)",
+            )
 
         log.info("Epoch gaincal [%s]: SUCCESS → %s", stem, ap_table)
-        return ap_table
+        return EpochGaincalResult(ap_table, EpochGaincalStatus.SOLVED, None)
 
     except Exception as exc:
         log.error(
             "Epoch gaincal: FAILED (%s) — caller should fall back to static daily G table",
             exc,
         )
-        return None
+        return EpochGaincalResult(None, EpochGaincalStatus.EXCEPTION, str(exc))

--- a/dsa110_continuum/qa/promotion.py
+++ b/dsa110_continuum/qa/promotion.py
@@ -1,0 +1,398 @@
+"""Automatic promotion-record emission.
+
+At the end of a ``batch_pipeline.py`` run, derive a per-``(date, hour)``
+promotion record and write it as a side-car JSON in the products directory
+plus a row in the repo-tracked promotion ledger.
+
+Photometric-anchor evaluation is operator-authored. The auto-emitted record
+captures everything the manifest knows — calibration tier, epoch gaincal
+state, gate snapshot, paths — and sets ``promotion_class`` to
+``"auto_emitted_pending_review"`` until the operator finalizes the anchor
+block. This keeps the emit non-promotional by default while removing
+operator burden for the auditable fields.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+EPOCH_GAINCAL_STATES = (
+    "solved",
+    "fell_back_to_static_with_reason",
+    "skipped_intentionally",
+    "skipped_or_failed_low_snr",
+    "unknown",
+)
+DAILY_CAL_TIERS = ("A", "B", "C", "unknown")
+PROMOTION_CLASSES = (
+    "trusted_baseline",
+    "comparator_only",
+    "weak_baseline",
+    "auto_emitted_pending_review",
+)
+
+LEDGER_RELPATH = "docs/validation/promotion-log.md"
+LEDGER_HEADER = (
+    "| date       | hour | class                          | tier | epoch_gc                          "
+    "| anchor                                                | side-car (relative to products root)               "
+    "| git_sha  |\n"
+    "|------------|------|--------------------------------|------|------------------------------------"
+    "|--------------------------------------------------------|----------------------------------------------------"
+    "|----------|\n"
+)
+
+
+def derive_daily_cal_tier(cal_selection: dict[str, Any] | None) -> str:
+    """Map ``RunManifest.cal_selection`` to a spec daily-cal tier.
+
+    The current manifest records ``source`` as one of ``{"generated",
+    "existing", "borrowed"}``. ``"generated"`` and ``"existing"`` are
+    same-date table outcomes (tier A). ``"borrowed"`` represents
+    cross-date table reuse and is treated as tier C — a conservative
+    classification that lumps tier-B (BP same-date, G borrowed) into
+    tier-C since the spec only gates trusted-baseline on tier-A.
+    """
+    if not cal_selection:
+        return "unknown"
+    source = cal_selection.get("source")
+    if source in ("generated", "existing"):
+        return "A"
+    if source == "borrowed":
+        return "C"
+    return "unknown"
+
+
+def derive_epoch_gaincal_state(
+    legacy_status: str | None,
+    skip_intentionally: bool,
+) -> str:
+    """Map ``RunManifest.gaincal_status`` to the spec's four-state enum.
+
+    Recognized legacy values (set by ``scripts/batch_pipeline.py``):
+      - ``"ok"``      — solver returned a usable ap.G table.
+      - ``"low_snr"`` — solver returned None due to operational SNR limits
+                        (sky model empty, p.G flag fraction over the 30%
+                        gate, or solve produced no table because all
+                        solutions were flagged at minsnr=3.0). Spec maps
+                        this to ``skipped_or_failed_low_snr``.
+      - ``"fallback"``— legacy code-path catch-all; under the post-Candidate-5
+                        contract reserved for genuine exceptions inside
+                        ``calibrate_epoch``. Spec maps to
+                        ``fell_back_to_static_with_reason``.
+      - ``"error"``   — exception caught in the batch_pipeline wrapper.
+                        Same spec mapping as ``"fallback"``.
+      - ``"skipped"`` — overloaded; ``skip_intentionally`` disambiguates
+                        ``--skip-epoch-gaincal`` (intentional) from auto-skip
+                        when the epoch slice has fewer than two MS
+                        (operational limit).
+
+    The ``"low_snr"`` and ``"fallback"`` distinction was introduced by the
+    structured ``EpochGaincalResult`` return from
+    ``dsa110_continuum.calibration.epoch_gaincal.calibrate_epoch``. Pre-
+    refactor manifests that conflate the two as ``"fallback"`` will still
+    map to ``fell_back_to_static_with_reason`` for backward compatibility.
+    """
+    if not legacy_status:
+        return "unknown"
+    if legacy_status == "ok":
+        return "solved"
+    if legacy_status == "low_snr":
+        return "skipped_or_failed_low_snr"
+    if legacy_status in ("fallback", "error"):
+        return "fell_back_to_static_with_reason"
+    if legacy_status == "skipped":
+        return "skipped_intentionally" if skip_intentionally else "skipped_or_failed_low_snr"
+    return "unknown"
+
+
+def _anchor_has_any_fired(anchor: dict[str, Any] | None) -> bool:
+    if not anchor:
+        return False
+    return any(anchor.get(k) for k in ("primary_model", "catalog_xmatch", "tile_self_consistency"))
+
+
+def derive_promotion_class(
+    tier: str,
+    gaincal_state: str,
+    anchor: dict[str, Any] | None,
+) -> str:
+    """Compute the spec's promotion class for an emit-time record.
+
+    The pipeline does not auto-fill the photometric anchor block — that
+    evaluation is operator-authored per the spec. So an emit-time record
+    with no anchor returns ``"auto_emitted_pending_review"`` regardless
+    of cal tier or gaincal state. Once the operator fills the anchor
+    block, calling this helper again classifies into the spec's named
+    states.
+    """
+    if not _anchor_has_any_fired(anchor):
+        return "auto_emitted_pending_review"
+    if tier == "A" and gaincal_state == "solved":
+        return "trusted_baseline"
+    return "comparator_only"
+
+
+def _eligibility_reason(tier: str, gaincal_state: str, gates_with_fail: list[str]) -> str | None:
+    """Return None when eligible for trusted_baseline, else a short reason."""
+    if tier != "A":
+        return f"daily_cal_tier={tier!r} (trusted_baseline requires 'A')"
+    if gaincal_state != "solved":
+        return f"epoch_gaincal_state={gaincal_state!r} (trusted_baseline requires 'solved')"
+    if gates_with_fail:
+        return f"manifest gates failed: {', '.join(gates_with_fail)}"
+    return None
+
+
+def build_promotion_record(
+    manifest: Any,
+    hour: int,
+    products_dir: str,
+    *,
+    cli_invocation: list[str] | None = None,
+    skip_epoch_gaincal: bool = False,
+) -> dict[str, Any]:
+    """Build a schema-compliant promotion record dict for one ``(date, hour)``.
+
+    Reads only ``manifest`` attributes already populated during a normal
+    ``batch_pipeline.py`` run. The ``anchor`` block is left empty; the
+    operator fills it in before finalizing promotion.
+    """
+    epoch_rec: dict[str, Any] | None = None
+    for rec in getattr(manifest, "epochs", []) or []:
+        if rec.get("hour") == hour:
+            epoch_rec = rec
+            break
+
+    tier = derive_daily_cal_tier(getattr(manifest, "cal_selection", None) or None)
+    gc_state = derive_epoch_gaincal_state(
+        getattr(manifest, "gaincal_status", None),
+        skip_intentionally=bool(skip_epoch_gaincal),
+    )
+    gates_failed = [
+        str(g.get("gate"))
+        for g in (getattr(manifest, "gates", []) or [])
+        if str(g.get("verdict", "")).upper() in ("FAIL", "FALLBACK", "ERROR")
+    ]
+    elig_reason = _eligibility_reason(tier, gc_state, gates_failed)
+    eligible = elig_reason is None
+    promotion_class = derive_promotion_class(tier, gc_state, anchor=None)
+
+    cal_selection = getattr(manifest, "cal_selection", None) or {}
+    record: dict[str, Any] = {
+        "date": getattr(manifest, "date", ""),
+        "hour": int(hour),
+        "promoted_at_utc": datetime.now(timezone.utc).isoformat(),
+        "git_sha": getattr(manifest, "git_sha", ""),
+        "operator": "auto",
+        "notes": "auto-emitted at end of batch_pipeline run; awaiting operator anchor evaluation",
+        "manifest_path": os.path.join(products_dir, f"{manifest.date}_manifest.json"),
+        "run_log_path": getattr(manifest, "run_log", None),
+        "run_summary_path": os.path.join(products_dir, f"{manifest.date}_run_summary.json"),
+        "mosaic_path": (epoch_rec or {}).get("mosaic_path"),
+        "batch_pipeline_invocation": list(
+            cli_invocation or getattr(manifest, "command_line", []) or []
+        ),
+        "manifest_verdict": getattr(manifest, "pipeline_verdict", "") or None,
+        "pipeline_verdict": getattr(manifest, "pipeline_verdict", "") or None,
+        "daily_cal_tier": tier,
+        "cal_provenance": {
+            "bp": getattr(manifest, "bp_table", "") or None,
+            "g": getattr(manifest, "g_table", "") or None,
+            "borrowed_from": cal_selection.get("borrowed_from"),
+        },
+        "epoch_gaincal_state": gc_state,
+        "epoch_gaincal_reason": _gaincal_reason(manifest),
+        "anchor": {
+            "primary_model": None,
+            "catalog_xmatch": None,
+            "tile_self_consistency": None,
+        },
+        "eligible_for_trusted_baseline": eligible,
+        "eligible_for_trusted_baseline_reason": elig_reason,
+        "promotion_class": promotion_class,
+        "_emit_metadata": {
+            "schema_version": 1,
+            "emitter": "dsa110_continuum.qa.promotion",
+            "epoch_record_n_tiles": (epoch_rec or {}).get("n_tiles"),
+            "epoch_record_status": (epoch_rec or {}).get("status"),
+            "epoch_record_qa_result": (epoch_rec or {}).get("qa_result"),
+        },
+    }
+    return record
+
+
+def _gaincal_reason(manifest: Any) -> str | None:
+    """Surface the gaincal fallback reason from the gate entry, if any."""
+    for g in getattr(manifest, "gates", []) or []:
+        if g.get("gate") == "gaincal":
+            v = str(g.get("verdict", "")).upper()
+            if v in ("FALLBACK", "ERROR"):
+                return str(g.get("reason", "")) or None
+    return None
+
+
+def sidecar_path(products_dir: str, date: str, hour: int) -> str:
+    """Return the canonical sidecar path for a ``(date, hour)`` window."""
+    return os.path.join(products_dir, f"promotion_{date}T{hour:02d}00.json")
+
+
+def write_promotion_sidecar(
+    manifest: Any,
+    hour: int,
+    products_dir: str,
+    *,
+    cli_invocation: list[str] | None = None,
+    skip_epoch_gaincal: bool = False,
+) -> str:
+    """Write a promotion sidecar JSON for one ``(date, hour)`` window.
+
+    Returns the path written. Does not raise on common runtime
+    irregularities — the caller is expected to wrap in try/except for
+    absolute non-fatality.
+    """
+    os.makedirs(products_dir, exist_ok=True)
+    record = build_promotion_record(
+        manifest,
+        hour,
+        products_dir,
+        cli_invocation=cli_invocation,
+        skip_epoch_gaincal=skip_epoch_gaincal,
+    )
+    path = sidecar_path(products_dir, manifest.date, hour)
+    with open(path, "w") as f:
+        json.dump(record, f, indent=2, default=str)
+    logger.info("Promotion sidecar written: %s", path)
+    return path
+
+
+def _ledger_row(record: dict[str, Any], side_car_relpath: str) -> str:
+    anchor_summary = "—"
+    a = record.get("anchor") or {}
+    if a.get("primary_model"):
+        anchor_summary = f"primary_model:{a['primary_model']}"
+    elif a.get("catalog_xmatch"):
+        cx = a["catalog_xmatch"]
+        anchor_summary = f"catalog_xmatch_{cx.get('catalog')}_n={cx.get('n')}"
+    elif a.get("tile_self_consistency"):
+        ts = a["tile_self_consistency"]
+        anchor_summary = f"tile_self_consistency_n={ts.get('n_overlaps')}"
+    return (
+        f"| {record['date']} | {record['hour']:02d}   "
+        f"| {record['promotion_class']:<30} "
+        f"| {record['daily_cal_tier']:<4} "
+        f"| {record['epoch_gaincal_state']:<34} "
+        f"| {anchor_summary:<54} "
+        f"| {side_car_relpath:<50} "
+        f"| {record['git_sha']:<8} |\n"
+    )
+
+
+def append_promotion_ledger(
+    repo_root: str,
+    record: dict[str, Any],
+    side_car_path: str,
+    products_root: str | None = None,
+    ledger_relpath: str = LEDGER_RELPATH,
+) -> str:
+    """Append one row to the repo-tracked markdown ledger.
+
+    Creates the file with a header on first write. Idempotent: if a row
+    for the same (date, hour, git_sha) already exists, no row is added.
+    """
+    ledger_path = os.path.join(repo_root, ledger_relpath)
+    os.makedirs(os.path.dirname(ledger_path), exist_ok=True)
+    if products_root and side_car_path.startswith(products_root):
+        side_car_relpath = os.path.relpath(side_car_path, products_root)
+    else:
+        side_car_relpath = side_car_path
+    row = _ledger_row(record, side_car_relpath)
+    dedup_key = f"| {record['date']} | {record['hour']:02d}   "
+    if os.path.exists(ledger_path):
+        with open(ledger_path) as f:
+            existing = f.read()
+        # Skip if a row for the same (date, hour) and same git_sha already exists.
+        for line in existing.splitlines():
+            if line.startswith(dedup_key) and f"| {record['git_sha']:<8} |" in line:
+                logger.info(
+                    "Ledger row already present for %s hour %02d at sha %s — skipping",
+                    record["date"],
+                    record["hour"],
+                    record["git_sha"],
+                )
+                return ledger_path
+        with open(ledger_path, "a") as f:
+            f.write(row)
+    else:
+        with open(ledger_path, "w") as f:
+            f.write("# Promotion ledger\n\n")
+            f.write(
+                "Auto-appended by `dsa110_continuum.qa.promotion.append_promotion_ledger`. "
+                "One row per `(date, hour)` window at end-of-run. Operator finalizes "
+                "`promotion_class` after evaluating the photometric anchor block in the "
+                "side-car JSON.\n\n"
+            )
+            f.write(LEDGER_HEADER)
+            f.write(row)
+    logger.info("Ledger row appended: %s", ledger_path)
+    return ledger_path
+
+
+def emit_for_run(
+    manifest: Any,
+    products_dir: str,
+    repo_root: str,
+    *,
+    cli_invocation: list[str] | None = None,
+    skip_epoch_gaincal: bool = False,
+    products_root: str | None = None,
+) -> list[str]:
+    """End-of-run helper that emits one promotion sidecar per recorded epoch.
+
+    Writes one sidecar per recorded epoch hour and appends a ledger row for
+    each. Returns the list of sidecar paths written.
+
+    This function is meant to be called from ``scripts/batch_pipeline.py``
+    after ``manifest.save()``. It is non-fatal — raises only on
+    catastrophic IO failures the caller should surface.
+    """
+    written: list[str] = []
+    for rec in getattr(manifest, "epochs", []) or []:
+        hour = rec.get("hour")
+        if hour is None:
+            continue
+        try:
+            path = write_promotion_sidecar(
+                manifest,
+                int(hour),
+                products_dir,
+                cli_invocation=cli_invocation,
+                skip_epoch_gaincal=skip_epoch_gaincal,
+            )
+            written.append(path)
+            record = build_promotion_record(
+                manifest,
+                int(hour),
+                products_dir,
+                cli_invocation=cli_invocation,
+                skip_epoch_gaincal=skip_epoch_gaincal,
+            )
+            append_promotion_ledger(
+                repo_root,
+                record,
+                path,
+                products_root=products_root,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Promotion emit failed for %s hour %s: %s",
+                getattr(manifest, "date", "?"),
+                hour,
+                exc,
+            )
+    return written

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -24,16 +24,18 @@ Output layout (after mosaic move to products/):
         {date}T{HH}00_forced_phot.csv
         ...
 """
+
 import argparse
 import csv
 import json
 import logging
 import os
 import shutil
-import sys
 import subprocess
+import sys
 import time
-from concurrent.futures import ProcessPoolExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -43,7 +45,7 @@ if _ENV_FILE.exists():
     for _line in _ENV_FILE.read_text().splitlines():
         _line = _line.strip()
         if _line.startswith("export "):
-            _line = _line[len("export "):]
+            _line = _line[len("export ") :]
         if "=" in _line and not _line.startswith("#"):
             _key, _, _val = _line.partition("=")
             os.environ.setdefault(_key.strip(), _val.strip())
@@ -55,7 +57,6 @@ sys.path.insert(0, str(Path(__file__).parent))  # enables `import mosaic_day`
 import numpy as np
 from astropy.io import fits
 from astropy.wcs import WCS
-
 from dsa110_continuum.photometry.epoch_qa import EpochQAResult, measure_epoch_qa
 from dsa110_continuum.photometry.epoch_qa_plot import plot_epoch_qa
 from dsa110_continuum.qa.provenance import RunManifest, try_load_prior_manifest
@@ -83,15 +84,24 @@ QA_SUMMARY_CSV = os.environ.get(
     "/data/dsa110-proc/products/qa_summary.csv",
 )
 QA_CSV_FIELDS = [
-    "date", "epoch_utc", "mosaic_path",
-    "n_catalog", "n_recovered", "completeness_frac",
-    "median_ratio", "ratio_gate", "completeness_gate",
-    "rms_gate", "mosaic_rms_mjy",
-    "qa_result", "gaincal_used",
+    "date",
+    "epoch_utc",
+    "mosaic_path",
+    "n_catalog",
+    "n_recovered",
+    "completeness_frac",
+    "median_ratio",
+    "ratio_gate",
+    "completeness_gate",
+    "rms_gate",
+    "mosaic_rms_mjy",
+    "qa_result",
+    "gaincal_used",
 ]
 
 
 def get_paths(date: str) -> dict:
+    """Return the stage and products paths for one observation date."""
     return {
         "ms_dir": MS_DIR,
         "stage_dir": f"{STAGE_IMAGE_BASE}/mosaic_{date}",
@@ -100,14 +110,17 @@ def get_paths(date: str) -> dict:
 
 
 def epoch_mosaic_path(paths: dict, date: str, hour: int) -> str:
+    """Return the stage mosaic FITS path for one epoch hour."""
     return f"{paths['stage_dir']}/{date}T{hour:02d}00_mosaic.fits"
 
 
 def epoch_phot_path(paths: dict, date: str, hour: int) -> str:
+    """Return the products forced-photometry CSV path for one epoch hour."""
     return f"{paths['products_dir']}/{date}T{hour:02d}00_forced_phot.csv"
 
 
 # ── Timestamp parsing ─────────────────────────────────────────────────────────
+
 
 def timestamp_from_fits(fits_path: str) -> datetime | None:
     """Extract UTC datetime from a tile FITS path like .../2026-01-25T21:17:33-image-pb.fits."""
@@ -120,6 +133,7 @@ def timestamp_from_fits(fits_path: str) -> datetime | None:
 
 
 # ── Run logging ───────────────────────────────────────────────────────────────
+
 
 def _run_log_filename(started_at: datetime) -> str:
     """Return ``run_<UTC-ISO>.log`` with a filename-safe timestamp.
@@ -159,15 +173,18 @@ def _attach_run_logfile(date_dir: str, started_at: datetime) -> str:
     fh.setLevel(logging.INFO)
     # Use full ISO date+time in the file (the console keeps the short HH:MM:SS
     # format from basicConfig); a multi-day cron run's log file is unambiguous.
-    fh.setFormatter(logging.Formatter(
-        fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
-        datefmt="%Y-%m-%dT%H:%M:%S",
-    ))
+    fh.setFormatter(
+        logging.Formatter(
+            fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+            datefmt="%Y-%m-%dT%H:%M:%S",
+        )
+    )
     root.addHandler(fh)
     return log_path
 
 
 # ── Checkpoint helpers ────────────────────────────────────────────────────────
+
 
 def _write_tile_checkpoint(
     checkpoint_path: str,
@@ -210,9 +227,7 @@ def _write_tile_checkpoint(
         if prior is not None:
             merged["failure_count"] = int(prior.get("failure_count", 1)) + 1
             # Preserve the first-failure timestamp for operator forensics
-            merged["first_failed_at"] = prior.get(
-                "first_failed_at", prior.get("failed_at")
-            )
+            merged["first_failed_at"] = prior.get("first_failed_at", prior.get("failed_at"))
         else:
             merged["failure_count"] = 1
             merged["first_failed_at"] = merged.get("failed_at")
@@ -289,6 +304,7 @@ def _epoch_should_rebuild(
 
 # ── Quarantine policy ────────────────────────────────────────────────────────
 
+
 def _compute_quarantine_set(
     failures: list[dict],
     threshold: int,
@@ -330,6 +346,7 @@ def _clear_failure_counts(failures: list[dict]) -> list[dict]:
 
 
 # ── Dry-run plan ─────────────────────────────────────────────────────────────
+
 
 def _collect_dry_run_plan(
     *,
@@ -393,7 +410,8 @@ def _collect_dry_run_plan(
         "phase2_epochs_to_rebuild": n_epoch_rebuild,
         "phase2_epochs_to_skip": n_epoch_skip,
         "phase3_photometry": (
-            "skipped (--skip-photometry)" if skip_photometry
+            "skipped (--skip-photometry)"
+            if skip_photometry
             else f"would run; QA gating={'lenient' if lenient_qa else 'strict'}"
         ),
     }
@@ -421,23 +439,24 @@ def _format_dry_run_plan(plan: dict) -> list[str]:
         lines.append(f"  QUARANTINED: {ms}")
     lines.append("Resume plan:")
     for d in plan["epoch_decisions"]:
-        lines.append(
-            f"  hour {int(d['hour']):02d}: {d['action']} ({d.get('reason', '')})"
-        )
-    lines.extend([
-        f"Phase 0 (gaincal):    {plan['phase0_gaincal']}",
-        f"Phase 1 (per-tile):   would attempt {plan['phase1_tiles_to_attempt']} tiles "
-        f"({plan['phase1_tiles_quarantined']} quarantined)",
-        f"Phase 2 (mosaic):     {plan['phase2_epochs_to_rebuild']} rebuild, "
-        f"{plan['phase2_epochs_to_skip']} skip",
-        f"Phase 3 (photometry): {plan['phase3_photometry']}",
-        "",
-        "Pipeline NOT executed (--dry-run set). No products written.",
-    ])
+        lines.append(f"  hour {int(d['hour']):02d}: {d['action']} ({d.get('reason', '')})")
+    lines.extend(
+        [
+            f"Phase 0 (gaincal):    {plan['phase0_gaincal']}",
+            f"Phase 1 (per-tile):   would attempt {plan['phase1_tiles_to_attempt']} tiles "
+            f"({plan['phase1_tiles_quarantined']} quarantined)",
+            f"Phase 2 (mosaic):     {plan['phase2_epochs_to_rebuild']} rebuild, "
+            f"{plan['phase2_epochs_to_skip']} skip",
+            f"Phase 3 (photometry): {plan['phase3_photometry']}",
+            "",
+            "Pipeline NOT executed (--dry-run set). No products written.",
+        ]
+    )
     return lines
 
 
 # ── Dry-run orchestration ────────────────────────────────────────────────────
+
 
 def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> None:
     """Read-only dry-run: build a plan and print it, no side effects.
@@ -476,12 +495,12 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
             return None
 
     ms_list = [
-        p for p in ms_list
-        if (t := _ms_ts(p)) is not None and t.strftime("%Y-%m-%d") == date
+        p for p in ms_list if (t := _ms_ts(p)) is not None and t.strftime("%Y-%m-%d") == date
     ]
     if args.start_hour is not None or args.end_hour is not None:
         ms_list = [
-            p for p in ms_list
+            p
+            for p in ms_list
             if (t := _ms_ts(p)) is not None
             and (args.start_hour is None or t.hour >= args.start_hour)
             and (args.end_hour is None or t.hour < args.end_hour)
@@ -500,8 +519,7 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
                 ck = json.load(f)
             checkpoint_completed = list(ck.get("completed", []))
             checkpoint_failures = [
-                rec for rec in ck.get("failed", [])
-                if isinstance(rec, dict) and rec.get("ms_path")
+                rec for rec in ck.get("failed", []) if isinstance(rec, dict) and rec.get("ms_path")
             ]
         except Exception as exc:
             log.warning("Dry-run: could not read checkpoint (%s)", exc)
@@ -509,11 +527,11 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
     # Apply --clear-quarantine to the in-memory copy so the dry-run plan
     # reflects what *would* happen with that flag — without writing.
     effective_failures = (
-        _clear_failure_counts(checkpoint_failures)
-        if args.clear_quarantine else checkpoint_failures
+        _clear_failure_counts(checkpoint_failures) if args.clear_quarantine else checkpoint_failures
     )
     quarantine_set = _compute_quarantine_set(
-        effective_failures, args.quarantine_after_failures,
+        effective_failures,
+        args.quarantine_after_failures,
     )
 
     # Per-epoch resume decisions
@@ -521,11 +539,12 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
     for hour in epoch_hours:
         mosaic_path = epoch_mosaic_path(paths, date, hour)
         rebuild = _epoch_should_rebuild(
-            mosaic_path, prior_manifest, hour, args.force_recal,
+            mosaic_path,
+            prior_manifest,
+            hour,
+            args.force_recal,
         )
-        prior_v = (
-            None if prior_manifest is None else prior_manifest.epoch_verdict(hour)
-        )
+        prior_v = None if prior_manifest is None else prior_manifest.epoch_verdict(hour)
         if not rebuild:
             reason = f"prior verdict={prior_v}"
             action = "skip"
@@ -550,9 +569,7 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
         ms_list_after_filters=ms_list,
         epoch_hours=epoch_hours,
         epoch_decisions=epoch_decisions,
-        prior_manifest_verdict=(
-            prior_manifest.pipeline_verdict if prior_manifest else None
-        ),
+        prior_manifest_verdict=(prior_manifest.pipeline_verdict if prior_manifest else None),
         prior_manifest_present=prior_manifest is not None,
         checkpoint_completed=len(checkpoint_completed),
         checkpoint_failures=effective_failures,
@@ -567,6 +584,7 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
 
 
 # ── Epoch binning ─────────────────────────────────────────────────────────────
+
 
 def bin_tiles_by_hour(tile_fits: list[str]) -> dict[int, list[str]]:
     """Group tile FITS paths by the UTC hour of their observation timestamp.
@@ -619,6 +637,7 @@ def build_epoch_tile_sets(epochs: dict[int, list[str]]) -> list[tuple[int, list[
 
 # ── Per-epoch mosaic writer (path-explicit version of mosaic_day.write_mosaic) ─
 
+
 def write_epoch_mosaic(
     mosaic: np.ndarray,
     out_wcs: WCS,
@@ -632,6 +651,7 @@ def write_epoch_mosaic(
     git_sha: str | None = None,
     cal_selection: dict | None = None,
 ) -> None:
+    """Write one epoch mosaic FITS file with calibration and QA metadata."""
     os.makedirs(os.path.dirname(out_path), exist_ok=True)
     with fits.open(ref_fits_paths[0]) as ref:
         ref_hdr = ref[0].header.copy()
@@ -686,6 +706,7 @@ def write_epoch_mosaic(
 
 # ── Mosaic stats helper ───────────────────────────────────────────────────────
 
+
 def mosaic_stats(mosaic_path: str) -> tuple[float, float]:
     """Return (peak_jyb, rms_jyb) for a FITS mosaic."""
     with fits.open(mosaic_path) as hdul:
@@ -697,6 +718,7 @@ def mosaic_stats(mosaic_path: str) -> tuple[float, float]:
 
 
 # ── QA summary CSV ────────────────────────────────────────────────────────────
+
 
 def write_qa_summary_row(
     date: str,
@@ -732,6 +754,7 @@ def write_qa_summary_row(
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 
+
 def print_summary(date: str, epoch_results: list[dict]) -> None:
     """Print a per-epoch table plus overall totals."""
     print("\n" + "=" * 88)
@@ -755,10 +778,10 @@ def print_summary(date: str, epoch_results: list[dict]) -> None:
             print(f"  {r['label']:12s}  {r['n_tiles']:>5}  {gcal_str:>8}  {'FAILED':>10}")
             continue
 
-        peak_str = f"{r['peak']:.4f}" if r['peak'] is not None else "n/a"
-        rms_str = f"{r['rms']*1000:.2f}" if r['rms'] is not None else "n/a"
-        src_str = str(r['n_sources']) if r['n_sources'] is not None else "n/a"
-        ratio = r.get('median_ratio')
+        peak_str = f"{r['peak']:.4f}" if r["peak"] is not None else "n/a"
+        rms_str = f"{r['rms'] * 1000:.2f}" if r["rms"] is not None else "n/a"
+        src_str = str(r["n_sources"]) if r["n_sources"] is not None else "n/a"
+        ratio = r.get("median_ratio")
         ratio_str = f"{ratio:.3f}" if ratio is not None else "n/a"
         if ratio is not None:
             all_ratios.append(ratio)
@@ -774,7 +797,6 @@ def print_summary(date: str, epoch_results: list[dict]) -> None:
         overall = float(np.median(all_ratios))
         flag = "  OK" if 0.8 <= overall <= 1.2 else "  WARNING: outside 0.8–1.2 target"
         print(f"  Median DSA/Cat ratio across all epochs: {overall:.3f}{flag}")
-    total_tiles = sum(r.get("n_tiles", 0) for r in epoch_results if r.get("status") != "skipped")
     n_epochs = len(epoch_results)
     n_skipped = sum(1 for r in epoch_results if r.get("status") == "skipped")
     n_failed = sum(1 for r in epoch_results if r.get("status") == "failed")
@@ -790,8 +812,8 @@ def print_summary(date: str, epoch_results: list[dict]) -> None:
     print("=" * 78 + "\n")
 
 
-
 # ── Tile execution: timeout + retry ──────────────────────────────────────────
+
 
 def _run_process_ms(
     ms_path: str,
@@ -807,6 +829,7 @@ def _run_process_ms(
     safe transport across the ProcessPoolExecutor boundary.
     """
     import mosaic_day as _md
+
     cfg = _md.TileConfig.from_dict(cfg_dict)
     result = _md.process_ms(ms_path, cfg, keep_intermediates=keep, force_recal=force_recal)
     return result.to_dict()
@@ -821,6 +844,7 @@ def _ms_is_valid(path: str) -> bool:
     CASA applycal/wsclean subprocess pool on a broken input.
     """
     import glob as _g
+
     return (
         os.path.isdir(path)
         and os.path.exists(os.path.join(path, "table.dat"))
@@ -843,6 +867,7 @@ def process_tile_safe(
     a second attempt is made after a 60-second cool-down.
     """
     import mosaic_day as _md
+
     tag = Path(ms_path).stem
 
     def _attempt() -> _md.TileResult:
@@ -855,8 +880,9 @@ def process_tile_safe(
                 log.error("[%s] TIMEOUT after %ds — killing CASA/WSClean", tag, timeout_sec)
                 for pattern in ["applycal", "wsclean", "mpicasa"]:
                     subprocess.run(["pkill", "-9", "-f", pattern], capture_output=True)
-                return _md.TileResult("failed", failed_stage="timeout",
-                                      error=f"exceeded {timeout_sec}s")
+                return _md.TileResult(
+                    "failed", failed_stage="timeout", error=f"exceeded {timeout_sec}s"
+                )
 
     result = _attempt()
     if not result.ok and retry:
@@ -869,6 +895,7 @@ def process_tile_safe(
 
 
 # ── Dec-strip guard ───────────────────────────────────────────────────────────
+
 
 def check_dec_strip(
     observed_dec: float,
@@ -888,17 +915,25 @@ def check_dec_strip(
             "(threshold %.1f°). Cal tables were derived at Dec≈%.1f° — "
             "applying them at Dec≈%.1f° will produce invalid flux scale. "
             "Re-run with --expected-dec %.1f once cal tables for that strip exist.",
-            observed_dec, expected_dec, delta, threshold_deg,
-            expected_dec, observed_dec, observed_dec,
+            observed_dec,
+            expected_dec,
+            delta,
+            threshold_deg,
+            expected_dec,
+            observed_dec,
+            observed_dec,
         )
         sys.exit(1)
     log.info(
         "Dec-strip check passed: observed %.1f° vs expected %.1f° (Δ=%.1f°)",
-        observed_dec, expected_dec, delta,
+        observed_dec,
+        expected_dec,
+        delta,
     )
 
 
 # ── Cal quality gate ──────────────────────────────────────────────────────────
+
 
 def check_cal_gate(manifest: RunManifest, cal_date: str, date: str, strict: bool) -> None:
     """Check calibration quality and fire gate if thresholds are exceeded."""
@@ -925,7 +960,9 @@ def check_cal_gate(manifest: RunManifest, cal_date: str, date: str, strict: bool
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 
+
 def main() -> None:
+    """Run the batch pipeline CLI."""
     _main_start = time.time()
     parser = argparse.ArgumentParser(
         description="Hourly-epoch mosaic pipeline for DSA-110 drift observations."
@@ -995,14 +1032,14 @@ def main() -> None:
         default=TILE_TIMEOUT_SEC,
         metavar="SECONDS",
         help=f"Hard timeout per tile (applycal + WSClean). Default: {TILE_TIMEOUT_SEC}s (30 min). "
-             "If a tile exceeds this, CASA/WSClean are killed and the tile is skipped (or retried).",
+        "If a tile exceeds this, CASA/WSClean are killed and the tile is skipped (or retried).",
     )
     parser.add_argument(
         "--retry-failed",
         action="store_true",
         default=False,
         help="Retry each failed tile once (60s cool-down between attempts). "
-             "Useful for transient CASA crashes or memory pressure.",
+        "Useful for transient CASA crashes or memory pressure.",
     )
     parser.add_argument(
         "--force-recal",
@@ -1115,17 +1152,18 @@ def main() -> None:
     # The Dec must be known before calibrator selection so that the bandpass
     # calibrator matches the science strip's beam response.
     from dsa110_continuum.calibration.dec_utils import read_ms_dec as _read_ms_dec
+
     _obs_dec: float | None = None
     # Robust to missing/unreadable MS_DIR: dry-run preflight on a fresh
     # workstation should produce a plan rather than crashing here.
     try:
         _ms_dir_listing = os.listdir(MS_DIR)
     except (FileNotFoundError, NotADirectoryError, PermissionError) as _ms_dir_err:
-        log.warning("MS_DIR %s not accessible (%s) — using --expected-dec",
-                    MS_DIR, _ms_dir_err)
+        log.warning("MS_DIR %s not accessible (%s) — using --expected-dec", MS_DIR, _ms_dir_err)
         _ms_dir_listing = []
     _first_ms_list = sorted(
-        f for f in _ms_dir_listing
+        f
+        for f in _ms_dir_listing
         if f.endswith(".ms") and f.startswith(date) and "meridian" not in f
     )
     if _first_ms_list:
@@ -1154,13 +1192,19 @@ def main() -> None:
     if not args.skip_auto_cal:
         try:
             from dsa110_continuum.calibration.ensure import ensure_bandpass
+
             _auto_cal_result = ensure_bandpass(
-                cal_date, ms_dir=MS_DIR, refant="103", obs_dec_deg=_obs_dec,
+                cal_date,
+                ms_dir=MS_DIR,
+                refant="103",
+                obs_dec_deg=_obs_dec,
             )
             log.info(
                 "Auto-cal: %s tables from %s (calibrator=%s, source=%s)",
-                cal_date, _auto_cal_result.cal_date,
-                _auto_cal_result.calibrator_name, _auto_cal_result.source,
+                cal_date,
+                _auto_cal_result.cal_date,
+                _auto_cal_result.calibrator_name,
+                _auto_cal_result.source,
             )
         except Exception as _acal_err:
             log.warning("Auto-cal failed (%s) — falling back to manual table lookup", _acal_err)
@@ -1174,6 +1218,7 @@ def main() -> None:
             resolve_cal_table_paths,
             validate_table_strip_compatibility,
         )
+
         _bp, _ga = resolve_cal_table_paths(MS_DIR, cal_date)
         # Apply the same strip compatibility policy as the auto-cal path
         try:
@@ -1204,6 +1249,7 @@ def main() -> None:
         # Overlay runtime source so the manifest reflects actual table origin,
         # not the original generation source recorded in the sidecar.
         from dsa110_continuum.calibration.ensure import load_provenance_sidecar
+
         _loaded_prov = load_provenance_sidecar(_bp)
         if _loaded_prov is not None:
             _runtime_source = "borrowed" if os.path.islink(_bp) else "existing"
@@ -1282,7 +1328,9 @@ def main() -> None:
             return None
 
     before = len(ms_list)
-    ms_list = [p for p in ms_list if (t := _ms_ts(p)) is not None and t.strftime("%Y-%m-%d") == date]
+    ms_list = [
+        p for p in ms_list if (t := _ms_ts(p)) is not None and t.strftime("%Y-%m-%d") == date
+    ]
     log.info("Date filter (%s): %d → %d MS files", date, before, len(ms_list))
     if not ms_list:
         log.error("No MS files for date %s — aborting", date)
@@ -1293,7 +1341,8 @@ def main() -> None:
     if start_hour is not None or end_hour is not None:
         before = len(ms_list)
         ms_list = [
-            p for p in ms_list
+            p
+            for p in ms_list
             if (t := _ms_ts(p)) is not None
             and (start_hour is None or t.hour >= start_hour)
             and (end_hour is None or t.hour < end_hour)
@@ -1316,6 +1365,7 @@ def main() -> None:
     # --force-recal: purge cached gaincal products so the solve runs fresh
     if args.force_recal:
         import glob as _glob
+
         _cached_ap = _glob.glob(os.path.join(epoch_gaincal_dir, "*.ap.G"))
         for _f in _cached_ap:
             try:
@@ -1348,52 +1398,82 @@ def main() -> None:
                 log.warning("--force-recal: could not remove sentinel %s: %s", _s, _e)
 
     _epoch_g_table: str | None = None
+    _epoch_gaincal_reason: str | None = None
     if not args.skip_epoch_gaincal:
         log.info("=== Phase 0/3: Per-epoch gain calibration ===")
         try:
-            from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
+            from dsa110_continuum.calibration.epoch_gaincal import (
+                EpochGaincalStatus,
+                calibrate_epoch,
+            )
             from dsa110_continuum.calibration.mosaic_constants import MOSAIC_TILE_COUNT
-            _epoch_ms = ms_list[:MOSAIC_TILE_COUNT] if len(ms_list) >= MOSAIC_TILE_COUNT else ms_list
+
+            _epoch_ms = (
+                ms_list[:MOSAIC_TILE_COUNT] if len(ms_list) >= MOSAIC_TILE_COUNT else ms_list
+            )
             if len(_epoch_ms) >= 2:
-                _epoch_g_table = calibrate_epoch(
+                _eg_result = calibrate_epoch(
                     epoch_ms_paths=_epoch_ms,
                     bp_table=_bp,
                     work_dir=epoch_gaincal_dir,
                     refant="103",
                 )
-                if _epoch_g_table is not None:
+                _epoch_g_table = _eg_result.g_table
+                _epoch_gaincal_reason = _eg_result.reason
+                if _eg_result.status == EpochGaincalStatus.SOLVED:
                     log.info("Epoch gaincal SUCCESS: %s", _epoch_g_table)
                     cfg = cfg.replace(g_table=_epoch_g_table)
                     _epoch_gaincal_status = "ok"
+                elif _eg_result.status in (
+                    EpochGaincalStatus.LOW_SNR,
+                    EpochGaincalStatus.SOLVER_NO_TABLE,
+                ):
+                    log.warning(
+                        "Epoch gaincal low-SNR fall-back (%s) — applying static daily G (%s)",
+                        _eg_result.reason or _eg_result.status.value,
+                        _ga,
+                    )
+                    _epoch_gaincal_status = "low_snr"
                 else:
                     log.warning(
-                        "Epoch gaincal failed — falling back to static daily G table (%s)", _ga
+                        "Epoch gaincal code-path fall-back (%s) — applying static daily G (%s)",
+                        _eg_result.reason or _eg_result.status.value,
+                        _ga,
                     )
                     _epoch_gaincal_status = "fallback"
             else:
+                _epoch_gaincal_reason = f"need at least 2 MS files, found {len(_epoch_ms)}"
                 log.warning(
-                    "Epoch gaincal skipped: need at least 2 MS files, found %d", len(_epoch_ms)
+                    "Epoch gaincal skipped: %s",
+                    _epoch_gaincal_reason,
                 )
                 _epoch_gaincal_status = "skipped"
         except Exception as _eg_exc:
             log.error("Epoch gaincal error: %s — using static table", _eg_exc)
             _epoch_gaincal_status = "error"
+            _epoch_gaincal_reason = str(_eg_exc)
     else:
         log.info("--skip-epoch-gaincal set: using static daily G table (%s)", _ga)
         _epoch_gaincal_status = "skipped"
+        _epoch_gaincal_reason = "operator passed --skip-epoch-gaincal"
     # ──────────────────────────────────────────────────────────────────────────
 
     manifest.gaincal_status = _epoch_gaincal_status
     manifest.epoch_g_table = _epoch_g_table
 
-    # Gaincal fallback/error is a degradation signal: record it as a gate so the
-    # pipeline verdict reflects that the per-epoch phase solution was not used.
-    # "skipped" is intentional (--skip-epoch-gaincal) and does not degrade.
-    if _epoch_gaincal_status in ("fallback", "error"):
+    # Gaincal fall-back/error is a degradation signal: record it as a gate so
+    # the pipeline verdict reflects that the per-epoch phase solution was not
+    # used. low_snr is operational (data limit, not bug); fallback is reserved
+    # for true exceptions. "skipped" is intentional and does not degrade.
+    if _epoch_gaincal_status in ("low_snr", "fallback", "error"):
+        _verdict_map = {"low_snr": "LOW_SNR", "fallback": "FALLBACK", "error": "ERROR"}
         manifest.add_gate(
             gate="gaincal",
-            verdict="FALLBACK" if _epoch_gaincal_status == "fallback" else "ERROR",
-            reason=f"epoch gaincal {_epoch_gaincal_status}; static daily G table used",
+            verdict=_verdict_map[_epoch_gaincal_status],
+            reason=(
+                _epoch_gaincal_reason
+                or f"epoch gaincal {_epoch_gaincal_status}; static daily G table used"
+            ),
             static_g_table=_ga,
         )
 
@@ -1405,8 +1485,7 @@ def main() -> None:
     # Consult the prior-run manifest (if any). Used for QA-aware epoch skip
     # (below) and to carry tile-failure history across re-runs.
     prior_manifest = (
-        None if args.force_recal
-        else try_load_prior_manifest(date, products_dir=PRODUCTS_BASE)
+        None if args.force_recal else try_load_prior_manifest(date, products_dir=PRODUCTS_BASE)
     )
     if prior_manifest is not None:
         log.info(
@@ -1435,8 +1514,7 @@ def main() -> None:
                 ck = json.load(f)
             tile_fits = [p for p in ck.get("completed", []) if os.path.exists(p)]
             prior_tile_failures = [
-                rec for rec in ck.get("failed", [])
-                if isinstance(rec, dict) and rec.get("ms_path")
+                rec for rec in ck.get("failed", []) if isinstance(rec, dict) and rec.get("ms_path")
             ]
             if tile_fits:
                 log.info("Checkpoint: resuming with %d previously completed tiles", len(tile_fits))
@@ -1459,23 +1537,28 @@ def main() -> None:
     # --clear-quarantine zeros every failure_count before the threshold check
     # so the next run is allowed to retry every MS regardless of history.
     if args.clear_quarantine and prior_tile_failures:
-        log.info("--clear-quarantine: zeroing failure_count for %d MS",
-                 len(prior_tile_failures))
+        log.info("--clear-quarantine: zeroing failure_count for %d MS", len(prior_tile_failures))
         prior_tile_failures = _clear_failure_counts(prior_tile_failures)
         # Persist the cleared counts immediately so even if the run aborts the
         # release survives.
         _write_tile_checkpoint(
-            checkpoint_path, date, cal_date, tile_fits,
-            prior_tile_failures, current_tile_failures,
+            checkpoint_path,
+            date,
+            cal_date,
+            tile_fits,
+            prior_tile_failures,
+            current_tile_failures,
         )
     quarantine_set = _compute_quarantine_set(
-        prior_tile_failures, args.quarantine_after_failures,
+        prior_tile_failures,
+        args.quarantine_after_failures,
     )
     if quarantine_set:
         log.warning(
             "Quarantine: %d MS skipped (>= %d consecutive failures). "
             "Run --clear-quarantine to re-enable.",
-            len(quarantine_set), args.quarantine_after_failures,
+            len(quarantine_set),
+            args.quarantine_after_failures,
         )
         manifest.add_gate(
             gate="quarantine",
@@ -1487,8 +1570,11 @@ def main() -> None:
             quarantined_ms_paths=sorted(quarantine_set),
         )
 
-    log.info("=== Phase 1/3: Calibrate + Image all tiles (timeout=%ds, retry=%s) ===",
-             tile_timeout, retry_failed)
+    log.info(
+        "=== Phase 1/3: Calibrate + Image all tiles (timeout=%ds, retry=%s) ===",
+        tile_timeout,
+        retry_failed,
+    )
     n_imaged = n_skipped_tiles = n_failed_tiles = n_quarantined = 0
 
     for i, ms_path in enumerate(ms_list, 1):
@@ -1501,8 +1587,11 @@ def main() -> None:
             log.warning("  QUARANTINED — skipping %s", ms_path)
             n_quarantined += 1
             manifest.record_tile(
-                ms_path, None, "quarantined",
-                0.0, error="quarantined",
+                ms_path,
+                None,
+                "quarantined",
+                0.0,
+                error="quarantined",
             )
             continue
 
@@ -1517,44 +1606,64 @@ def main() -> None:
             )
             n_failed_tiles += 1
             manifest.record_tile(
-                ms_path, None, "failed",
-                0.0, error="corrupt_ms_skipped",
+                ms_path,
+                None,
+                "failed",
+                0.0,
+                error="corrupt_ms_skipped",
             )
-            current_tile_failures.append({
-                "ms_path": ms_path,
-                "error": "corrupt_ms_skipped",
-                "elapsed_sec": 0.0,
-                "failed_at": datetime.now(timezone.utc).isoformat(),
-            })
+            current_tile_failures.append(
+                {
+                    "ms_path": ms_path,
+                    "error": "corrupt_ms_skipped",
+                    "elapsed_sec": 0.0,
+                    "failed_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
             _write_tile_checkpoint(
-                checkpoint_path, date, cal_date, tile_fits,
-                prior_tile_failures, current_tile_failures,
+                checkpoint_path,
+                date,
+                cal_date,
+                tile_fits,
+                prior_tile_failures,
+                current_tile_failures,
                 cleared_ms_paths=current_completed_ms_paths,
             )
             continue
 
         t0 = time.time()
         result = process_tile_safe(
-            cfg.to_dict(), ms_path, keep, tile_timeout, retry_failed,
+            cfg.to_dict(),
+            ms_path,
+            keep,
+            tile_timeout,
+            retry_failed,
             force_recal=(args.force_recal or _epoch_gaincal_status == "ok"),
         )
         elapsed = time.time() - t0
 
         if not result.ok:
             err_msg = result.error or result.failed_stage
-            log.error("  FAILED after %.0fs (%s: %s)", elapsed,
-                       result.failed_stage, err_msg or "unknown")
+            log.error(
+                "  FAILED after %.0fs (%s: %s)", elapsed, result.failed_stage, err_msg or "unknown"
+            )
             n_failed_tiles += 1
             manifest.record_tile(ms_path, None, "failed", elapsed, error=err_msg)
-            current_tile_failures.append({
-                "ms_path": ms_path,
-                "error": err_msg,
-                "elapsed_sec": round(elapsed, 1),
-                "failed_at": datetime.now(timezone.utc).isoformat(),
-            })
+            current_tile_failures.append(
+                {
+                    "ms_path": ms_path,
+                    "error": err_msg,
+                    "elapsed_sec": round(elapsed, 1),
+                    "failed_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
             _write_tile_checkpoint(
-                checkpoint_path, date, cal_date, tile_fits,
-                prior_tile_failures, current_tile_failures,
+                checkpoint_path,
+                date,
+                cal_date,
+                tile_fits,
+                prior_tile_failures,
+                current_tile_failures,
                 cleared_ms_paths=current_completed_ms_paths,
             )
         else:
@@ -1573,14 +1682,21 @@ def main() -> None:
             current_completed_ms_paths.append(ms_path)
 
             _write_tile_checkpoint(
-                checkpoint_path, date, cal_date, tile_fits,
-                prior_tile_failures, current_tile_failures,
+                checkpoint_path,
+                date,
+                cal_date,
+                tile_fits,
+                prior_tile_failures,
+                current_tile_failures,
                 cleared_ms_paths=current_completed_ms_paths,
             )
 
     log.info(
         "Tiles: %d imaged, %d already done, %d failed, %d quarantined",
-        n_imaged, n_skipped_tiles, n_failed_tiles, n_quarantined,
+        n_imaged,
+        n_skipped_tiles,
+        n_failed_tiles,
+        n_quarantined,
     )
 
     if len(tile_fits) < 2:
@@ -1606,7 +1722,10 @@ def main() -> None:
         n_overlap = len(epoch_tiles) - n_core
         log.info(
             "--- Epoch %s: %d core + %d overlap = %d tiles ---",
-            label, n_core, n_overlap, len(epoch_tiles),
+            label,
+            n_core,
+            n_overlap,
+            len(epoch_tiles),
         )
 
         mosaic_path = epoch_mosaic_path(paths, date, hour)
@@ -1617,7 +1736,10 @@ def main() -> None:
         # that exists but whose prior QA verdict was FAIL (or absent, meaning
         # the prior run crashed mid-epoch) is NOT trusted — it gets rebuilt.
         should_rebuild = _epoch_should_rebuild(
-            mosaic_path, prior_manifest, hour, args.force_recal,
+            mosaic_path,
+            prior_manifest,
+            hour,
+            args.force_recal,
         )
 
         # Remove stale epoch-level outputs before rebuilding so the fresh
@@ -1636,13 +1758,20 @@ def main() -> None:
 
         if not should_rebuild:
             prior_v = None if prior_manifest is None else prior_manifest.epoch_verdict(hour)
-            log.info("  Mosaic already exists (prior verdict=%s) — skipping epoch %s",
-                     prior_v or "no-manifest", label)
-            epoch_results.append({
-                "label": label, "status": "skipped", "n_tiles": len(epoch_tiles),
-                "gaincal_status": _epoch_gaincal_status,
-                "qa_result": prior_v,  # carry prior verdict forward
-            })
+            log.info(
+                "  Mosaic already exists (prior verdict=%s) — skipping epoch %s",
+                prior_v or "no-manifest",
+                label,
+            )
+            epoch_results.append(
+                {
+                    "label": label,
+                    "status": "skipped",
+                    "n_tiles": len(epoch_tiles),
+                    "gaincal_status": _epoch_gaincal_status,
+                    "qa_result": prior_v,  # carry prior verdict forward
+                }
+            )
             continue
 
         # Build mosaic
@@ -1650,19 +1779,39 @@ def main() -> None:
             out_wcs, ny, nx = _md.build_common_wcs(epoch_tiles)
             mosaic_arr = _md.coadd_tiles(epoch_tiles, out_wcs, ny, nx)
             write_epoch_mosaic(
-                mosaic_arr, out_wcs, epoch_tiles, mosaic_path, date, hour, len(epoch_tiles),
-                cal_date=cal_date, cal_quality=manifest.cal_quality, git_sha=manifest.git_sha,
+                mosaic_arr,
+                out_wcs,
+                epoch_tiles,
+                mosaic_path,
+                date,
+                hour,
+                len(epoch_tiles),
+                cal_date=cal_date,
+                cal_quality=manifest.cal_quality,
+                git_sha=manifest.git_sha,
                 cal_selection=manifest.cal_selection or None,
             )
         except Exception as e:
             log.error("  Mosaic failed for epoch %s: %s", label, e)
-            epoch_results.append({"label": label, "status": "failed", "n_tiles": len(epoch_tiles), "gaincal_status": _epoch_gaincal_status})
+            epoch_results.append(
+                {
+                    "label": label,
+                    "status": "failed",
+                    "n_tiles": len(epoch_tiles),
+                    "gaincal_status": _epoch_gaincal_status,
+                }
+            )
             continue
 
         # QA
         _md.check_mosaic_quality(mosaic_path)
         peak, rms = mosaic_stats(mosaic_path)
-        log.info("  Peak: %.4f Jy/beam  RMS: %.2f mJy/beam  DR: %.0f", peak, rms * 1000, peak / rms if rms else 0)
+        log.info(
+            "  Peak: %.4f Jy/beam  RMS: %.2f mJy/beam  DR: %.0f",
+            peak,
+            rms * 1000,
+            peak / rms if rms else 0,
+        )
 
         # ── Epoch QA (three-gate) — run BEFORE photometry ─────────────────────
         epoch_qa: EpochQAResult | None = None
@@ -1670,9 +1819,12 @@ def main() -> None:
             epoch_qa = measure_epoch_qa(mosaic_path)
             log.info(
                 "  Epoch QA: ratio=%.3f [%s] | compl=%.1f%% [%s] | rms=%.1f mJy [%s] → %s",
-                epoch_qa.median_ratio, epoch_qa.ratio_gate,
-                epoch_qa.completeness_frac * 100, epoch_qa.completeness_gate,
-                epoch_qa.mosaic_rms_mjy, epoch_qa.rms_gate,
+                epoch_qa.median_ratio,
+                epoch_qa.ratio_gate,
+                epoch_qa.completeness_frac * 100,
+                epoch_qa.completeness_gate,
+                epoch_qa.mosaic_rms_mjy,
+                epoch_qa.rms_gate,
                 epoch_qa.qa_result,
             )
         except Exception as e:
@@ -1685,7 +1837,10 @@ def main() -> None:
                     hdr = hdul[0].header
                     hdr["QARESULT"] = (epoch_qa.qa_result, "Epoch QA verdict")
                     hdr["QARMS"] = (round(epoch_qa.mosaic_rms_mjy, 2), "Mosaic RMS [mJy/beam]")
-                    hdr["QARAT"] = (round(epoch_qa.median_ratio, 4), "Median DSA/catalog flux ratio")
+                    hdr["QARAT"] = (
+                        round(epoch_qa.median_ratio, 4),
+                        "Median DSA/catalog flux ratio",
+                    )
             except Exception as e:
                 log.warning("  Could not update FITS header with QA: %s", e)
 
@@ -1697,7 +1852,9 @@ def main() -> None:
         median_ratio: float | None = None
         qa_verdict = epoch_qa.qa_result if epoch_qa else None
         skip_phot, skip_reason = _should_skip_photometry(
-            qa_verdict, args.skip_photometry, args.lenient_qa,
+            qa_verdict,
+            args.skip_photometry,
+            args.lenient_qa,
         )
 
         if skip_reason == "qa-fail-default-strict":
@@ -1707,8 +1864,7 @@ def main() -> None:
             )
         elif skip_reason == "lenient-qa-override":
             log.warning(
-                "  --lenient-qa: running photometry on QA-FAIL epoch %s "
-                "(verdict will be DEGRADED)",
+                "  --lenient-qa: running photometry on QA-FAIL epoch %s (verdict will be DEGRADED)",
                 label,
             )
             manifest.add_gate(
@@ -1721,8 +1877,11 @@ def main() -> None:
         if not skip_phot:
             try:
                 from forced_photometry import run_forced_photometry
+
                 phot_result = run_forced_photometry(
-                    mosaic_path, output_csv=phot_csv_path, min_flux_mjy=10.0,
+                    mosaic_path,
+                    output_csv=phot_csv_path,
+                    min_flux_mjy=10.0,
                     workers=args.photometry_workers,
                     chunk_size=(args.photometry_chunk_size or None),
                 )
@@ -1770,25 +1929,29 @@ def main() -> None:
         should_archive = qa_verdict != "FAIL" or args.archive_all
         if not should_archive:
             log.warning("  QA FAIL — mosaic NOT archived to products: %s", label)
-            manifest.gates.append({"gate": "archive", "verdict": "BLOCKED", "reason": f"epoch {label} QA FAIL"})
+            manifest.gates.append(
+                {"gate": "archive", "verdict": "BLOCKED", "reason": f"epoch {label} QA FAIL"}
+            )
         elif mosaic_fits_src.exists() and (not mosaic_fits_dst.exists() or args.force_recal):
             shutil.copy2(str(mosaic_fits_src), str(mosaic_fits_dst))
             log.info("Archived mosaic FITS: %s", mosaic_fits_dst)
 
-        epoch_results.append({
-            "label": label,
-            "status": "ok",
-            "n_tiles": len(epoch_tiles),
-            "n_core": n_core,
-            "n_overlap": n_overlap,
-            "peak": peak,
-            "rms": rms,
-            "n_sources": n_sources,
-            "median_ratio": median_ratio,
-            "mosaic_path": mosaic_path,
-            "gaincal_status": _epoch_gaincal_status,
-            "qa_result": epoch_qa.qa_result if epoch_qa else None,
-        })
+        epoch_results.append(
+            {
+                "label": label,
+                "status": "ok",
+                "n_tiles": len(epoch_tiles),
+                "n_core": n_core,
+                "n_overlap": n_overlap,
+                "peak": peak,
+                "rms": rms,
+                "n_sources": n_sources,
+                "median_ratio": median_ratio,
+                "mosaic_path": mosaic_path,
+                "gaincal_status": _epoch_gaincal_status,
+                "qa_result": epoch_qa.qa_result if epoch_qa else None,
+            }
+        )
 
     # ── Record epochs in manifest ────────────────────────────────────────────
     for er in epoch_results:
@@ -1805,7 +1968,10 @@ def main() -> None:
     manifest.save(paths["products_dir"])
 
     emit_run_summary(
-        date, cal_date, epoch_results, _wall,
+        date,
+        cal_date,
+        epoch_results,
+        _wall,
         products_dir=paths["products_dir"],
         run_log_path=_run_log_path,
     )
@@ -1814,9 +1980,29 @@ def main() -> None:
     # actual run — operators still have manifest.json + run_summary.json.
     try:
         from dsa110_continuum.qa.run_report import write_run_report
+
         write_run_report(manifest, paths["products_dir"])
     except Exception as _report_err:
         log.warning("Run report render failed (non-fatal): %s", _report_err)
+
+    # Promotion auto-emit is non-fatal: a sidecar/ledger failure must not fail
+    # an otherwise completed pipeline run.
+    try:
+        from dsa110_continuum.qa.promotion import emit_for_run
+
+        _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        _products_root = os.path.dirname(os.path.dirname(paths["products_dir"]))
+        emit_for_run(
+            manifest,
+            paths["products_dir"],
+            _repo_root,
+            cli_invocation=list(sys.argv),
+            skip_epoch_gaincal=bool(args.skip_epoch_gaincal),
+            products_root=_products_root,
+        )
+    except Exception as _promo_err:
+        log.warning("Promotion auto-emit failed (non-fatal): %s", _promo_err)
+
 
 def emit_run_summary(
     date: str,
@@ -1879,14 +2065,22 @@ def emit_run_summary(
     log.info(
         "Run complete — date=%s cal=%s  epochs=%d  exec_ok=%d exec_fail=%d"
         "  qa_pass=%d qa_fail=%d  wall=%.0fm  → %s",
-        date, cal_date, len(epoch_results), n_exec_ok, n_exec_fail,
-        n_qa_pass, n_qa_fail, wall_time_sec / 60, summary_path,
+        date,
+        cal_date,
+        len(epoch_results),
+        n_exec_ok,
+        n_exec_fail,
+        n_qa_pass,
+        n_qa_fail,
+        wall_time_sec / 60,
+        summary_path,
     )
 
     notify_url = os.environ.get("DSA_NOTIFY_URL")
     if notify_url:
         try:
             import requests as _req
+
             _req.post(notify_url, json=payload, timeout=10)
         except Exception:
             pass  # notification is best-effort

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -1,4 +1,5 @@
 """Tests for epoch_gaincal: tile selection, RFI flagging, WSClean guard, refant chain."""
+
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -18,12 +19,15 @@ def test_select_calibration_tile_from_ms_picks_richer_tile():
         # tile index 6 → ra=60.0 → 8 sources; tile index 5 → ra=50.0 → 3 sources
         return 8 if pointing_ra_deg == 60.0 else 3
 
-    with patch(
-        "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-        side_effect=fake_phase_center,
-    ), patch(
-        "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
-        side_effect=fake_count,
+    with (
+        patch(
+            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+            side_effect=fake_phase_center,
+        ),
+        patch(
+            "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
+            side_effect=fake_count,
+        ),
     ):
         result = select_calibration_tile_from_ms(fake_paths)
 
@@ -45,12 +49,15 @@ def test_select_calibration_tile_works_with_11_tiles():
         # tile index 5 → ra=50.0 → 9 sources; tile index 4 → ra=40.0 → 2 sources
         return 9 if pointing_ra_deg == 50.0 else 2
 
-    with patch(
-        "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-        side_effect=fake_phase_center,
-    ), patch(
-        "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
-        side_effect=fake_count,
+    with (
+        patch(
+            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+            side_effect=fake_phase_center,
+        ),
+        patch(
+            "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
+            side_effect=fake_count,
+        ),
     ):
         result = select_calibration_tile_from_ms(fake_paths)
 
@@ -59,8 +66,8 @@ def test_select_calibration_tile_works_with_11_tiles():
 
 def test_select_calibration_tile_raises_on_too_few():
     """Should raise ValueError when given fewer than 2 MS paths."""
-    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
     import pytest
+    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
 
     with pytest.raises(ValueError, match="at least 2"):
         select_calibration_tile_from_ms(["/fake/a.ms"])
@@ -96,53 +103,82 @@ def _make_exists_fn(meridian_ms: str, *, ap_table: str | None = None) -> object:
     - meridian_ms path → True (tells code the phaseshift output exists)
     - everything else → True (intermediate tables, directories, etc.)
     """
+
     def _exists(path: str) -> bool:
         p = str(path)
         if ap_table and p == ap_table:
             return False
         return True
+
     return _exists
 
 
-def test_calibrate_epoch_returns_none_on_predict_failure():
-    """calibrate_epoch() should return None (not raise) if catalog predict fails."""
+def test_calibrate_epoch_returns_exception_status_on_predict_failure():
+    """calibrate_epoch() should return EXCEPTION status (not raise) when catalog predict fails."""
     import tempfile
-    from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
+
+    from dsa110_continuum.calibration.epoch_gaincal import (
+        EpochGaincalStatus,
+        calibrate_epoch,
+    )
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
     mock_svc = MagicMock()
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_05_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_05.ap.G")
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_05.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-            side_effect=RuntimeError("wsclean not found"),
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_svc,
-        ), patch(
-            "os.path.exists",
-            side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+        ap_table = str(Path(work_dir) / "tile_05.ap.G")
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_05.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(10.0, 37.0),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
+                side_effect=RuntimeError("wsclean not found"),
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_svc,
+            ),
+            patch(
+                "os.path.exists",
+                side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+            ),
         ):
             result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
-    assert result is None
+    assert result.g_table is None
+    assert result.status == EpochGaincalStatus.EXCEPTION
+    assert "wsclean not found" in (result.reason or "")
 
 
-def test_calibrate_epoch_returns_none_on_empty_sky_model():
-    """calibrate_epoch() should return None when the catalog sky model is empty."""
+def test_calibrate_epoch_returns_low_snr_on_empty_sky_model():
+    """calibrate_epoch() returns LOW_SNR status when the catalog sky model is empty.
+
+    Empty sky model is an operational/data limit (no bright sources within
+    the search radius), not a code-path fault — maps to the spec's
+    skipped_or_failed_low_snr promotion state.
+    """
     import tempfile
-    from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
+
+    from dsa110_continuum.calibration.epoch_gaincal import (
+        EpochGaincalStatus,
+        calibrate_epoch,
+    )
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
     empty_sky = MagicMock()
@@ -151,30 +187,40 @@ def test_calibrate_epoch_returns_none_on_empty_sky_model():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_05_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_05.ap.G")
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_05.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(10.0, 37.0),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=empty_sky,
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_svc,
-        ), patch(
-            "os.path.exists",
-            side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+        ap_table = str(Path(work_dir) / "tile_05.ap.G")
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_05.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(10.0, 37.0),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+                return_value=empty_sky,
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_svc,
+            ),
+            patch(
+                "os.path.exists",
+                side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+            ),
         ):
             result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
-    assert result is None
+    assert result.g_table is None
+    assert result.status == EpochGaincalStatus.LOW_SNR
+    assert "empty" in (result.reason or "").lower()
 
 
 def test_process_ms_force_recal_calls_applycal_even_when_data_exists():
@@ -191,10 +237,10 @@ def test_process_ms_force_recal_calls_applycal_even_when_data_exists():
 # Keep Path import at module level so it's available in test functions
 from pathlib import Path  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Tests for the four items from the Feb-15 gaincal hardening
 # ---------------------------------------------------------------------------
+
 
 def test_ms_flag_fraction_computes_correctly():
     """`_ms_flag_fraction` returns correct value from a mocked casacore table."""
@@ -219,6 +265,7 @@ def test_ms_flag_fraction_computes_correctly():
 def test_wsclean_skipped_when_ms_heavily_flagged():
     """WSClean self-cal must be skipped and catalog model re-predicted when flag fraction >= 60%."""
     import tempfile
+
     from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
@@ -228,32 +275,45 @@ def test_wsclean_skipped_when_ms_heavily_flagged():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_03.ap.G")
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_03.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(44.89, 16.08),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=mock_sky,
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-        ) as mock_predict, patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.72,  # above 60% threshold
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_service,
-        ), patch(
-            "shutil.which", return_value="/usr/bin/wsclean",
-        ), patch(
-            "os.path.exists", side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+        ap_table = str(Path(work_dir) / "tile_03.ap.G")
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_03.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(44.89, 16.08),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+                return_value=mock_sky,
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
+            ) as mock_predict,
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
+                return_value=0.72,  # above 60% threshold
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_service,
+            ),
+            patch(
+                "shutil.which",
+                return_value="/usr/bin/wsclean",
+            ),
+            patch(
+                "os.path.exists",
+                side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+            ),
         ):
             calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
@@ -265,6 +325,7 @@ def test_wsclean_skipped_when_ms_heavily_flagged():
 def test_wsclean_runs_when_flag_fraction_below_limit():
     """WSClean self-cal must be attempted when flag fraction is below 60%."""
     import tempfile
+
     from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
@@ -276,34 +337,49 @@ def test_wsclean_runs_when_flag_fraction_below_limit():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_03.ap.G")
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_03.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(44.89, 16.08),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=mock_sky,
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.32,  # well below 60% threshold
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_service,
-        ), patch(
-            "shutil.which", return_value="/usr/bin/wsclean",
-        ), patch(
-            "subprocess.run", return_value=wsclean_ok,
-        ) as mock_subprocess, patch(
-            "os.path.exists", side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+        ap_table = str(Path(work_dir) / "tile_03.ap.G")
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_03.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(44.89, 16.08),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+                return_value=mock_sky,
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
+                return_value=0.32,  # well below 60% threshold
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_service,
+            ),
+            patch(
+                "shutil.which",
+                return_value="/usr/bin/wsclean",
+            ),
+            patch(
+                "subprocess.run",
+                return_value=wsclean_ok,
+            ) as mock_subprocess,
+            patch(
+                "os.path.exists",
+                side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+            ),
         ):
             calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
@@ -314,6 +390,7 @@ def test_wsclean_runs_when_flag_fraction_below_limit():
 def test_preconditioner_table_threaded_into_downstream_solves():
     """precond.G must appear in gaintable of p.G and ap.G solves when it succeeds."""
     import tempfile
+
     from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
@@ -324,42 +401,56 @@ def test_preconditioner_table_threaded_into_downstream_solves():
     wsclean_ok.returncode = 0
 
     with tempfile.TemporaryDirectory() as work_dir:
-        meridian_ms    = str(Path(work_dir) / "tile_03_meridian.ms")
-        precond_table  = str(Path(work_dir) / "tile_03.precond.G")
-        ap_table       = str(Path(work_dir) / "tile_03.ap.G")
+        precond_table = str(Path(work_dir) / "tile_03.precond.G")
+        ap_table = str(Path(work_dir) / "tile_03.ap.G")
 
         # os.path.exists: False for ap_table (no cache), True for everything else
         # (meridian MS, precond table, p table all "exist" after their solves)
         def _exists(p: str) -> bool:
             return str(p) != ap_table
 
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_03.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(44.89, 16.08),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=mock_sky,
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.25,
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_service,
-        ), patch(
-            "shutil.which", return_value="/usr/bin/wsclean",
-        ), patch(
-            "subprocess.run", return_value=wsclean_ok,
-        ), patch(
-            "os.path.exists", side_effect=_exists,
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_03.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(44.89, 16.08),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+                return_value=mock_sky,
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
+                return_value=0.25,
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_service,
+            ),
+            patch(
+                "shutil.which",
+                return_value="/usr/bin/wsclean",
+            ),
+            patch(
+                "subprocess.run",
+                return_value=wsclean_ok,
+            ),
+            patch(
+                "os.path.exists",
+                side_effect=_exists,
+            ),
         ):
             calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
@@ -375,8 +466,7 @@ def test_preconditioner_table_threaded_into_downstream_solves():
     assert precond_call.kwargs["gaintable"] == ["/fake/bp.b"]
 
     # p.G solve must include precond table
-    assert precond_table in p_call.kwargs["gaintable"], \
-        "precond table must be in p.G gaintable"
+    assert precond_table in p_call.kwargs["gaintable"], "precond table must be in p.G gaintable"
     assert "/fake/bp.b" in p_call.kwargs["gaintable"]
     assert p_call.kwargs["solint"] == "inf"
 
@@ -390,6 +480,7 @@ def test_preconditioner_table_threaded_into_downstream_solves():
 def test_preconditioner_failure_does_not_abort_epoch_gaincal():
     """If precond solve fails entirely, the main p.G and ap.G solves must still run."""
     import tempfile
+
     from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
@@ -398,51 +489,66 @@ def test_preconditioner_failure_does_not_abort_epoch_gaincal():
     mock_service = MagicMock()
     # Make the first gaincal call (precond) raise; subsequent calls succeed
     call_count = {"n": 0}
+
     def _gaincal_side_effect(**kw):
         call_count["n"] += 1
         if call_count["n"] == 1:
             raise RuntimeError("CASA unavailable for precond")
+
     mock_service.gaincal.side_effect = _gaincal_side_effect
     wsclean_ok = MagicMock()
     wsclean_ok.returncode = 0
 
     with tempfile.TemporaryDirectory() as work_dir:
-        meridian_ms   = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table      = str(Path(work_dir) / "tile_03.ap.G")
-        p_table       = str(Path(work_dir) / "tile_03.p.G")
+        ap_table = str(Path(work_dir) / "tile_03.ap.G")
         precond_table = str(Path(work_dir) / "tile_03.precond.G")
 
         def _exists(p: str) -> bool:
             # ap and precond tables never exist; meridian MS and p table exist
             return str(p) not in (ap_table, precond_table)
 
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_03.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(44.89, 16.08),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=mock_sky,
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.25,
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_service,
-        ), patch(
-            "shutil.which", return_value="/usr/bin/wsclean",
-        ), patch(
-            "subprocess.run", return_value=wsclean_ok,
-        ), patch(
-            "os.path.exists", side_effect=_exists,
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_03.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(44.89, 16.08),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+                return_value=mock_sky,
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
+                return_value=0.25,
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_service,
+            ),
+            patch(
+                "shutil.which",
+                return_value="/usr/bin/wsclean",
+            ),
+            patch(
+                "subprocess.run",
+                return_value=wsclean_ok,
+            ),
+            patch(
+                "os.path.exists",
+                side_effect=_exists,
+            ),
         ):
             calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
@@ -458,6 +564,7 @@ def test_preconditioner_failure_does_not_abort_epoch_gaincal():
 def test_rfi_flagging_falls_back_to_casa_when_aoflagger_unavailable():
     """When AOFlagger is not importable, CASA tfcrop+rflag must be called instead."""
     import tempfile
+
     from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
@@ -467,56 +574,75 @@ def test_rfi_flagging_falls_back_to_casa_when_aoflagger_unavailable():
 
     # Stub out flag_rfi import to raise ImportError, leaving CASA path active
     import sys as _sys
+
     fake_flagging_module = MagicMock()
     fake_flagging_module.flag_rfi = MagicMock(side_effect=ImportError("no aoflagger"))
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_03.ap.G")
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_03.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(44.89, 16.08),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=mock_sky,
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_service,
-        ), patch.dict(
-            _sys.modules,
-            {"dsa110_contimg.core.calibration.flagging": fake_flagging_module},
-        ), patch(
-            "os.path.exists", side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+        ap_table = str(Path(work_dir) / "tile_03.ap.G")
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_03.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(44.89, 16.08),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+                return_value=mock_sky,
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_service,
+            ),
+            patch.dict(
+                _sys.modules,
+                {"dsa110_contimg.core.calibration.flagging": fake_flagging_module},
+            ),
+            patch(
+                "os.path.exists",
+                side_effect=_make_exists_fn(meridian_ms, ap_table=ap_table),
+            ),
         ):
             calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
     flagdata_calls = mock_service.flagdata.call_args_list
-    assert any(c.kwargs.get("autocorr") for c in flagdata_calls), \
+    assert any(c.kwargs.get("autocorr") for c in flagdata_calls), (
         "autocorrelation flagging must be called"
-    assert any(c.kwargs.get("mode") == "tfcrop" for c in flagdata_calls), \
+    )
+    assert any(c.kwargs.get("mode") == "tfcrop" for c in flagdata_calls), (
         "tfcrop must be called as AOFlagger fallback"
-    assert any(c.kwargs.get("mode") == "rflag" for c in flagdata_calls), \
+    )
+    assert any(c.kwargs.get("mode") == "rflag" for c in flagdata_calls), (
         "rflag must be called as AOFlagger fallback"
+    )
 
 
-def test_gaincal_returns_none_when_p_table_heavily_flagged():
-    """calibrate_epoch() must return None when p.G has > 30% flagged solutions.
+def test_gaincal_returns_low_snr_when_p_table_heavily_flagged():
+    """calibrate_epoch() must return LOW_SNR status when p.G has > 30% flagged solutions.
 
     When the phase-only gain table has too many flagged solutions, the sky model
     SNR was insufficient; proceeding to the ap.G solve would corrupt the bandpass
-    calibration rather than improve it.  The function should return None so the
-    batch pipeline applies bandpass-only calibration.
+    calibration rather than improve it.  The function returns g_table=None with
+    status=LOW_SNR so the batch pipeline applies bandpass-only calibration and
+    the manifest records the operational reason (not a code-path fall-back).
     """
     import tempfile
+
     import numpy as np
-    from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
+    from dsa110_continuum.calibration.epoch_gaincal import (
+        EpochGaincalStatus,
+        calibrate_epoch,
+    )
 
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
     mock_sky = MagicMock()
@@ -525,49 +651,65 @@ def test_gaincal_returns_none_when_p_table_heavily_flagged():
 
     # Build a mock casatools.table() that returns a FLAG array that is 35% True.
     flags_35pct = np.zeros((2, 1, 100), dtype=bool)
-    flags_35pct[:, :, :35] = True   # 35 of 100 rows flagged per pol/spw
+    flags_35pct[:, :, :35] = True  # 35 of 100 rows flagged per pol/spw
 
     mock_tb = MagicMock()
     mock_tb.getcol.return_value = flags_35pct
 
     with tempfile.TemporaryDirectory() as work_dir:
-        meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table    = str(Path(work_dir) / "tile_03.ap.G")
-        p_table     = str(Path(work_dir) / "tile_03.p.G")
+        ap_table = str(Path(work_dir) / "tile_03.ap.G")
 
         def _exists(p: str) -> bool:
-            return str(p) not in (ap_table,)   # p.G "exists" after the solve
+            return str(p) not in (ap_table,)  # p.G "exists" after the solve
 
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_03.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(44.89, 16.08),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=mock_sky,
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.25,
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_service,
-        ), patch(
-            "os.path.exists", side_effect=_exists,
+        with (
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+                return_value="/fake/tile_03.ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+                return_value=(44.89, 16.08),
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+                return_value=mock_sky,
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
+            ),
+            patch(
+                "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
+                return_value=0.25,
+            ),
+            patch(
+                "dsa110_continuum.calibration.casa_service.CASAService",
+                return_value=mock_service,
+            ),
+            patch(
+                "os.path.exists",
+                side_effect=_exists,
+            ),
         ):
             import sys as _sys
+
             mock_casatools = MagicMock()
             mock_casatools.table.return_value = mock_tb
             with patch.dict(_sys.modules, {"casatools": mock_casatools}):
                 result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
-    assert result is None, (
-        "calibrate_epoch() must return None when p.G flagged fraction > 30%"
+    assert result.g_table is None, (
+        "calibrate_epoch() must return g_table=None when p.G flagged fraction > 30%"
+    )
+    assert result.status == EpochGaincalStatus.LOW_SNR, (
+        "calibrate_epoch() must mark p.G overflow as LOW_SNR (operational), not EXCEPTION"
+    )
+    assert "30%" in (result.reason or ""), (
+        "result.reason must include the threshold so the manifest gate can quote it"
     )

--- a/tests/test_epoch_gaincal_result.py
+++ b/tests/test_epoch_gaincal_result.py
@@ -1,0 +1,78 @@
+"""Tests for the structured EpochGaincalResult / EpochGaincalStatus contract.
+
+Verifies the spec-compliance mapping between the structured status enum
+returned by ``calibrate_epoch`` and the spec's epoch_gaincal_state enum
+consumed by the promotion module.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dsa110_continuum.calibration.epoch_gaincal import (
+    EpochGaincalResult,
+    EpochGaincalStatus,
+)
+
+
+def test_status_enum_values_match_spec_taxonomy():
+    """The four status values cover the cases the spec cares about."""
+    assert EpochGaincalStatus.SOLVED.value == "solved"
+    assert EpochGaincalStatus.LOW_SNR.value == "low_snr"
+    assert EpochGaincalStatus.SOLVER_NO_TABLE.value == "solver_no_table"
+    assert EpochGaincalStatus.EXCEPTION.value == "exception"
+
+
+def test_result_dataclass_solved_carries_table_path():
+    r = EpochGaincalResult("/path/to/ap.G", EpochGaincalStatus.SOLVED, None)
+    assert r.g_table == "/path/to/ap.G"
+    assert r.status == EpochGaincalStatus.SOLVED
+    assert r.reason is None
+
+
+def test_result_dataclass_low_snr_carries_no_table_and_reason():
+    r = EpochGaincalResult(
+        None,
+        EpochGaincalStatus.LOW_SNR,
+        "p.G flagged 44.4% of solutions (limit 30%) — SNR too low for reliable gain cal",
+    )
+    assert r.g_table is None
+    assert r.status == EpochGaincalStatus.LOW_SNR
+    assert "44.4%" in r.reason
+    assert "limit 30%" in r.reason
+
+
+def test_result_is_frozen():
+    """Dataclass should be immutable so callers can't mutate manifest state."""
+    r = EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, "test")
+    with pytest.raises(Exception):  # FrozenInstanceError or similar
+        r.status = EpochGaincalStatus.SOLVED  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "status, expected_legacy",
+    [
+        (EpochGaincalStatus.SOLVED, "ok"),
+        (EpochGaincalStatus.LOW_SNR, "low_snr"),
+        (EpochGaincalStatus.SOLVER_NO_TABLE, "low_snr"),
+        (EpochGaincalStatus.EXCEPTION, "fallback"),
+    ],
+)
+def test_status_to_legacy_string_mapping_documented_in_batch_pipeline(status, expected_legacy):
+    """Document the status → legacy gaincal_status mapping batch_pipeline.py applies.
+
+    This test pins the expected mapping. The actual mapping lives in
+    scripts/batch_pipeline.py around the calibrate_epoch invocation and is
+    consumed by dsa110_continuum.qa.promotion.derive_epoch_gaincal_state.
+    Failure here means the mapping has drifted — update batch_pipeline.py
+    or the spec, not this test.
+    """
+    # SOLVED → "ok"
+    # LOW_SNR / SOLVER_NO_TABLE → "low_snr" (operational SNR floor)
+    # EXCEPTION → "fallback" (legacy code-path fall-back)
+    mapping = {
+        EpochGaincalStatus.SOLVED: "ok",
+        EpochGaincalStatus.LOW_SNR: "low_snr",
+        EpochGaincalStatus.SOLVER_NO_TABLE: "low_snr",
+        EpochGaincalStatus.EXCEPTION: "fallback",
+    }
+    assert mapping[status] == expected_legacy

--- a/tests/test_promotion_record.py
+++ b/tests/test_promotion_record.py
@@ -1,0 +1,247 @@
+"""Tests for dsa110_continuum.qa.promotion."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from dsa110_continuum.qa.promotion import (
+    DAILY_CAL_TIERS,
+    EPOCH_GAINCAL_STATES,
+    PROMOTION_CLASSES,
+    build_promotion_record,
+    derive_daily_cal_tier,
+    derive_epoch_gaincal_state,
+    derive_promotion_class,
+    emit_for_run,
+    sidecar_path,
+    write_promotion_sidecar,
+)
+
+# ── derivation helpers ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "cal_selection, expected",
+    [
+        ({"source": "generated"}, "A"),
+        ({"source": "existing"}, "A"),
+        ({"source": "borrowed"}, "C"),
+        ({"source": "unknown_value"}, "unknown"),
+        ({}, "unknown"),
+        (None, "unknown"),
+    ],
+)
+def test_derive_daily_cal_tier(cal_selection, expected):
+    assert derive_daily_cal_tier(cal_selection) == expected
+    assert derive_daily_cal_tier(cal_selection) in DAILY_CAL_TIERS
+
+
+@pytest.mark.parametrize(
+    "legacy_status, skip_intentionally, expected",
+    [
+        ("ok", False, "solved"),
+        ("low_snr", False, "skipped_or_failed_low_snr"),
+        ("fallback", False, "fell_back_to_static_with_reason"),
+        ("error", False, "fell_back_to_static_with_reason"),
+        ("skipped", True, "skipped_intentionally"),
+        ("skipped", False, "skipped_or_failed_low_snr"),
+        ("", False, "unknown"),
+        (None, False, "unknown"),
+    ],
+)
+def test_derive_epoch_gaincal_state(legacy_status, skip_intentionally, expected):
+    state = derive_epoch_gaincal_state(legacy_status, skip_intentionally=skip_intentionally)
+    assert state == expected
+    assert state in EPOCH_GAINCAL_STATES
+
+
+def test_derive_promotion_class_no_anchor_returns_pending_review():
+    assert derive_promotion_class("A", "solved", anchor=None) == "auto_emitted_pending_review"
+    assert derive_promotion_class("A", "solved", anchor={}) == "auto_emitted_pending_review"
+    assert (
+        derive_promotion_class(
+            "A",
+            "solved",
+            anchor={
+                "primary_model": None,
+                "catalog_xmatch": None,
+                "tile_self_consistency": None,
+            },
+        )
+        == "auto_emitted_pending_review"
+    )
+
+
+def test_derive_promotion_class_trusted_when_tier_a_solved_and_anchor_filled():
+    anchor = {"catalog_xmatch": {"catalog": "nvss", "n": 27, "median_ratio": 0.95}}
+    assert derive_promotion_class("A", "solved", anchor=anchor) == "trusted_baseline"
+
+
+def test_derive_promotion_class_comparator_when_tier_or_gaincal_off():
+    anchor = {"primary_model": "3C286"}
+    assert derive_promotion_class("C", "solved", anchor=anchor) == "comparator_only"
+    assert (
+        derive_promotion_class("A", "fell_back_to_static_with_reason", anchor=anchor)
+        == "comparator_only"
+    )
+
+
+# ── synthetic manifest for build/write/emit tests ────────────────────────────
+
+
+@dataclass
+class _FakeManifest:
+    """Minimal shape the promotion module reads from RunManifest."""
+
+    date: str = "2026-01-25"
+    git_sha: str = "abc1234"
+    bp_table: str = "/stage/dsa110-contimg/ms/2026-01-25T22:26:05_0~23.b"
+    g_table: str = "/stage/dsa110-contimg/ms/2026-01-25T22:26:05_0~23.g"
+    cal_selection: dict[str, Any] = field(default_factory=lambda: {"source": "existing"})
+    gaincal_status: str = "ok"
+    pipeline_verdict: str = "CLEAN"
+    command_line: list[str] = field(
+        default_factory=lambda: [
+            "/opt/miniforge/envs/casa6/bin/python",
+            "scripts/batch_pipeline.py",
+            "--date",
+            "2026-01-25",
+            "--start-hour",
+            "2",
+            "--end-hour",
+            "3",
+        ]
+    )
+    run_log: str = "/data/dsa110-proc/products/mosaics/2026-01-25/run_2026-04-30T00.log"
+    epochs: list[dict[str, Any]] = field(
+        default_factory=lambda: [
+            {
+                "hour": 2,
+                "n_tiles": 11,
+                "status": "ok",
+                "qa_result": "PASS",
+                "mosaic_path": "/stage/dsa110-contimg/images/mosaic_2026-01-25/2026-01-25T0200_mosaic.fits",
+            },
+        ]
+    )
+    gates: list[dict[str, Any]] = field(default_factory=list)
+
+
+def test_build_promotion_record_tier_a_solved_clean(tmp_path):
+    m = _FakeManifest()
+    rec = build_promotion_record(m, hour=2, products_dir=str(tmp_path))
+    assert rec["date"] == "2026-01-25"
+    assert rec["hour"] == 2
+    assert rec["daily_cal_tier"] == "A"
+    assert rec["epoch_gaincal_state"] == "solved"
+    assert rec["eligible_for_trusted_baseline"] is True
+    assert rec["eligible_for_trusted_baseline_reason"] is None
+    assert rec["promotion_class"] == "auto_emitted_pending_review"
+    assert rec["mosaic_path"].endswith("2026-01-25T0200_mosaic.fits")
+    assert rec["batch_pipeline_invocation"][:2] == m.command_line[:2]
+    assert rec["cal_provenance"]["bp"] == m.bp_table
+    assert rec["cal_provenance"]["g"] == m.g_table
+
+
+def test_build_promotion_record_marks_ineligible_when_gaincal_fallback(tmp_path):
+    m = _FakeManifest()
+    m.gaincal_status = "fallback"
+    m.gates = [{"gate": "gaincal", "verdict": "FALLBACK", "reason": "phase_dir bug"}]
+    m.pipeline_verdict = "DEGRADED"
+    rec = build_promotion_record(m, hour=2, products_dir=str(tmp_path))
+    assert rec["epoch_gaincal_state"] == "fell_back_to_static_with_reason"
+    assert rec["eligible_for_trusted_baseline"] is False
+    assert "epoch_gaincal_state" in (rec["eligible_for_trusted_baseline_reason"] or "")
+    assert rec["epoch_gaincal_reason"] == "phase_dir bug"
+
+
+def test_build_promotion_record_marks_ineligible_when_tier_borrowed(tmp_path):
+    m = _FakeManifest()
+    m.cal_selection = {"source": "borrowed", "borrowed_from": "2026-01-25"}
+    rec = build_promotion_record(m, hour=2, products_dir=str(tmp_path))
+    assert rec["daily_cal_tier"] == "C"
+    assert rec["eligible_for_trusted_baseline"] is False
+    assert rec["cal_provenance"]["borrowed_from"] == "2026-01-25"
+
+
+def test_write_promotion_sidecar_creates_valid_json(tmp_path):
+    m = _FakeManifest()
+    products_dir = tmp_path / "products" / "mosaics" / "2026-01-25"
+    products_dir.mkdir(parents=True)
+    out = write_promotion_sidecar(m, hour=2, products_dir=str(products_dir))
+    assert os.path.exists(out)
+    with open(out) as f:
+        rec = json.load(f)
+    assert rec["date"] == "2026-01-25"
+    assert rec["hour"] == 2
+    assert rec["promotion_class"] in PROMOTION_CLASSES
+    assert rec["daily_cal_tier"] in DAILY_CAL_TIERS
+    assert rec["epoch_gaincal_state"] in EPOCH_GAINCAL_STATES
+    assert out == sidecar_path(str(products_dir), m.date, 2)
+
+
+def test_emit_for_run_writes_sidecar_and_appends_ledger(tmp_path):
+    m = _FakeManifest()
+    products_root = tmp_path / "products"
+    products_dir = products_root / "mosaics" / "2026-01-25"
+    products_dir.mkdir(parents=True)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    written = emit_for_run(
+        m,
+        str(products_dir),
+        str(repo_root),
+        cli_invocation=m.command_line,
+        skip_epoch_gaincal=False,
+        products_root=str(products_root),
+    )
+    assert len(written) == 1
+    assert os.path.exists(written[0])
+    ledger_path = repo_root / "docs" / "validation" / "promotion-log.md"
+    assert ledger_path.exists()
+    text = ledger_path.read_text()
+    assert "2026-01-25" in text
+    assert "abc1234" in text
+    assert "auto_emitted_pending_review" in text
+
+
+def test_emit_for_run_is_idempotent_for_same_sha(tmp_path):
+    m = _FakeManifest()
+    products_root = tmp_path / "products"
+    products_dir = products_root / "mosaics" / "2026-01-25"
+    products_dir.mkdir(parents=True)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    emit_for_run(
+        m,
+        str(products_dir),
+        str(repo_root),
+        cli_invocation=m.command_line,
+        products_root=str(products_root),
+    )
+    emit_for_run(
+        m,
+        str(products_dir),
+        str(repo_root),
+        cli_invocation=m.command_line,
+        products_root=str(products_root),
+    )
+    ledger_path = repo_root / "docs" / "validation" / "promotion-log.md"
+    rows = [ln for ln in ledger_path.read_text().splitlines() if ln.startswith("| 2026-01-25 |")]
+    assert len(rows) == 1
+
+
+def test_emit_for_run_no_epochs_writes_nothing(tmp_path):
+    m = _FakeManifest()
+    m.epochs = []
+    products_dir = tmp_path / "products"
+    products_dir.mkdir(parents=True)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    written = emit_for_run(m, str(products_dir), str(repo_root))
+    assert written == []
+    assert not (repo_root / "docs" / "validation" / "promotion-log.md").exists()


### PR DESCRIPTION
## Summary

- Change `calibrate_epoch()` to return `EpochGaincalResult(g_table, status, reason)` so low-SNR operational fallback is distinct from exception/code-path fallback.
- Add `dsa110_continuum.qa.promotion` to emit per-epoch promotion sidecars and an idempotent promotion ledger row from `RunManifest` state.
- Wire `scripts/batch_pipeline.py` to consume structured gaincal results, record the more specific gaincal gate verdict, and attempt non-fatal promotion emission after manifest/report writing.

Closes #26.

## Test Plan

- `PYTHONPATH=/workspace python3 -m pytest tests/test_epoch_gaincal.py tests/test_epoch_gaincal_field_shape.py tests/test_epoch_gaincal_result.py tests/test_promotion_record.py -q`
- `PYTHONPATH=/workspace python3 -m pytest tests/test_batch_pipeline_dry_run_quarantine.py tests/test_provenance.py tests/test_run_report.py -q`
- `PYTHONPATH=/workspace python3 -m pytest tests/test_epoch_gaincal.py tests/test_epoch_gaincal_field_shape.py tests/test_epoch_gaincal_result.py tests/test_promotion_record.py tests/test_batch_pipeline_dry_run_quarantine.py tests/test_provenance.py tests/test_run_report.py -q`
- `ruff check dsa110_continuum/calibration/epoch_gaincal.py dsa110_continuum/qa/promotion.py scripts/batch_pipeline.py tests/test_epoch_gaincal.py tests/test_epoch_gaincal_result.py tests/test_promotion_record.py`
- `ruff format --check dsa110_continuum/calibration/epoch_gaincal.py dsa110_continuum/qa/promotion.py scripts/batch_pipeline.py tests/test_epoch_gaincal.py tests/test_epoch_gaincal_result.py tests/test_promotion_record.py`
