### PR TITLE
Fix cloud pytest collection optional imports

### DIFF
--- a/dsa110_continuum/conversion/__init__.py
+++ b/dsa110_continuum/conversion/__init__.py
@@ -35,39 +35,47 @@ Writers:
         writer.write()
 """
 
-from . import helpers_coordinates  # Make coordinate helpers accessible via the package
+from __future__ import annotations
 
-# Downsampling utilities
-from .downsample_uvh5 import (
-    downsample_uvh5,
-    get_downsampling_info,
-)
+from importlib import import_module
+from typing import Any
 
-# Flattened exports - main conversion API
-from .conversion_orchestrator import convert_subband_groups_to_ms
+_LAZY_EXPORTS = {
+    # Submodules
+    "helpers_coordinates": ".helpers_coordinates",
+    # Batch conversion
+    "convert_subband_groups_to_ms": ".conversion_orchestrator",
+    # Normalization
+    "build_subband_filename": ".normalize",
+    "normalize_directory": ".normalize",
+    "normalize_subband_on_ingest": ".normalize",
+    "normalize_subband_path": ".normalize",
+    # Writers
+    "MSWriter": ".writers",
+    "DirectSubbandWriter": ".writers",
+    "get_writer": ".writers",
+    # Downsampling
+    "downsample_uvh5": ".downsample_uvh5",
+    "get_downsampling_info": ".downsample_uvh5",
+    # Calibrator MS generation
+    "CalibratorMSGenerator": ".calibrator_ms_generator",
+    "CalibratorMSResult": ".calibrator_ms_generator",
+    "CalibratorInfo": ".calibrator_ms_generator",
+    "TransitInfo": ".calibrator_ms_generator",
+}
 
-# File normalization utilities (formerly in streaming submodule)
-from .normalize import (
-    build_subband_filename,
-    normalize_directory,
-    normalize_subband_on_ingest,
-    normalize_subband_path,
-)
 
-# Writers
-from .writers import (
-    DirectSubbandWriter,
-    MSWriter,
-    get_writer,
-)
+def __getattr__(name: str) -> Any:
+    """Lazily load conversion exports so package import stays cloud-collectable."""
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-# Calibrator transit-based MS generation
-from .calibrator_ms_generator import (
-    CalibratorInfo,
-    CalibratorMSGenerator,
-    CalibratorMSResult,
-    TransitInfo,
-)
+    module = import_module(module_name, __name__)
+    value = module if name == "helpers_coordinates" else getattr(module, name)
+    globals()[name] = value
+    return value
+
 
 __all__ = [
     # Submodules

--- a/dsa110_continuum/conversion/helpers_coordinates.py
+++ b/dsa110_continuum/conversion/helpers_coordinates.py
@@ -6,11 +6,6 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-
-from pyuvdata.utils.phasing import calc_uvw as _PU_CALC_UVW
-from pyuvdata.utils.phasing import calc_app_coords as _calc_app_coords
-from pyuvdata.utils.phasing import calc_frame_pos_angle as _calc_frame_pos_angle
-
 from dsa110_continuum.conversion.helpers_antenna import (
     _ensure_antenna_diameters,
     set_antenna_positions,
@@ -32,6 +27,20 @@ logger = logging.getLogger("dsa110_contimg.conversion.helpers")
 # Log fallback warning once at import time, not every function call
 if not _USE_NUMBA_ANGULAR_SEP:
     logger.warning("Numba angular separation not available, using pure numpy (2-5x slower)")
+
+
+def _load_pyuvdata_phasing_helpers():
+    """Load pyuvdata phasing helpers only for UVW recomputation paths."""
+    try:
+        from pyuvdata.utils.phasing import calc_app_coords, calc_frame_pos_angle
+        from pyuvdata.utils.phasing import calc_uvw as pu_calc_uvw
+    except ImportError as exc:
+        raise ImportError(
+            "pyuvdata is required for conversion UVW recomputation. "
+            "Install pyuvdata or run inside the casa6 pipeline environment."
+        ) from exc
+
+    return pu_calc_uvw, calc_app_coords, calc_frame_pos_angle
 
 
 def angular_separation(ra1, dec1, ra2, dec2):
@@ -63,6 +72,7 @@ def angular_separation(ra1, dec1, ra2, dec2):
     # REFACTOR: Usage of astropy.coordinates.angular_separation instead of manual implementation
     # astropy.coordinates.angular_separation accepts radians for unitless float inputs
     from astropy.coordinates import angular_separation as astropy_sep
+
     return astropy_sep(ra1, dec1, ra2, dec2)
 
 
@@ -255,6 +265,8 @@ def compute_and_set_uvw(uvdata, pt_dec: u.Quantity) -> None:
     import numpy as _np
     from astropy.time import Time as _Time
 
+    pu_calc_uvw, calc_app_coords, calc_frame_pos_angle = _load_pyuvdata_phasing_helpers()
+
     # Telescope metadata (lat, lon, alt; frame)
     tel_latlonalt = getattr(uvdata, "telescope_location_lat_lon_alt", None)
     if tel_latlonalt is None and hasattr(uvdata, "telescope"):
@@ -303,7 +315,7 @@ def compute_and_set_uvw(uvdata, pt_dec: u.Quantity) -> None:
         ra_icrs, dec_icrs = get_meridian_coords(pt_dec, float(mjd), fast=False)
         try:
             # pyuvdata 3.2+ uses keyword-only lon_coord/lat_coord
-            new_app_ra, new_app_dec = _calc_app_coords(
+            new_app_ra, new_app_dec = calc_app_coords(
                 lon_coord=ra_icrs.to_value(u.rad),
                 lat_coord=dec_icrs.to_value(u.rad),
                 coord_frame="icrs",
@@ -319,7 +331,7 @@ def compute_and_set_uvw(uvdata, pt_dec: u.Quantity) -> None:
                 telescope_loc=tel_latlonalt,
                 telescope_frame=tel_frame,
             )
-            new_frame_pa = _calc_frame_pos_angle(
+            new_frame_pa = calc_frame_pos_angle(
                 time_array=uvdata.time_array[uinvert == i],
                 app_ra=new_app_ra,
                 app_dec=new_app_dec,
@@ -347,7 +359,7 @@ def compute_and_set_uvw(uvdata, pt_dec: u.Quantity) -> None:
     tel_lat = float(tel_latlonalt[0])
     tel_lon = float(tel_latlonalt[1])
 
-    uvw_all = _PU_CALC_UVW(
+    uvw_all = pu_calc_uvw(
         app_ra=app_ra_all,
         app_dec=app_dec_all,
         frame_pa=frame_pa_all,

--- a/dsa110_continuum/conversion/merge_spws.py
+++ b/dsa110_continuum/conversion/merge_spws.py
@@ -10,8 +10,6 @@ import os
 import shutil
 
 import numpy as np
-
-
 from dsa110_continuum.adapters import casa_tables as casatables  # type: ignore[import]
 
 table = casatables.table  # noqa: N816
@@ -20,7 +18,7 @@ table = casatables.table  # noqa: N816
 try:
     from dsa110_contimg.common.utils.runtime_safeguards import require_casa6_python
 except ImportError:
-    pass  # dsa110_contimg not installed (cloud/test env)
+    from dsa110_continuum._compat import require_casa6_python
 
 # Use canonical angular_separation with numba→astropy fallback chain
 from dsa110_continuum.conversion.helpers_coordinates import angular_separation

--- a/tests/test_bad_pol_wiring_smoke.py
+++ b/tests/test_bad_pol_wiring_smoke.py
@@ -24,8 +24,9 @@ passed.
 from __future__ import annotations
 
 import numpy as np
-import pyuvdata
 import pytest
+
+pyuvdata = pytest.importorskip("pyuvdata")
 
 from dsa110_continuum.simulation.harness import SimulationHarness
 

--- a/tests/test_cloud_collection_optional_imports.py
+++ b/tests/test_cloud_collection_optional_imports.py
@@ -1,0 +1,54 @@
+"""Regression tests for cloud-safe collection without optional UVH5 deps."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+BLOCK_PYuvdata_SCRIPT = textwrap.dedent(
+    """
+    import sys
+
+    class BlockPyuvdata:
+        prefix = "pyuvdata"
+
+        def find_spec(self, name, path=None, target=None):
+            if name == self.prefix or name.startswith(self.prefix + "."):
+                raise ModuleNotFoundError(f"blocked optional dependency: {name}")
+            return None
+
+    sys.meta_path.insert(0, BlockPyuvdata())
+
+    import dsa110_continuum.conversion as conversion  # noqa: F401
+    from dsa110_continuum.calibration import solver_common  # noqa: F401
+    from dsa110_continuum.conversion.calibrator_ms_generator import (
+        CalibratorMSGenerator,
+    )
+
+    assert CalibratorMSGenerator.__name__ == "CalibratorMSGenerator"
+    assert "pyuvdata" not in sys.modules
+    print("OK")
+    """
+)
+
+
+def test_conversion_and_calibration_imports_do_not_require_pyuvdata():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT) + os.pathsep + env.get("PYTHONPATH", "")
+    proc = subprocess.run(
+        [sys.executable, "-c", BLOCK_PYuvdata_SCRIPT],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+    assert proc.returncode == 0, (
+        "conversion/calibration imports required pyuvdata during collection\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert "OK" in proc.stdout

--- a/tests/test_plot_lightcurves.py
+++ b/tests/test_plot_lightcurves.py
@@ -1,13 +1,19 @@
-import pandas as pd
-import numpy as np
 import sys
 from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+pytest.importorskip("matplotlib")
+pytest.importorskip("scienceplots")
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from plot_lightcurves import (
-    plot_source_lightcurve,
     build_summary_html,
+    plot_source_lightcurve,
 )
 
 

--- a/tests/test_simulated_pipeline.py
+++ b/tests/test_simulated_pipeline.py
@@ -1,7 +1,11 @@
 # tests/test_simulated_pipeline.py
+from pathlib import Path
+
 import numpy as np
 import pytest
-from pathlib import Path
+
+pytest.importorskip("pyuvdata")
+
 from dsa110_continuum.simulation.harness import SimulationHarness
 
 

--- a/tests/test_stage_a_diagnostics.py
+++ b/tests/test_stage_a_diagnostics.py
@@ -1,15 +1,14 @@
-# tests/test_stage_a_diagnostics.py
-import matplotlib
-matplotlib.use("Agg")
-
 import csv
 import os
 import tempfile
 
 import numpy as np
 import pytest
-import matplotlib.pyplot as plt
 from astropy.io import fits
+
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")
+plt = pytest.importorskip("matplotlib.pyplot")
 
 from dsa110_continuum.visualization.config import FigureConfig, PlotStyle
 


### PR DESCRIPTION
## Summary

- keep cloud-safe pytest collection from importing optional `pyuvdata` / plotting dependencies at module import time
- lazy-load conversion package re-exports and pyuvdata phasing helpers so calibration/conversion imports remain collectable without `pyuvdata`
- add a subprocess regression test that blocks `pyuvdata` and imports the conversion/calibration collection path

## Root Cause

The cloud collection path failed before tests could be selected because optional runtime dependencies were imported at module import time. `helpers_coordinates.py` imported pyuvdata phasing helpers eagerly, `conversion.__init__` eagerly re-exported pyuvdata-backed conversion modules, and several optional plotting/simulation tests imported optional packages before pytest could skip them.

## Validation

- Local RED: `PYTHONPATH="$PWD" rtk pytest -q tests/test_cloud_collection_optional_imports.py` failed before the import changes with blocked `pyuvdata`
- Local: `RTK_DISABLED=1 env PYTHONPATH="$PWD" python3 -m pytest --collect-only -q tests/ | tail -5` -> `968 tests collected in 3.33s`
- Local: `PYTHONPATH="$PWD" rtk pytest -q tests/test_cloud_collection_optional_imports.py tests/test_plot_lightcurves.py tests/test_stage_a_diagnostics.py` -> `7 passed, 1 skipped`
- Local lint: `rtk ruff check --select I001,F401 ...` -> no issues on scoped touched files
- H17 branch `737fcf4`: `PYTHONPATH=/data/dsa110-continuum /opt/miniforge/envs/casa6/bin/python -m pytest --collect-only -q tests/ | tail -5` -> `1115 tests collected in 36.17s`
- H17 branch `737fcf4`: targeted affected tests -> `45 passed, 1 skipped, 108 warnings`
- H17 lint: scoped `ruff check --select I001,F401` -> all checks passed; `ruff format --check` on production/new-test files -> 4 files already formatted
- H17 `agent-closeout-check` -> ok with `.emdash/` classified as preserved generated/tool state

## Residual Risk / Notes

- `scripts/pipeline_evidence_matrix.py --run-evidence` from issue #35 could not be rerun because `scripts/pipeline_evidence_matrix.py` is not present in the current local or H17 checkout; H17 only has prior `outputs/pipeline_evidence_matrix/` logs and a stale pycache entry.
- H17 dirty state remains only untracked `.emdash/`, preserved per campaign handoff.

Addresses #35.
