### PR TITLE
Defer legacy Dagster import out of mosaic module import chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,17 +134,7 @@ Telescope data paths (`/data/incoming/`, `/stage/dsa110-contimg/ms/`) do not exi
 
 <important if="you are importing, testing, or running anything under `dsa110_continuum.mosaic.*`">
 
-The mosaic subsystem requires `/dev/shm/dsa110-contimg/` to be writable by the current user **at import time**. `dsa110_continuum/mosaic/__init__.py` → `mosaic/pipeline.py` → `mosaic/science_jobs.py` reaches into the legacy `dsa110_contimg.workflow.dagster.definitions`, which calls `_validate_pipeline_prerequisites()` on module load — a hard requirement, not lazy. Symptom: `RuntimeError: Pipeline validation failed: [DIR] /dev/shm/dsa110-contimg: Not writable`, raised the moment the import chain is touched (including by pure-Python WCS tests).
-
-Fix when blocked: either (a) make the directory writable for your user, or (b) bypass the import chain by loading `dsa110_continuum.mosaic.builder` directly with `importlib.util.spec_from_file_location` — but if you do (b), resolve the path relative to `__file__`, NEVER hard-code an absolute path.
-
-</important>
-
-<important if="you are debugging test failures or interpreting suite results">
-
-Environment-dependent tests:
-
-- `tests/test_simulated_pipeline.py::TestSimulatedMosaic` — class-level `skipif` skips all 3 tests when `/dev/shm/dsa110-contimg/` isn't writable by the current user. The tests would otherwise hit the legacy import-time validator described in the mosaic block above. If you need them to run, get write access to that directory (e.g., as the host's pipeline service user).
+Pure-Python `dsa110_continuum.mosaic.*` imports (including the whole package `__init__`) do NOT require `/dev/shm/dsa110-contimg/` or the legacy Dagster bootstrap. The legacy `dsa110_contimg.workflow.dagster.definitions` module (which validates runtime prerequisites at module load) is only imported lazily inside `ScienceMosaicBridgeJob.execute()` in `mosaic/science_jobs.py` — so the science-mosaic execution path still requires those runtime prerequisites, but plain imports and unit tests do not. Regression test: `tests/test_mosaic_import_no_dagster.py`. Do NOT reintroduce module-level `dsa110_contimg.workflow.dagster` imports anywhere under `dsa110_continuum/mosaic/` — the validator raises `RuntimeError`, which `except ImportError` guards do not catch.
 
 </important>
 

--- a/dsa110_continuum/mosaic/science_jobs.py
+++ b/dsa110_continuum/mosaic/science_jobs.py
@@ -29,10 +29,6 @@ except ImportError:
         pass
 
 from dsa110_continuum.mosaic.jobs import MosaicJobConfig
-try:
-    from dsa110_contimg.workflow.dagster.jobs.science_mosaic import science_mosaic_workflow
-except ImportError:
-    science_mosaic_workflow = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +150,14 @@ class ScienceMosaicBridgeJob(Job):
         self._update_status("building")
 
         try:
+            # Deferred import: the legacy Dagster definitions module validates
+            # runtime prerequisites (e.g. /dev/shm/dsa110-contimg) at module
+            # load, raising RuntimeError. Importing it here keeps pure-Python
+            # mosaic imports free of that bootstrap (issue #75).
+            from dsa110_contimg.workflow.dagster.jobs.science_mosaic import (
+                science_mosaic_workflow,
+            )
+
             # Convert timestamps to ISO8601
             start_iso = datetime.fromtimestamp(self.start_time, tz=timezone.utc).isoformat()
             end_iso = datetime.fromtimestamp(self.end_time, tz=timezone.utc).isoformat()

--- a/tests/test_mosaic_import_no_dagster.py
+++ b/tests/test_mosaic_import_no_dagster.py
@@ -1,0 +1,62 @@
+"""Regression test for issue #75.
+
+Importing dsa110_continuum.mosaic (or any submodule such as builder) must not
+touch the legacy ``dsa110_contimg.workflow.dagster`` package, whose
+``definitions`` module runs ``_validate_pipeline_prerequisites()`` at import
+time and raises RuntimeError unless /dev/shm/dsa110-contimg/ is writable.
+
+Rather than depending on host /dev/shm permissions, a subprocess installs an
+import finder that raises RuntimeError for any legacy Dagster module — the
+same exception type the real validator raises, which the ImportError guards
+in science_jobs.py do not catch.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+POISONED_IMPORT_SCRIPT = textwrap.dedent(
+    """
+    import sys
+
+    class PoisonLegacyDagster:
+        prefix = "dsa110_contimg.workflow.dagster"
+
+        def find_spec(self, name, path=None, target=None):
+            if name == self.prefix or name.startswith(self.prefix + "."):
+                raise RuntimeError(
+                    f"legacy Dagster bootstrap touched at import time: {name}"
+                )
+            return None
+
+    sys.meta_path.insert(0, PoisonLegacyDagster())
+
+    import dsa110_continuum.mosaic.builder  # noqa: F401
+    import dsa110_continuum.mosaic  # noqa: F401
+
+    loaded = [m for m in sys.modules if m.startswith(PoisonLegacyDagster.prefix)]
+    assert not loaded, f"legacy Dagster modules loaded: {loaded}"
+    print("OK")
+    """
+)
+
+
+def test_mosaic_imports_do_not_trigger_legacy_dagster_bootstrap():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [sys.executable, "-c", POISONED_IMPORT_SCRIPT],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+    assert proc.returncode == 0, (
+        f"mosaic import triggered legacy Dagster bootstrap\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert "OK" in proc.stdout

--- a/tests/test_mosaic_ra_wrap.py
+++ b/tests/test_mosaic_ra_wrap.py
@@ -18,24 +18,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.wcs import WCS
-
-# Import directly from the submodule to avoid the mosaic/__init__.py chain,
-# which pulls in the legacy dsa110_contimg.workflow.dagster validator that
-# requires /dev/shm/dsa110-contimg/ writable at module-load time.
-import importlib.util, sys
-from pathlib import Path
-_BUILDER_PATH = Path(__file__).resolve().parents[1] / "dsa110_continuum" / "mosaic" / "builder.py"
-_spec = importlib.util.spec_from_file_location(
-    "dsa110_continuum.mosaic.builder",
-    str(_BUILDER_PATH),
-)
-_mod = importlib.util.module_from_spec(_spec)
-sys.modules["dsa110_continuum.mosaic.builder"] = _mod
-_spec.loader.exec_module(_mod)
-
-compute_optimal_wcs = _mod.compute_optimal_wcs
-fast_reproject_and_coadd = _mod.fast_reproject_and_coadd
-
+from dsa110_continuum.mosaic.builder import compute_optimal_wcs, fast_reproject_and_coadd
 
 # ── FITS HDU helpers ──────────────────────────────────────────────────────────
 

--- a/tests/test_simulated_pipeline.py
+++ b/tests/test_simulated_pipeline.py
@@ -1,7 +1,6 @@
 # tests/test_simulated_pipeline.py
 import numpy as np
 import pytest
-import tempfile
 from pathlib import Path
 from dsa110_continuum.simulation.harness import SimulationHarness
 

--- a/tests/test_simulated_pipeline.py
+++ b/tests/test_simulated_pipeline.py
@@ -1,15 +1,9 @@
 # tests/test_simulated_pipeline.py
-import os
 import numpy as np
 import pytest
 import tempfile
 from pathlib import Path
 from dsa110_continuum.simulation.harness import SimulationHarness
-
-# Importing dsa110_continuum.mosaic.* triggers the legacy
-# dsa110_contimg.workflow.dagster validator at module-load time, which
-# requires /dev/shm/dsa110-contimg/ writable by the current user.
-_DEVSHM_DSA110_WRITABLE = os.access("/dev/shm/dsa110-contimg", os.W_OK)
 
 
 class TestGainCorruption:
@@ -284,11 +278,6 @@ class TestSimulatedImaging:
 
 
 class TestSimulatedMosaic:
-    pytestmark = pytest.mark.skipif(
-        not _DEVSHM_DSA110_WRITABLE,
-        reason="Requires /dev/shm/dsa110-contimg/ writable: legacy dsa110_contimg.workflow.dagster validator runs at import time",
-    )
-
     @pytest.fixture
     def two_tile_fits(self, tmp_path):
         """Two minimal synthetic FITS tiles with overlapping footprints."""


### PR DESCRIPTION
## Summary

Importing anything under `dsa110_continuum.mosaic` (including pure-Python modules like `mosaic.builder`) triggered the legacy `dsa110_contimg.workflow.dagster.definitions` import-time validator via `mosaic/__init__.py → pipeline.py → science_jobs.py`. The validator hard-requires `/dev/shm/dsa110-contimg/` writable and raises `RuntimeError`, which escaped the `except ImportError` guard in `science_jobs.py`.

Fix: move the `science_mosaic_workflow` import inside `ScienceMosaicBridgeJob.execute()`. Pure-Python mosaic imports no longer touch the legacy Dagster bootstrap; the science-mosaic execution path still validates its runtime prerequisites at execute time. All public `mosaic.__init__` re-exports are unchanged.

Cleanups enabled by the fix:
- Removed the class-level `skipif` on `tests/test_simulated_pipeline.py::TestSimulatedMosaic` — its 3 tests now run unconditionally.
- Replaced the `spec_from_file_location` bypass in `tests/test_mosaic_ra_wrap.py` with a plain import.
- Updated the CLAUDE.md mosaic-import block to describe the new behavior.

## Test plan (TDD, on H17 with casa6 env)

- New regression test `tests/test_mosaic_import_no_dagster.py`: subprocess installs an import finder that raises `RuntimeError` for `dsa110_contimg.workflow.dagster*` (same exception type as the real validator, host-independent), then imports `dsa110_continuum.mosaic.builder` and `dsa110_continuum.mosaic`. **RED on main** (failed with the exact issue-#75 traceback through `science_jobs.py:33`), **GREEN after the fix**.
- `tests/test_mosaic_import_no_dagster.py` + `tests/test_simulated_pipeline.py`: **20 passed, 1 skipped** (`TestSimulatedMosaic`'s 3 tests now execute; `/dev/shm/dsa110-contimg/` is root-owned/non-writable on H17, so they were skipped before).
- `tests/test_simulated_pipeline.py::TestSimulatedMosaic` + `tests/test_mosaic_ra_wrap.py`: **23 passed**.
- `tests/test_mosaic_day_ms_discovery.py` + `tests/test_mosaic_windowing.py`: **31 passed**.
- Ruff: touched files clean for new code; pre-existing violations in `test_simulated_pipeline.py` / `science_jobs.py` left as-is per repo policy.

## H17 production validation

`scripts/batch_pipeline.py --date 2026-01-25 --start-hour 22 --end-hour 23 --dry-run --quarantine-after-failures 3` → rc=0. Full plan printed: Dec-strip check passed, BP/G tables resolved (`2026-01-25T22:26:05_0~23.{b,g}` exist), 179 valid MS discovered, 11 tiles planned for hour 22, checkpoint/quarantine state read, strict QA gating, no products written. The batch path's own `/dev/shm` fallback behavior is unchanged.

Fixes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)