### PR TITLE
Scope calibrator group selection to the requested transit time

### DIFF
--- a/dsa110_continuum/conversion/calibrator_ms_generator.py
+++ b/dsa110_continuum/conversion/calibrator_ms_generator.py
@@ -311,6 +311,8 @@ class CalibratorMSGenerator:
         source_dec_deg: float,
         beam_radius_deg: float = 1.75,
         n_groups: int = 12,
+        transit_time: Time | None = None,
+        max_transit_offset_minutes: float = 360.0,
     ) -> list:
         """Select HDF5 groups where a source is within the primary beam.
 
@@ -329,23 +331,65 @@ class CalibratorMSGenerator:
             DSA-110 primary beam FWHM ≈ 3.5° at 1.4 GHz).
         n_groups : int
             Maximum number of groups to return.  Default 12.
+        transit_time : Time, optional
+            If given, keep only groups within ``max_transit_offset_minutes``
+            of this time.  The same RA transits every sidereal day, so
+            positional matching alone can return groups from a different
+            date than the requested transit.
+        max_transit_offset_minutes : float
+            Time-scoping tolerance around ``transit_time``.  Only needs to
+            separate transits one sidereal day (~1436 min) apart; must stay
+            well above the beam-crossing time (tens of minutes).
 
         Returns
         -------
         list
-            List of group representative timestamps (ISO format).
+            List of group representative timestamps (ISO format), ordered
+            by angular proximity to the source.
+
+        Raises
+        ------
+        ValueError
+            If ``transit_time`` is given and no positionally matched group
+            falls within the tolerance.
         """
         from dsa110_contimg.infrastructure.database.hdf5_index import (
             select_hdf5_groups_by_position,
         )
 
-        return select_hdf5_groups_by_position(
+        groups = select_hdf5_groups_by_position(
             db_path=str(self.db_path),
             source_ra_deg=source_ra_deg,
             source_dec_deg=source_dec_deg,
             beam_radius_deg=beam_radius_deg,
             n_groups=n_groups,
         )
+
+        if transit_time is None:
+            return groups
+
+        max_offset_sec = max_transit_offset_minutes * 60.0
+        scoped = [g for g in groups if abs((Time(str(g)) - transit_time).sec) <= max_offset_sec]
+
+        if not scoped:
+            raise ValueError(
+                f"{len(groups)} HDF5 group(s) match the source position "
+                f"(RA={source_ra_deg:.3f}°, Dec={source_dec_deg:.3f}°) but none "
+                f"fall within {max_transit_offset_minutes:.0f} min of the "
+                f"requested transit {transit_time.iso}. The matched groups are "
+                f"from a different transit date — refusing to select them."
+            )
+
+        if len(scoped) < len(groups):
+            logger.info(
+                "Transit-time scoping kept %d/%d positionally matched groups within %.0f min of %s",
+                len(scoped),
+                len(groups),
+                max_transit_offset_minutes,
+                transit_time.iso,
+            )
+
+        return scoped
 
     def convert_groups(
         self,
@@ -490,7 +534,9 @@ class CalibratorMSGenerator:
                 transit_time_mjd=transit_time.mjd,
             )
 
-            # Select groups by spatial position (preferred for drift-scan)
+            # Select groups by spatial position (preferred for drift-scan),
+            # scoped to the requested transit so same-RA groups from other
+            # dates are never selected.
             n_groups = max(1, window_minutes // 5)
 
             groups = self.select_groups_by_position(
@@ -498,6 +544,7 @@ class CalibratorMSGenerator:
                 source_dec_deg=calibrator.dec_deg,
                 beam_radius_deg=1.75,
                 n_groups=n_groups,
+                transit_time=transit_time,
             )
 
             if not groups:
@@ -665,6 +712,7 @@ class CalibratorMSGenerator:
                 source_dec_deg=calibrator.dec_deg,
                 beam_radius_deg=1.75,
                 n_groups=n_groups,
+                transit_time=transit_time,
             )
 
             if not groups:

--- a/dsa110_continuum/conversion/calibrator_ms_generator.py
+++ b/dsa110_continuum/conversion/calibrator_ms_generator.py
@@ -357,12 +357,17 @@ class CalibratorMSGenerator:
             select_hdf5_groups_by_position,
         )
 
+        # The legacy selector caps to n_groups BEFORE we can time-scope, so
+        # wrong-date candidates could crowd out the requested date. When
+        # time-scoping, fetch effectively uncapped and re-apply n_groups after.
+        uncapped_n_groups = 1_000_000
+
         groups = select_hdf5_groups_by_position(
             db_path=str(self.db_path),
             source_ra_deg=source_ra_deg,
             source_dec_deg=source_dec_deg,
             beam_radius_deg=beam_radius_deg,
-            n_groups=n_groups,
+            n_groups=n_groups if transit_time is None else uncapped_n_groups,
         )
 
         if transit_time is None:
@@ -389,7 +394,7 @@ class CalibratorMSGenerator:
                 transit_time.iso,
             )
 
-        return scoped
+        return scoped[:n_groups]
 
     def convert_groups(
         self,

--- a/tests/test_calibrator_ms_generator.py
+++ b/tests/test_calibrator_ms_generator.py
@@ -58,6 +58,33 @@ class TestSelectGroupsByPosition:
             )
         assert groups == [D2_GROUP, D1_GROUP]
 
+    def test_n_groups_cap_applied_after_time_scoping(self, generator):
+        """A wrong-date closest candidate must not crowd out the requested date.
+
+        The legacy selector caps to n_groups before this wrapper can
+        time-scope, so with n_groups=1 a positionally closer D2 group would
+        be the only candidate returned. The wrapper must fetch uncapped,
+        filter by transit_time, then re-apply the caller's n_groups.
+        """
+        with patch(LEGACY_SELECTOR, return_value=[D2_GROUP, D1_GROUP]) as legacy:
+            groups = generator.select_groups_by_position(
+                source_ra_deg=CAL.ra_deg,
+                source_dec_deg=CAL.dec_deg,
+                n_groups=1,
+                transit_time=TRANSIT_D1,
+            )
+        assert legacy.call_args.kwargs["n_groups"] > 1000
+        assert groups == [D1_GROUP]
+
+    def test_no_transit_time_passes_caller_n_groups(self, generator):
+        with patch(LEGACY_SELECTOR, return_value=[D2_GROUP]) as legacy:
+            generator.select_groups_by_position(
+                source_ra_deg=CAL.ra_deg,
+                source_dec_deg=CAL.dec_deg,
+                n_groups=1,
+            )
+        assert legacy.call_args.kwargs["n_groups"] == 1
+
     def test_raises_when_no_group_near_transit(self, generator):
         with patch(LEGACY_SELECTOR, return_value=[D2_GROUP]):
             with pytest.raises(ValueError, match="transit"):

--- a/tests/test_calibrator_ms_generator.py
+++ b/tests/test_calibrator_ms_generator.py
@@ -1,0 +1,116 @@
+"""Regression tests for transit-time-scoped group selection (issue #72).
+
+In drift scan the same RA transits every sidereal day, so purely positional
+group selection can pick a group from a different date than the requested
+transit. These tests pin that ``generate_from_transit`` honors the requested
+``transit_time`` when the index contains same-position candidates on
+multiple dates.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from astropy.time import Time
+from dsa110_continuum.conversion.calibrator_ms_generator import (
+    CalibratorInfo,
+    CalibratorMSGenerator,
+)
+
+D1_GROUP = "2026-01-25T22:26:05"
+D2_GROUP = "2026-01-26T22:22:09"  # same RA strip, next sidereal day
+TRANSIT_D1 = Time("2026-01-25T22:30:00")
+
+CAL = CalibratorInfo(name="3C454.3", ra_deg=343.49, dec_deg=16.15, flux_jy=12.5)
+
+LEGACY_SELECTOR = "dsa110_contimg.infrastructure.database.hdf5_index.select_hdf5_groups_by_position"
+
+
+@pytest.fixture
+def generator(tmp_path):
+    catalog = tmp_path / "vla_calibrators.sqlite3"
+    catalog.touch()
+    return CalibratorMSGenerator(
+        input_dir=tmp_path,
+        output_dir=tmp_path / "ms",
+        db_path=tmp_path / "pipeline.sqlite3",
+        vla_catalog_path=catalog,
+    )
+
+
+class TestSelectGroupsByPosition:
+    def test_transit_time_filters_other_dates(self, generator):
+        with patch(LEGACY_SELECTOR, return_value=[D2_GROUP, D1_GROUP]):
+            groups = generator.select_groups_by_position(
+                source_ra_deg=CAL.ra_deg,
+                source_dec_deg=CAL.dec_deg,
+                transit_time=TRANSIT_D1,
+            )
+        assert groups == [D1_GROUP]
+
+    def test_no_transit_time_keeps_positional_order(self, generator):
+        with patch(LEGACY_SELECTOR, return_value=[D2_GROUP, D1_GROUP]):
+            groups = generator.select_groups_by_position(
+                source_ra_deg=CAL.ra_deg,
+                source_dec_deg=CAL.dec_deg,
+            )
+        assert groups == [D2_GROUP, D1_GROUP]
+
+    def test_raises_when_no_group_near_transit(self, generator):
+        with patch(LEGACY_SELECTOR, return_value=[D2_GROUP]):
+            with pytest.raises(ValueError, match="transit"):
+                generator.select_groups_by_position(
+                    source_ra_deg=CAL.ra_deg,
+                    source_dec_deg=CAL.dec_deg,
+                    transit_time=TRANSIT_D1,
+                )
+
+
+class TestGenerateFromTransit:
+    def test_selects_group_from_requested_date(self, generator):
+        """D2 is positionally closer (listed first) but D1 holds the transit."""
+        with (
+            patch.object(generator, "get_calibrator", return_value=CAL),
+            patch(LEGACY_SELECTOR, return_value=[D2_GROUP, D1_GROUP]),
+            patch.object(generator, "convert_groups", return_value=[Path("d1.ms")]) as convert,
+        ):
+            result = generator.generate_from_transit(
+                calibrator_name=CAL.name,
+                transit_time=TRANSIT_D1,
+                verify=False,
+            )
+        assert result.success
+        assert convert.call_args.args[0] == [D1_GROUP]
+
+    def test_fails_loudly_when_requested_date_missing(self, generator):
+        with (
+            patch.object(generator, "get_calibrator", return_value=CAL),
+            patch(LEGACY_SELECTOR, return_value=[D2_GROUP]),
+            patch.object(generator, "convert_groups") as convert,
+        ):
+            result = generator.generate_from_transit(
+                calibrator_name=CAL.name,
+                transit_time=TRANSIT_D1,
+                verify=False,
+            )
+        assert not result.success
+        assert convert.call_count == 0
+        assert "transit" in (result.error_message or "").lower()
+
+
+class TestGenerateMultiple:
+    def test_passes_transit_time_to_selection(self, generator):
+        with (
+            patch.object(generator, "get_calibrator", return_value=CAL),
+            patch(LEGACY_SELECTOR, return_value=[D2_GROUP, D1_GROUP]),
+            patch.object(generator, "convert_groups", return_value=[Path("d1.ms")]) as convert,
+        ):
+            result = generator.generate_multiple(
+                calibrator_name=CAL.name,
+                transit_time=TRANSIT_D1,
+                verify=False,
+            )
+        assert result.success
+        assert convert.call_args.args[0] == [D1_GROUP]


### PR DESCRIPTION
## Summary

`generate_from_transit(calibrator_name, transit_time, ...)` stored `transit_time` in `TransitInfo` but selected HDF5 groups via `select_groups_by_position`, which is purely positional. In drift scan the same RA transits every sidereal day, so with an all-dates index the closest-by-RA group could come from a different date than the requested transit — silent wrong-date calibration provenance.

- `select_groups_by_position` gains `transit_time: Time | None` and `max_transit_offset_minutes: float = 360.0`. When `transit_time` is given, positionally matched groups are filtered to within the tolerance; positional (angular-proximity) ordering is preserved among survivors.
- If groups match the position but none fall within the tolerance, it raises `ValueError` with an explicit message instead of silently selecting another date (surfaces as `CalibratorMSResult.error_message` so the `ensure.py` BP/G ladder proceeds to its explicit fallback/borrow rungs).
- `generate_from_transit` and `generate_multiple` pass their `transit_time` through. `generate_for_pointing` is covered via delegation. Behavior without `transit_time` is unchanged.
- Default tolerance of 360 min only needs to separate transits one sidereal day (~1436 min) apart while staying well above beam-crossing time (tens of minutes), so it cannot reject valid same-transit groups.

Conversion of selected groups is untouched.

## Test plan

New `tests/test_calibrator_ms_generator.py` (6 tests, mocked legacy selector + conversion, no real HDF5/MS). Written TDD: 5 failed before the fix — including the exact #72 scenario where the D2 group (positionally closer) was selected over the D1 group holding the requested transit.

- `select_groups_by_position` filters other-date groups when `transit_time` given; keeps positional order when not; raises when no group is near the transit.
- `generate_from_transit(cal, T_in_D1)` converts the D1 group even when a D2 group is positionally closer; fails loudly (no conversion attempted) when only other-date groups match.
- `generate_multiple` passes `transit_time` through.

## H17 validation (casa6 env)

```
PYTHONPATH=/data/dsa110-continuum /opt/miniforge/envs/casa6/bin/python -m pytest \
  tests/test_calibrator_ms_generator.py tests/test_ensure_calibration.py -q
60 passed
```

`tests/test_hdf5_calibrator_tile_smoke.py` also green (68 passed combined with ensure suite). `ruff check` and `ruff format --check` clean on touched files (module-wide reformat of pre-existing lines deliberately avoided).

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum (c50e599): post-cap residual risk removed

The initial fix filtered by `transit_time` **after** the legacy selector's `n_groups` cap, so many wrong-date positional candidates could crowd the requested-date group out of the capped candidate list before filtering ever ran (worst case `n_groups=1`). Now, when `transit_time` is given, the wrapper calls the legacy `select_hdf5_groups_by_position` with an effectively uncapped `n_groups` (the legacy selector builds and sorts all positional candidates before slicing, so this is safe), time-scopes the full candidate set, preserves angular-proximity order among survivors, and re-applies the caller's `n_groups` last. Behavior without `transit_time` is byte-for-byte unchanged (caller's `n_groups` passed through).

Regression tests added (mocked legacy selector): with `n_groups=1` and a wrong-date group listed closest, the legacy call is asserted to use the expanded cap and the return is exactly the requested-date group; a companion test pins that without `transit_time` the caller's `n_groups` is passed through unmodified.

Validation (H17 casa6): `tests/test_calibrator_ms_generator.py` (8 tests) + `tests/test_ensure_calibration.py` + `tests/test_hdf5_calibrator_tile_smoke.py` → 76 passed. `ruff check` clean on both touched files; `ruff format --check` clean on the test file — the module shows only pre-existing wrapping diffs untouched by this change, deliberately not reformatted.
