### PR TITLE
Record canonical hourly-epoch coadd ADR

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -54,10 +54,10 @@ Each entry that names a code-level fact ends with a citation in `<path>::<Symbol
 
 ## Mosaicking
 
-- **Quicklook** — image-domain mosaic on pre-deconvolved tile FITS; nearest-neighbour regridding, weighted coadd with `weight = w_rms × w_PB²` (Airy-disk primary beam, dish diameter 4.65 m). Pixels below 10% peak beam response blanked. Fast (`dsa110_continuum/mosaic/builder.py::build_mosaic`; see `docs/reference/mosaicking.md` for parameters).
+- **Quicklook** — image-domain mosaic on pre-deconvolved tile FITS. The package builder does nearest-neighbour regridding and PB-weighted coadd from an analytic Airy-disk model; the production day-batch path additionally blanks pixels where WSClean's per-tile beam map is below 20% of peak response. ADR 0001 makes the package the canonical home for the production hourly-epoch coadd by absorbing that production behavior, not by treating the 10% PB-correction floor as default coadd blanking (`dsa110_continuum/mosaic/builder.py::build_mosaic`; `scripts/mosaic_day.py::PB_CUTOFF`).
 - **Science / Deep** — visibility-domain joint deconvolution: all tile MS files phaseshifted to a common centre and jointly imaged with WSClean+IDG using `-grid-with-beam` for direction-dependent beam correction. Slower; scientifically correct for wide fields (see `docs/reference/mosaicking.md`).
 - **RA-wrap (circular mean)** — when tiles span 0° RA, the mosaic centre is computed as `arctan2(mean(sin(RA)), mean(cos(RA)))` rather than arithmetic mean. Fixes the bug where a [350°, 5°, 10°] tile set centred at 121.7° instead of 1.7° (`dsa110_continuum/mosaic/builder.py::build_mosaic`).
-- **Coadd** — combine reprojected tiles into a single mosaic FITS. Uses `reproject.reproject_interp` per tile (full-grid; optimisation deferred) (`dsa110_continuum/mosaic/builder.py::build_mosaic`).
+- **Coadd** — combine regridded tile images into a single mosaic FITS. The canonical hourly-epoch coadd is moving into `dsa110_continuum.mosaic` while preserving production batch semantics for beam-map blanking and strip grouping (`dsa110_continuum/mosaic/builder.py::build_mosaic`; `scripts/mosaic_day.py::coadd_tiles`).
 - **Strip grouping** (legacy day-batch) — `scripts/mosaic_day.py::group_tiles_by_ra` partitions a day's tiles into contiguous RA strips with a 10° gap threshold. Used by the per-day batch path; the streaming path does not partition (it produces sliding-window mosaics directly).
 
 ## Photometry and variability

--- a/docs/adr/0001-canonical-hourly-epoch-coadd.md
+++ b/docs/adr/0001-canonical-hourly-epoch-coadd.md
@@ -1,0 +1,55 @@
+# Canonical hourly-epoch coadd
+
+Status: accepted
+
+The production hourly-epoch mosaic path and the package Quicklook builder currently
+encode different coadd behavior. Production uses `scripts/mosaic_day.py` through
+`scripts/batch_pipeline.py`: it partitions disjoint RA strips, blanks low-response
+pixels with WSClean beam maps at 20% of peak response, and then coadds the tile
+images. The package builder has the RA-wrap-safe WCS behavior and is the importable
+package surface, but it uses an analytic Airy-disk beam model and does not blank
+low primary-beam pixels during the default coadd.
+
+We will make the package the canonical home for the production hourly-epoch coadd
+by absorbing the production `mosaic_day` behavior into `dsa110_continuum.mosaic`,
+not by promoting the current package builder behavior unchanged. The migration in
+#77 should move or wrap the production coadd behind a package entry point, preserve
+the package RA-wrap invariant, and then make `scripts/batch_pipeline.py` call that
+package entry point instead of importing `scripts/mosaic_day.py`.
+
+## Considered Options
+
+- **Promote current `builder.build_mosaic` as-is.** This would use the already
+  packaged Quicklook API and RA-wrap regression, but would silently drop current
+  production behavior around WSClean beam-map blanking and strip partitioning.
+- **Absorb production behavior into the package.** This keeps the production
+  science behavior stable while moving ownership into the canonical package
+  namespace. This is the selected option.
+
+## Per-Axis Decision
+
+- **Primary-beam blanking.** Keep production blanking at `PB_CUTOFF = 0.2` before
+  coadd when WSClean `*-beam-0.fits` companions exist. The 10% cutoff in
+  `compute_pb_correction_map` is a primary-beam correction floor, not the default
+  hourly-epoch coadd blanking policy.
+- **Primary-beam model source.** For production batch mosaics, use WSClean's
+  per-tile beam model from disk. The analytic Airy-disk map may remain useful for
+  Quicklook fallback or simulation paths, but it is not the production beam source
+  for #77.
+- **Strip partitioning.** Keep 10-degree RA gap strip grouping for day-batch and
+  UTC-hour batch inputs so disjoint tile sets do not produce oversized mosaics.
+  Sliding-window streaming inputs may bypass strip grouping when the trigger has
+  already selected a single contiguous Dec strip window.
+- **Glossary.** `CONTEXT.md` should describe Quicklook as the image-domain coadd
+  tier, not as a single implementation's current internals. It must not claim
+  default 10% blanking for hourly-epoch coadds.
+
+## Consequences
+
+After #77, `scripts/batch_pipeline.py` should stop importing `mosaic_day` for
+coadd construction. `scripts/mosaic_day.py` can then either be reduced to a thin
+compatibility wrapper around the package entry point or kept only for the legacy
+standalone day-batch CLI until its callers are retired. Tests for the production
+call path must assert that `batch_pipeline.py` reaches the package entry point and
+that the selected primary-beam blanking, beam-map source, strip grouping, and
+RA-wrap behavior match this decision.


### PR DESCRIPTION
## Summary

- add ADR 0001 choosing the canonical hourly-epoch coadd direction
- correct CONTEXT.md so Quicklook no longer claims default 10% coadd blanking
- update #77 with ADR-derived file-level migration instructions and acceptance criteria

Fixes #76

## Validation

- `PYTHONPATH="$PWD" python3 scripts/verify_glossary.py`
- `git diff --check`
- H17: `PYTHONPATH=/data/dsa110-continuum /opt/miniforge/envs/casa6/bin/python scripts/verify_glossary.py`
- `agent-closeout-check --repo /Users/jakobfaber/Developer/repos/github.com/jakobtfaber/dsa110-continuum --touched CONTEXT.md --touched docs/adr/0001-canonical-hourly-epoch-coadd.md --json`
- H17 closeout checker via local script over SSH, classifying pre-existing `.emdash/` as generated/cache
