### PR TITLE
compat: centralize gpu_safety/memory_safety stubs with tuple-return parity

### DIFF
--- a/dsa110_continuum/_compat.py
+++ b/dsa110_continuum/_compat.py
@@ -145,6 +145,46 @@ def initialize_gpu_safety() -> None:
     """No-op stub."""
 
 
+def is_gpu_available() -> bool:
+    """Return False when ``dsa110_contimg`` / a CUDA runtime is unavailable.
+
+    Mirrors ``dsa110_contimg.common.utils.gpu_safety.is_gpu_available``.
+    """
+    return False
+
+
+def check_gpu_memory_available(
+    required_gb: float,
+    gpu_id: int = 0,
+    config: Any = None,
+) -> tuple[bool, str]:
+    """Stub for ``dsa110_contimg.common.utils.gpu_safety.check_gpu_memory_available``.
+
+    The real helper returns ``(ok, reason)`` so callers can both gate on the
+    bool *and* surface the reason in logs / manifests. This stub preserves the
+    tuple shape so call sites that do ``ok, reason = check_gpu_memory_available(2.0)``
+    keep working when ``dsa110_contimg`` is absent.
+
+    Always reports the GPU as unavailable here — the cloud/CI environment that
+    falls back to this shim has no GPU runtime to poll.
+    """
+    del required_gb, gpu_id, config
+    return False, "dsa110_contimg gpu_safety unavailable; running in cloud/CI fallback"
+
+
+def check_system_memory_available(
+    required_gb: float,
+    config: Any = None,
+) -> tuple[bool, str]:
+    """Stub for ``dsa110_contimg`` ``check_system_memory_available``.
+
+    Same tuple-return contract as ``check_gpu_memory_available`` — call sites
+    treat both the same way (gate + reason).
+    """
+    del required_gb, config
+    return False, "dsa110_contimg memory_safety unavailable; running in cloud/CI fallback"
+
+
 # ── Path/env utilities ────────────────────────────────────────────────────────
 
 

--- a/dsa110_continuum/calibration/applycal.py
+++ b/dsa110_continuum/calibration/applycal.py
@@ -36,16 +36,12 @@ try:
     from dsa110_contimg.common.utils.ms_permissions import ensure_ms_writable
 except ImportError:
     from dsa110_continuum._compat import (
-        timed,
+        check_gpu_memory_available,
         gpu_safe,
+        is_gpu_available,
         memory_safe,
+        timed,
     )
-
-    def check_gpu_memory_available(*_a: object, **_kw: object) -> bool:
-        return False
-
-    def is_gpu_available() -> bool:
-        return False
 
     def ensure_ms_writable(path: object) -> None:  # type: ignore[misc]
         pass

--- a/dsa110_continuum/imaging/worker.py
+++ b/dsa110_continuum/imaging/worker.py
@@ -45,7 +45,14 @@ try:
         memory_safe,
     )
 except ImportError:
-    pass  # dsa110_contimg not installed (cloud/test env)
+    # Fall back to centralized stubs that match the contimg signatures so
+    # ``gpu_ok, reason = check_gpu_memory_available(...)`` keeps unpacking.
+    from dsa110_continuum._compat import (
+        check_gpu_memory_available,
+        gpu_safe,
+        is_gpu_available,
+        memory_safe,
+    )
 from dsa110_continuum.conversion.ms_utils import (
     inject_provenance_metadata,
 )

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,131 @@
+"""Tests pinning dsa110_continuum._compat shim signatures.
+
+These shims stand in for ``dsa110_contimg.common.utils.gpu_safety`` etc. when
+the legacy package is not installed (cloud/CI). The shims must match the
+real contimg contracts where call sites unpack or compose return values, or
+they cause TypeErrors that the legacy module's actual presence would mask.
+
+Reference signatures (from dsa110_contimg.common.utils.gpu_safety on H17):
+
+    check_gpu_memory_available(required_gb: float, gpu_id: int = 0,
+                               config: SafetyConfig | None = None)
+        -> tuple[bool, str]
+    is_gpu_available() -> bool
+    gpu_safe(max_gpu_gb=None, max_system_gb=None, required_gpu_gb=None,
+             gpu_id=0, timeout_seconds=None) -> Callable[[F], F]
+    memory_safe(max_system_gb=None, required_gb=None,
+                timeout_seconds=None) -> Callable[[F], F]
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from dsa110_continuum import _compat
+
+
+class TestGpuSafetyContract:
+    def test_check_gpu_memory_available_returns_tuple_bool_str(self):
+        result = _compat.check_gpu_memory_available(2.0)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        ok, reason = result
+        assert isinstance(ok, bool)
+        assert isinstance(reason, str)
+        # When dsa110_contimg is unavailable the shim must report not-OK
+        # so callers gate GPU paths off.
+        assert ok is False
+
+    def test_check_gpu_memory_available_accepts_real_contimg_kwargs(self):
+        # The contimg signature is (required_gb, gpu_id=0, config=None);
+        # the shim must accept all three call shapes without TypeError.
+        ok, _ = _compat.check_gpu_memory_available(2.0)
+        ok, _ = _compat.check_gpu_memory_available(2.0, 0)
+        ok, _ = _compat.check_gpu_memory_available(2.0, gpu_id=0, config=None)
+        assert ok is False
+
+    def test_check_gpu_memory_available_unpacks_at_call_sites(self):
+        # Callers in applycal.py and imaging/worker.py do
+        # ``gpu_ok, gpu_reason = check_gpu_memory_available(2.0)``.
+        # If the shim returns a scalar, this raises TypeError.
+        gpu_ok, gpu_reason = _compat.check_gpu_memory_available(2.0)
+        assert gpu_ok is False
+        assert gpu_reason  # non-empty diagnostic string
+
+    def test_is_gpu_available_returns_bool(self):
+        assert _compat.is_gpu_available() is False
+
+    def test_check_system_memory_available_matches_contimg_shape(self):
+        # When the contimg helper exists it returns ``tuple[bool, str]``.
+        # The shim must too — same unpack contract.
+        ok, reason = _compat.check_system_memory_available(2.0)
+        assert ok is False
+        assert isinstance(reason, str)
+
+
+class TestDecoratorStubs:
+    def test_memory_safe_accepts_contimg_kwargs(self):
+        @_compat.memory_safe(max_system_gb=4.0, required_gb=1.0, timeout_seconds=60)
+        def f(x):
+            return x + 1
+
+        assert f(2) == 3
+
+    def test_gpu_safe_accepts_contimg_kwargs(self):
+        @_compat.gpu_safe(
+            max_gpu_gb=2.0,
+            max_system_gb=4.0,
+            required_gpu_gb=1.0,
+            gpu_id=0,
+            timeout_seconds=60,
+        )
+        def f(x):
+            return x * 2
+
+        assert f(3) == 6
+
+    def test_gpu_safe_works_as_plain_decorator(self):
+        @_compat.gpu_safe
+        def f(x):
+            return x
+
+        assert f(5) == 5
+
+    def test_timed_works_with_and_without_label(self):
+        @_compat.timed
+        def a(x):
+            return x
+
+        @_compat.timed("label")
+        def b(x):
+            return x + 1
+
+        assert a(1) == 1
+        assert b(1) == 2
+
+
+class TestAntennaStubs:
+    def test_get_outrigger_and_core_partition_correctly(self):
+        outriggers = _compat.get_outrigger_antenna_ids()
+        cores = _compat.get_core_antenna_ids()
+        assert set(outriggers).isdisjoint(set(cores))
+        # The DSA-110 instrument has 117 array elements (per CLAUDE.md);
+        # the union of stubs should match that or a subset, never overlap.
+        assert len(set(outriggers) | set(cores)) == len(outriggers) + len(cores)
+
+
+class TestSignatureParityWithCallers:
+    """Pins shim signatures so a future _compat refactor cannot regress them.
+
+    These tests are static: they introspect the shim signatures rather than
+    calling them, so they fail loudly if a refactor renames a parameter or
+    drops one that real call sites pass.
+    """
+
+    def test_check_gpu_memory_available_signature(self):
+        sig = inspect.signature(_compat.check_gpu_memory_available)
+        params = list(sig.parameters)
+        # First positional parameter is the required-memory amount.
+        assert params[0] in {"required_gb", "required_bytes"}
+        # Must accept gpu_id (used by contimg call sites).
+        assert any(p in sig.parameters for p in ("gpu_id",))


### PR DESCRIPTION
## Summary

- Adds `is_gpu_available`, `check_gpu_memory_available`, and `check_system_memory_available` to `dsa110_continuum/_compat.py` with the **tuple[bool, str]** return shape that matches the real `dsa110_contimg.common.utils.gpu_safety` / `memory_safety` helpers
- Replaces broken local fallbacks in `calibration/applycal.py` (returned scalar `bool`, would crash at unpack) and `imaging/worker.py` (no fallback at all — `NameError` when `dsa110_contimg` absent)
- Pins shim contracts with 11 unit tests in `tests/test_compat.py`

## Why

Two call sites do `gpu_ok, gpu_reason = check_gpu_memory_available(2.0)`. The contimg helper returns `tuple[bool, str]`. The local fallback in `applycal.py` returned plain `bool` — any cloud/CI run hitting the GPU gate path crashed with `TypeError: cannot unpack non-iterable bool object`. The fallback in `worker.py` was just `pass` — `NameError` on the same call.

This is the *first* of a planned multi-PR migration toward removing the runtime dependency on `dsa110_contimg`. Subsequent PRs will migrate per-subpackage import sites; this one only ratchets `_compat.py` correctness so the rest can build on a known-good base.

## Test plan

- [x] `pytest tests/test_compat.py` — 11/11 pass
- [x] `pytest tests/test_compat.py tests/test_calibration_flag_fraction.py` — 16/16 pass together
- [x] `import dsa110_continuum.calibration.applycal` — clean
- [x] `import dsa110_continuum.imaging.worker` — clean
- [x] `ruff check` clean for new code

## Reference signatures captured

From `/opt/miniforge/envs/casa6/bin/python -c "from dsa110_contimg.common.utils.gpu_safety import …"`:

```
check_gpu_memory_available(required_gb: float, gpu_id: int = 0,
                           config: SafetyConfig | None = None)
    -> tuple[bool, str]
is_gpu_available() -> bool
gpu_safe(max_gpu_gb=None, max_system_gb=None, required_gpu_gb=None,
         gpu_id=0, timeout_seconds=None) -> Callable[[F], F]
memory_safe(max_system_gb=None, required_gb=None,
            timeout_seconds=None) -> Callable[[F], F]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)