### PR TITLE
Fix pytest tempdir cleanup race

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,11 +154,12 @@ dsa110-validate = "dsa110_contimg.validation.package_health:main"
 where = ["."]
 
 [tool.pytest.ini_options]
-# Keep pytest tmp_path output on the /data filesystem (not /tmp which is on a
-# small disk).  Placing it inside the workspace also avoids ownership conflicts
-# with the stale /data/dsa110-contimg/tmp/pytest-of-* directory left by earlier
-# pipeline runs under a different user.
-addopts = "--basetemp=/data/dsa110-continuum/.pytest_tmp"
+# pytest temp dirs are re-rooted under <rootdir>/.pytest_tmp/uid-<uid> by
+# tests/conftest.py (PYTEST_DEBUG_TEMPROOT), keeping large tmp_path output on
+# the checkout's filesystem (not tiny /tmp on H17) while avoiding stale
+# root-owned pytest temp dirs and staying per-checkout. Do NOT pin an absolute
+# --basetemp here: a shared path breaks checkouts/worktrees and races on cleanup
+# (issue #47).
 testpaths = ["tests"]
 norecursedirs = [".git", ".hypothesis", ".venv", "venv", "__pycache__", ".pytest_cache", ".mypy_cache", "node_modules", ".idea", ".vscode", "dist", "build", ".tox", ".eggs", "*.egg", ".archive", ".stale", "manual"]
 python_files = ["test_*.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,12 +154,12 @@ dsa110-validate = "dsa110_contimg.validation.package_health:main"
 where = ["."]
 
 [tool.pytest.ini_options]
-# pytest temp dirs are re-rooted under <rootdir>/.pytest_tmp/uid-<uid> by
-# tests/conftest.py (PYTEST_DEBUG_TEMPROOT), keeping large tmp_path output on
-# the checkout's filesystem (not tiny /tmp on H17) while avoiding stale
-# root-owned pytest temp dirs and staying per-checkout. Do NOT pin an absolute
-# --basetemp here: a shared path breaks checkouts/worktrees and races on cleanup
-# (issue #47).
+# pytest temp dirs are re-rooted under
+# <rootdir>/.pytest_tmp/uid-<uid>/run-<pid> by tests/conftest.py, keeping large
+# tmp_path output on the checkout's filesystem (not tiny /tmp on H17) while
+# avoiding stale root-owned pytest temp dirs and staying per-run/per-checkout.
+# Do NOT pin an absolute --basetemp here: a shared path breaks
+# checkouts/worktrees and races on cleanup (issue #47).
 testpaths = ["tests"]
 norecursedirs = [".git", ".hypothesis", ".venv", "venv", "__pycache__", ".pytest_cache", ".mypy_cache", "node_modules", ".idea", ".vscode", "dist", "build", ".tox", ".eggs", "*.egg", ".archive", ".stale", "manual"]
 python_files = ["test_*.py"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,15 @@ def pytest_configure(config: pytest.Config) -> None:
         ):
             tmp_path_factory._given_basetemp = basetemp
 
+    if (
+        "CASA_LOG_DIR" not in os.environ
+        and "CONTIMG_PATHS__CASA_LOGS_DIR" not in os.environ
+        and "CONTIMG_BASE_DIR" not in os.environ
+    ):
+        casa_log_dir = Path(config.option.basetemp, "casa-logs")
+        os.environ["CASA_LOG_DIR"] = str(casa_log_dir)
+        os.environ["DSA110_TEST_DEFAULT_CASA_LOG_DIR"] = "1"
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register ``--run-slow`` to opt into ``@pytest.mark.slow`` tests."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,37 @@ so the default ``pytest tests/`` run finishes in seconds, not minutes.
 """
 from __future__ import annotations
 
+import os
 import sys
 import types
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Re-root pytest's temp tree under the current checkout (issue #47).
+
+    A hard-coded ``--basetemp=/data/dsa110-continuum/.pytest_tmp`` broke any
+    checkout not at that path and made runs from multiple checkouts share one
+    directory, so pytest's start-of-session wipe raced live runs
+    (``OSError [Errno 39] Directory not empty``) and contaminated consecutive
+    full-suite runs.
+
+    Instead, point ``PYTEST_DEBUG_TEMPROOT`` at
+    ``<rootdir>/.pytest_tmp/uid-<uid>`` so tmp_path lands on the checkout's
+    filesystem (not tiny /tmp on H17) while avoiding stale root-owned
+    ``pytest-of-<user>`` directories from previous runs.  Each run still gets
+    its own numbered ``pytest-N`` dir with pytest's built-in lock-guarded,
+    retention-based cleanup.  Explicit ``--basetemp`` or a pre-set
+    ``PYTEST_DEBUG_TEMPROOT`` still win.
+    """
+    if config.option.basetemp is None and "PYTEST_DEBUG_TEMPROOT" not in os.environ:
+        uid = getattr(os, "getuid", lambda: "unknown")()
+        temproot = Path(config.rootpath, ".pytest_tmp", f"uid-{uid}")
+        temproot.mkdir(parents=True, exist_ok=True)
+        os.environ["PYTEST_DEBUG_TEMPROOT"] = str(temproot)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,19 +28,26 @@ def pytest_configure(config: pytest.Config) -> None:
     (``OSError [Errno 39] Directory not empty``) and contaminated consecutive
     full-suite runs.
 
-    Instead, point ``PYTEST_DEBUG_TEMPROOT`` at
-    ``<rootdir>/.pytest_tmp/uid-<uid>`` so tmp_path lands on the checkout's
-    filesystem (not tiny /tmp on H17) while avoiding stale root-owned
-    ``pytest-of-<user>`` directories from previous runs.  Each run still gets
-    its own numbered ``pytest-N`` dir with pytest's built-in lock-guarded,
-    retention-based cleanup.  Explicit ``--basetemp`` or a pre-set
-    ``PYTEST_DEBUG_TEMPROOT`` still win.
+    Instead, set pytest's explicit ``basetemp`` to a per-process path under
+    ``<rootdir>/.pytest_tmp/uid-<uid>``.  This keeps tmp_path output on the
+    checkout's filesystem (not tiny /tmp on H17), avoids the shared
+    ``pytest-of-<user>`` owner check that fails on H17's root-owned /data
+    mount, and prevents consecutive/concurrent runs from wiping each other's
+    temp trees.  An explicit user-provided ``--basetemp`` still wins.
     """
-    if config.option.basetemp is None and "PYTEST_DEBUG_TEMPROOT" not in os.environ:
+    if config.option.basetemp is None:
         uid = getattr(os, "getuid", lambda: "unknown")()
-        temproot = Path(config.rootpath, ".pytest_tmp", f"uid-{uid}")
-        temproot.mkdir(parents=True, exist_ok=True)
-        os.environ["PYTEST_DEBUG_TEMPROOT"] = str(temproot)
+        basetemp = Path(config.rootpath, ".pytest_tmp", f"uid-{uid}", f"run-{os.getpid()}")
+        basetemp.parent.mkdir(parents=True, exist_ok=True)
+        config.option.basetemp = str(basetemp)
+
+        tmp_path_factory = getattr(config, "_tmp_path_factory", None)
+        if (
+            tmp_path_factory is not None
+            and tmp_path_factory._given_basetemp is None
+            and tmp_path_factory._basetemp is None
+        ):
+            tmp_path_factory._given_basetemp = basetemp
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test_pytest_basetemp.py
+++ b/tests/test_pytest_basetemp.py
@@ -6,10 +6,10 @@ not at that exact path (FileNotFoundError on tmp_path setup) and makes
 concurrent/consecutive runs from multiple checkouts race on the same
 directory (OSError [Errno 39] Directory not empty during cleanup).
 
-Instead, ``tests/conftest.py`` re-roots pytest's temp tree under the current
-checkout (``<rootdir>/.pytest_tmp/uid-<uid>``) via
-``PYTEST_DEBUG_TEMPROOT``, so each run gets its own numbered ``pytest-N``
-directory with pytest's built-in retention-based cleanup.
+Instead, ``tests/conftest.py`` sets pytest's explicit basetemp under the
+current checkout (``<rootdir>/.pytest_tmp/uid-<uid>/run-<pid>``), avoiding
+pytest's shared ``pytest-of-<user>`` owner check and giving each run an
+isolated cleanup target.
 """
 
 from __future__ import annotations
@@ -33,19 +33,15 @@ def test_ini_addopts_do_not_pin_basetemp(pytestconfig: pytest.Config) -> None:
 def test_default_basetemp_is_rooted_in_current_checkout_uid_namespace(
     pytestconfig: pytest.Config, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
-    """Without overrides, temp dirs land under <rootdir>/.pytest_tmp/uid-<uid>."""
-    if pytestconfig.getoption("basetemp"):
-        pytest.skip("explicit --basetemp override in effect")
-
+    """Without overrides, temp dirs land under <rootdir>/.pytest_tmp/uid-<uid>/run-*."""
     uid = getattr(os, "getuid", lambda: "unknown")()
-    expected_root = Path(pytestconfig.rootpath, ".pytest_tmp", f"uid-{uid}").resolve()
-    temproot = os.environ.get("PYTEST_DEBUG_TEMPROOT")
-    assert temproot is not None, "tests/conftest.py did not set PYTEST_DEBUG_TEMPROOT"
-    if Path(temproot).resolve() != expected_root:
-        pytest.skip("external PYTEST_DEBUG_TEMPROOT override in effect")
+    expected_parent = Path(pytestconfig.rootpath, ".pytest_tmp", f"uid-{uid}").resolve()
 
     basetemp = tmp_path_factory.getbasetemp().resolve()
-    assert basetemp.is_relative_to(expected_root)
-    # Each run must get its own numbered dir, never the shared root itself,
+    configured = Path(pytestconfig.getoption("basetemp")).resolve()
+    assert basetemp == configured
+    assert basetemp.parent == expected_parent
+    # Each run must get its own per-process dir, never the shared uid root,
     # so consecutive/concurrent runs cannot collide on cleanup.
-    assert basetemp != expected_root
+    assert basetemp.name.startswith("run-")
+    assert basetemp != expected_parent

--- a/tests/test_pytest_basetemp.py
+++ b/tests/test_pytest_basetemp.py
@@ -1,0 +1,51 @@
+"""Regression tests for issue #47: pytest basetemp hygiene.
+
+The suite must not pin ``--basetemp`` to an absolute host-specific path in
+``pyproject.toml``.  A shared absolute basetemp breaks any checkout that is
+not at that exact path (FileNotFoundError on tmp_path setup) and makes
+concurrent/consecutive runs from multiple checkouts race on the same
+directory (OSError [Errno 39] Directory not empty during cleanup).
+
+Instead, ``tests/conftest.py`` re-roots pytest's temp tree under the current
+checkout (``<rootdir>/.pytest_tmp/uid-<uid>``) via
+``PYTEST_DEBUG_TEMPROOT``, so each run gets its own numbered ``pytest-N``
+directory with pytest's built-in retention-based cleanup.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def test_ini_addopts_do_not_pin_basetemp(pytestconfig: pytest.Config) -> None:
+    """addopts must not hard-code --basetemp (issue #47)."""
+    addopts = pytestconfig.getini("addopts")
+    offending = [opt for opt in addopts if "--basetemp" in opt]
+    assert not offending, (
+        f"pyproject.toml addopts pins basetemp to a host-specific path: {offending}. "
+        "Temp re-rooting is handled per-checkout in tests/conftest.py (issue #47)."
+    )
+
+
+def test_default_basetemp_is_rooted_in_current_checkout_uid_namespace(
+    pytestconfig: pytest.Config, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    """Without overrides, temp dirs land under <rootdir>/.pytest_tmp/uid-<uid>."""
+    if pytestconfig.getoption("basetemp"):
+        pytest.skip("explicit --basetemp override in effect")
+
+    uid = getattr(os, "getuid", lambda: "unknown")()
+    expected_root = Path(pytestconfig.rootpath, ".pytest_tmp", f"uid-{uid}").resolve()
+    temproot = os.environ.get("PYTEST_DEBUG_TEMPROOT")
+    assert temproot is not None, "tests/conftest.py did not set PYTEST_DEBUG_TEMPROOT"
+    if Path(temproot).resolve() != expected_root:
+        pytest.skip("external PYTEST_DEBUG_TEMPROOT override in effect")
+
+    basetemp = tmp_path_factory.getbasetemp().resolve()
+    assert basetemp.is_relative_to(expected_root)
+    # Each run must get its own numbered dir, never the shared root itself,
+    # so consecutive/concurrent runs cannot collide on cleanup.
+    assert basetemp != expected_root

--- a/tests/test_pytest_basetemp.py
+++ b/tests/test_pytest_basetemp.py
@@ -45,3 +45,13 @@ def test_default_basetemp_is_rooted_in_current_checkout_uid_namespace(
     # so consecutive/concurrent runs cannot collide on cleanup.
     assert basetemp.name.startswith("run-")
     assert basetemp != expected_parent
+
+
+def test_default_casa_log_dir_is_test_local(pytestconfig: pytest.Config) -> None:
+    """Tests should not create CASA logs under production /data defaults."""
+    if os.environ.get("DSA110_TEST_DEFAULT_CASA_LOG_DIR") != "1":
+        pytest.skip("external CASA log configuration in effect")
+
+    casa_log_dir = Path(os.environ["CASA_LOG_DIR"]).resolve()
+    basetemp = Path(pytestconfig.getoption("basetemp")).resolve()
+    assert casa_log_dir.is_relative_to(basetemp)


### PR DESCRIPTION
## Summary
- Removes the hard-coded absolute pytest basetemp `/data/dsa110-continuum/.pytest_tmp` from `pyproject.toml`
- Re-roots default pytest temp output under the active checkout with a per-UID, per-process explicit basetemp
- Adds regression tests to prevent host-specific `--basetemp` from returning and to prove temp dirs are isolated per run

## Root cause
`pyproject.toml` pinned `--basetemp=/data/dsa110-continuum/.pytest_tmp`. That broke non-H17 checkouts/worktrees and made consecutive or concurrent runs share one cleanup target. H17 also has root-owned paths under `/data/dsa110-continuum`, so pytest's default `PYTEST_DEBUG_TEMPROOT` owner check rejects shared `pytest-of-ubuntu` directories.

## Validation
Local worktree:
- `PYTHONPATH="$PWD" rtk pytest tests/test_pytest_basetemp.py tests/test_batch_e1_hygiene.py -q` -> `10 passed`
- repeated same command -> `10 passed`
- `rtk ruff check tests/conftest.py tests/test_pytest_basetemp.py` -> no issues
- `mskill tool agent-closeout-check ... --packet /tmp/dsa110-continuum-issue47-closeout.json` -> ok

H17 `/data/dsa110-continuum` with CASA Python:
- `PYTHONPATH=/data/dsa110-continuum /opt/miniforge/envs/casa6/bin/python -m pytest tests/test_pytest_basetemp.py tests/test_batch_e1_hygiene.py -q` -> `10 passed in 13.96s`
- repeated same command -> `10 passed in 14.30s`

## Runtime/restart inventory
No daemon, service, port, or long-lived runtime changed. Fresh pytest processes pick up the config on next invocation.

Fixes #47
Part of #82