### PR TITLE
Thread --force-recal into ensure_bandpass force=True

### DIFF
--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -1010,8 +1010,10 @@ def main() -> None:
         default=False,
         help=(
             "Force full re-calibration and re-imaging of every tile, even when FITS outputs "
-            "already exist. Also clears the epoch_gaincal ap.G cache so the fallback check "
-            "runs fresh. Use when re-running a date after code changes (e.g. BP-only fallback)."
+            "already exist. Also forces BP/G table re-acquisition (ensure_bandpass force=True, "
+            "skipping same-date table reuse) and clears the epoch_gaincal ap.G cache so the "
+            "fallback check runs fresh. Use when re-running a date after code changes "
+            "(e.g. BP-only fallback)."
         ),
     )
     parser.add_argument(
@@ -1156,6 +1158,7 @@ def main() -> None:
             from dsa110_continuum.calibration.ensure import ensure_bandpass
             _auto_cal_result = ensure_bandpass(
                 cal_date, ms_dir=MS_DIR, refant="103", obs_dec_deg=_obs_dec,
+                force=args.force_recal,
             )
             log.info(
                 "Auto-cal: %s tables from %s (calibrator=%s, source=%s)",

--- a/tests/test_force_recal_bandpass.py
+++ b/tests/test_force_recal_bandpass.py
@@ -1,0 +1,60 @@
+"""Regression tests for issue #70: --force-recal must thread force=True
+into ensure_bandpass so same-date BP/G tables are re-acquired, not
+silently reused via the priority-1 same-date branch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ on sys.path so we can import batch_pipeline helpers
+_REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+
+def _run_main_capturing_ensure_bandpass(tmp_path, monkeypatch, argv_extra):
+    import batch_pipeline as bp
+    import dsa110_continuum.calibration.ensure as ensure_mod
+
+    ms_dir = tmp_path / "ms"
+    ms_dir.mkdir()
+    monkeypatch.setattr(bp, "MS_DIR", str(ms_dir))
+
+    captured = {}
+
+    def fake_ensure_bandpass(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        # SystemExit is not swallowed by the auto-cal except Exception
+        # handler, so main() stops here without touching later phases.
+        raise SystemExit(0)
+
+    monkeypatch.setattr(ensure_mod, "ensure_bandpass", fake_ensure_bandpass)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["batch_pipeline.py", "--date", "2026-04-27", *argv_extra],
+    )
+
+    with pytest.raises(SystemExit):
+        bp.main()
+
+    assert captured, "ensure_bandpass was never called"
+    return captured
+
+
+def test_force_recal_passes_force_true_to_ensure_bandpass(tmp_path, monkeypatch):
+    captured = _run_main_capturing_ensure_bandpass(
+        tmp_path,
+        monkeypatch,
+        ["--force-recal"],
+    )
+    assert captured["kwargs"].get("force") is True
+
+
+def test_default_run_does_not_force_bandpass_reacquisition(tmp_path, monkeypatch):
+    captured = _run_main_capturing_ensure_bandpass(tmp_path, monkeypatch, [])
+    assert captured["kwargs"].get("force", False) is False


### PR DESCRIPTION
## Summary

`scripts/batch_pipeline.py` called `ensure_bandpass(...)` without `force`, so `--force-recal` never reached the BP/G acquisition ladder: valid same-date `*_0~23.{b,g}` tables always won on the priority-1 same-date branch and were silently reused. This PR passes `force=args.force_recal` into the call and documents the expanded semantics in the `--force-recal` help text.

- `scripts/batch_pipeline.py`: one-line `force=args.force_recal` in the auto-cal `ensure_bandpass(...)` call; help text now states that `--force-recal` also forces BP/G table re-acquisition.
- `tests/test_force_recal_bandpass.py`: new regression tests driving `main()` with a mocked `ensure_bandpass` — asserts `force is True` with `--force-recal` and falsy without it.

No change to the calibration acquisition policy ladder itself; `ensure_bandpass(force=True)` already implements "skip existing-table reuse, regenerate."

## Test plan

TDD on H17 (casa6 env):

- RED: new test failed before the fix — captured kwargs were `{'ms_dir': ..., 'obs_dec_deg': 16.1, 'refant': '103'}` with no `force` key (`AssertionError: assert None is True`).
- GREEN: `PYTHONPATH=/data/dsa110-continuum /opt/miniforge/envs/casa6/bin/python -m pytest tests/test_force_recal_bandpass.py tests/test_batch_pipeline_dry_run_quarantine.py tests/test_batch_e2_hygiene.py tests/test_resume_semantics.py -q` → **38 passed**.
- `ruff check` / `ruff format --check` clean on the new test file; remaining `batch_pipeline.py` findings are pre-existing (tracked separately, not bulk-fixed per repo policy).

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)