### PR TITLE
Complete Sault coadd weight products and provenance

### DIFF
--- a/docs/rse/specs/handoff-2026-07-04-08-19-sault-coadd-and-fringe-forensics.md
+++ b/docs/rse/specs/handoff-2026-07-04-08-19-sault-coadd-and-fringe-forensics.md
@@ -1,0 +1,190 @@
+# Handoff: Sault-weighted coadd + crosshatch forensics
+
+**Created:** 2026-07-04 08:19 (local)
+**Branch:** `agent/sault-weighted-coadd` @ `72d963b` (LOCAL ONLY — never pushed; 1 commit ahead of `main` @ `57821b5`)
+**Working tree:** clean
+**Current phase:** Implement (mid-work-item) → next is a small follow-up commit, then PR, then Validate
+
+## Context: how we got here
+
+`main` now contains the fully merged dsa110_contimg import retirement (PR #93
+`baef485`, validation addendum PR #94 `57821b5`; see
+[validation-contimg-import-retirement.md](validation-contimg-import-retirement.md)).
+After merge, the user pivoted to mosaic quality. Visual inspection of two
+production hourly-epoch mosaics found: (a) edge dipole artifacts, (b) a
+crosshatch/herringbone fringe pattern, (c) a missing-tile coverage pinch. Two
+work items were authorized: **implement beam-validated per-pixel Sault
+weighting in the production coadd** (this branch) and **root-cause the
+crosshatch** (done, investigation only — fixes NOT yet implemented).
+
+## Work item A — Sault coadd (this branch, one commit `72d963b`)
+
+**Code:** `dsa110_continuum/mosaic/production.py` — `coadd_tiles` rewritten:
+per-pixel weight `(1/sigma_flat^2) * PB^2` for PB-corrected inputs; PB
+recovered as the `image/image-pb` ratio (fallback: band-average of
+`-beam-N.fits`; last resort uniform + warning); `PB_CUTOFF=0.2` is now a
+weight floor; numerator and weight planes reprojected identically. Helper
+`_beam_path_for_tile` was deleted (no external references), `_pb_map_for_tile`
++ `_tile_base` added.
+
+**Tests:** `tests/test_mosaic_sault_coadd.py` (7 tests: exact PB-ratio
+recovery, constant-sky flux preservation = double-correction oracle,
+overlap-pixel formula check that recomputes the coadd's own weight definition,
+floor semantics ×2, band-average fallback, no-PB fallback). All 57 mosaic
+tests + 122 mosaic/batch subset pass on Mac py312. Legacy blanking pin
+(`tests/test_mosaic_production_coadd.py`) passes unchanged.
+
+**H17 validation (all artifacts in
+`/data/dsa110-continuum/outputs/mosaic-visual-qa-2026-07-03/` on h17):**
+- Beam check: `image/image-pb` ratio is **pixel-identical** to `-beam-0.fits`
+  on production tiles (`pb_ratio_vs_beam0.png`; widths equal at PB=0.9/0.7/0.5/0.3).
+  The applied beam is strongly asymmetric (drift-averaged) — model-free ratio
+  weighting is the right call. (An earlier "beam-0 is ~19% too wide" claim was
+  measured false and has been corrected in docstring + commit message.)
+- Epoch 2026-01-25T2200 rebuilt from same 11 tiles
+  (`2026-01-25T2200_mosaic_sault.fits`, `_sault_full/zoom.png`): 3C454.3 peak
+  16.28→16.24 Jy/beam (flux preserved), rms 26.6→24.9 mJy.
+- Epoch 2026-02-26T0000 rebuilt (`ALL DONE` in `/tmp/sault-validate.log` on
+  h17): rms 24.3→23.3 mJy, **but the 5.77 Jy edge dipole survived
+  bit-identical** — it is a SINGLE-COVERAGE boundary pixel; Sault weighting
+  only reallocates weight between overlapping tiles (num/den ≡ pixel value
+  where one tile covers). Honest negative, already explained to user.
+- NVSS cross-match (`scripts/verify_sources.py`): old vs new at ≥100 mJy →
+  median_ratio 0.929 vs 0.880, BUT bright-end (0.5–20 Jy) 1.187→0.962 and all
+  big outliers (2.2×, 2.6×, 8.2×) moved toward unity — the new estimator is
+  more accurate; old median was noise-peak-inflated. SNR>5 detections 94/95.
+  Deep run at ≥20 mJy (`verify_sault_deep.json`, CSV format despite name):
+  311/608 detected; 100% at ≥100 mJy; dimmest detection MS_1555381 at 20.1 mJy
+  SNR 5.3 (NVSS-proper: NVSS_1011389, 20.2 mJy). Detection-fraction-by-flux
+  table + miss attribution: 63% of misses below 5× local rms, only 16%
+  (49/297) pathology-attributable. Overlay renders:
+  `sault_nvss_overlay.png`, `sault_dimmest_zoom.png`.
+
+**Verify-gate:** oracle + cross-check records exist for both files (sha
+`049a8d56a8fe`, `1476145c498e`, `5f0918e1b71c`).
+
+**Remaining before PR (decided with user):**
+1. Write the accumulated weight plane out as a companion product
+   (e.g. `*_mosaic_weight.fits`) so photometry/source-finding can threshold on
+   effective local noise `1/sqrt(sum_weight)` — this is the correct handling
+   of the surviving single-coverage edge artifacts. Wire through
+   `build_epoch_coadd` → `scripts/batch_pipeline.py:1058,1887` (mosaic write
+   site) without breaking the `(arr, wcs)` return contract used by
+   `tests/test_mosaic_production_coadd.py:98`.
+2. Note in the PR body: reprojection cost doubled (two planes; epoch rebuild
+   ~1.7 h per epoch on h17 vs ~half before) — acceptable now, optimization
+   follow-up (single coordinate-transform for both planes).
+3. Push branch (`git push -u origin agent/sault-weighted-coadd` — push-gate
+   sticky window may need a human Allow), PR to `dsa110/dsa110-continuum` with
+   `--head jakobtfaber:agent/sault-weighted-coadd`, before/after renders +
+   NVSS tables in body, then `ai-research-workflows:validating-implementations`.
+
+## Work item B — crosshatch forensics (DONE, fixes NOT implemented)
+
+Full memo: `/data/dsa110-continuum/outputs/fringe-forensics-2026-07-04/DIAGNOSIS.md`
+on h17 (+ figures, `qa_metric_all.json`). Headlines:
+- Crosshatch is **systemic** (every tile, both epochs, same spatial-frequency
+  lattice) and **visibility-domain** (fringe power identical in
+  dirty/image/residual; PSF itself carries the lattice). Deeper CLEAN is
+  explicitly useless (~4% effect on worst tile).
+- **Root cause 1 (pattern):** bandpass/gain solve flags the identical
+  34-antenna list in both epochs (30%); ~11 of those have normal raw
+  amplitudes — solver-yield problem (refant/minsnr=5.0,
+  `dsa110_continuum/calibration/runner.py:1206-1216`;
+  `bandpass_diagnostics.py:656,784` names the "bad_antenna_or_refant" mode,
+  suggests alt refant 104/105). Depleted array → PSF sidelobe lattice at
+  |uv| ≈ 1.0–1.35 kλ (215–290 m, at the >1 kλ cut).
+- **Root cause 2 (amplitude):** RFI flagging NEVER runs in the production
+  batch path — base MS FLAG fraction 0.0000, no AOFlagger/MAD flag versions;
+  `scripts/batch_pipeline.py` never calls `flag_rfi_aoflagger` /
+  `flag_residual_rfi_clip` / `flag_extend`
+  (`dsa110_continuum/calibration/flagging_rfi.py:214,434`,
+  `flagging_amplitude.py:111`, orchestration `flagging_rfi.py:89-172`).
+  Two-stage flagging contract (docs/reference/flagging.md) is un-invoked.
+- **Prototyped QA metric** (not committed): fringe-annulus anisotropy
+  (herringbone ≫1000 vs ~5 white noise) + central rms; suggested post-fix
+  gate rms > 8 mJy OR anisotropy > 5000.
+- Caveat: imaged `_meridian.ms` files were deleted; evidence is from base MS +
+  cal tables (strong but inferential).
+
+## Next steps in priority order
+
+1. **Finish work item A** (weight-map product → push → PR → validate). Small.
+2. **New work item (needs user go-ahead already implicitly given as "next"):
+   wire two-stage RFI flagging into the production path** — biggest image
+   quality win. Touches batch_pipeline/calibration orchestration; changes
+   runtime and products materially.
+3. **Cal-yield fix** — recover the ~11 wrongly-dropped antennas (alt refant
+   104/105; minsnr sensitivity), re-solve on 2026-01-25, re-image one epoch to
+   confirm lattice amplitude drops.
+4. **Herringbone QA gate** — productionize the forensics metric into the
+   per-tile QA hooks so bad tiles are quarantined pre-coadd.
+5. Earlier semi-automation gap list (still open): new-namespace
+   conversion/indexing entry point (`dsa110 convert`/`index add` live only in
+   the old install), cal ladder proof on a non-golden date, catalog
+   completeness QA fix. See conversation-era analysis; no spec doc exists yet.
+
+## Known-broken / unverified
+
+- Branch `agent/sault-weighted-coadd` is **unpushed**; no CI run yet. Mac full
+  suite NOT re-run on this branch (only the 122-test mosaic/batch subset +
+  57 mosaic tests). The 8 known pre-existing Mac failures baseline is
+  documented in validation-contimg-import-retirement.md.
+- Epoch-2 Sault renders (`2026-02-26T0000_sault_full/zoom.png` on h17) were
+  generated but never vision-reviewed.
+- Edge dipole artifact persists by design until the weight-map product lands.
+- Crosshatch persists in all products; both epochs remain unusable for
+  compact-source variability per the forensics QA metric until flagging + cal
+  fixes land.
+- The `verify_*.json` outputs are CSV content despite the extension.
+- `/tmp/production_sault.py`, `/tmp/sault-validate.log` on h17 are scratch;
+  the outputs dirs are the durable copies.
+
+## Critical files to read first
+
+1. `dsa110_continuum/mosaic/production.py` (the rewritten coadd)
+2. `tests/test_mosaic_sault_coadd.py`
+3. h17: `/data/dsa110-continuum/outputs/fringe-forensics-2026-07-04/DIAGNOSIS.md`
+
+## Environment / gotchas (hard-won this session)
+
+- H17: ssh alias `h17`, user `ubuntu` (do NOT override HOME); python
+  `/opt/miniforge/envs/casa6/bin/python`; repo `/data/dsa110-continuum` on
+  `main` @ `57821b5`; reproject 0.19 available. Filter ssh noise with
+  `grep -av "WARNING\|post-quantum\|openssh"` (note `-a`: logs contain
+  binary-ish bytes; plain grep goes silent).
+- Python-over-ssh: stdout is block-buffered under nohup redirect — prints
+  appear only at exit; use `strings` on the log. Single quotes INSIDE
+  ssh-single-quoted heredocs get shell-mangled — use double-quoted dict keys
+  (py3.12 allows same-quote nesting in f-strings).
+- `ls -t /data/incoming` hangs (stat storm; ~40k files) — use name-sorted.
+- push-gate: `gate:main` pushes (any remote's main) block until a human
+  clicks Allow (sticky window ~8h); feature-branch pushes and `gh pr merge`
+  passed this session. Repo convention: merge commits via cross-repo PRs
+  (`--head jakobtfaber:<branch>` to `dsa110/dsa110-continuum`).
+- Commit trailers required: `Co-Authored-By: Claude Fable 5
+  <noreply@anthropic.com>` + `Claude-Session:
+  https://claude.ai/code/session_018Tsfo7PUmu4LFRv6stySfV` (new session ⇒ new
+  session URL).
+- Show images to the user via `open <png>` (macOS Preview), after scp to the
+  session scratchpad.
+- Domain numbers used repeatedly: Dec strip 16.13°, drift 1.20°/5-min tile,
+  tile footprint ~4.0° (4800 px @ 3″ tiles; mosaic grid 6″/px), PB FWHM ≈
+  3.2°, ~3-tile sensitivity overlap (N±1 ≈ 46% weight, N±2 ≈ 4%), tiles 1&4
+  footprints still touch (3Δ=3.61° < 4.0°), 5th does not.
+
+## Recommended next skill
+
+Finish item A inline (small), then `ai-research-workflows:validating-implementations`
+for the branch. For items 2–3 (flagging + cal yield), start with
+`ai-research-workflows:planning-implementations` — they change production
+behavior and deserve a phased plan grounded in
+`docs/reference/flagging.md` + the DIAGNOSIS.md evidence.
+
+## References
+
+- [validation-contimg-import-retirement.md](validation-contimg-import-retirement.md)
+- [implement-contimg-import-retirement.md](implement-contimg-import-retirement.md)
+- [handoff-2026-07-03-03-16-caskade-simulation-control.md](handoff-2026-07-03-03-16-caskade-simulation-control.md) (prior session)
+- h17: `/data/dsa110-continuum/outputs/mosaic-visual-qa-2026-07-03/`,
+  `/data/dsa110-continuum/outputs/fringe-forensics-2026-07-04/`

--- a/dsa110_continuum/mosaic/production.py
+++ b/dsa110_continuum/mosaic/production.py
@@ -417,14 +417,7 @@ def weight_map_is_valid(
                 if np.any(weight_row[science] <= 0):
                     return False
 
-        return has_science_pixel and all(
-            np.allclose(weight_values, mosaic_values, rtol=0.0, atol=1e-10)
-            for weight_values, mosaic_values in (
-                (weight_wcs.wcs.crpix, mosaic_wcs.wcs.crpix),
-                (weight_wcs.wcs.crval, mosaic_wcs.wcs.crval),
-                (weight_wcs.wcs.cdelt, mosaic_wcs.wcs.cdelt),
-            )
-        )
+        return has_science_pixel and bool(weight_wcs.wcs.compare(mosaic_wcs.wcs))
     except (OSError, ValueError, IndexError, TypeError):
         return False
 

--- a/dsa110_continuum/mosaic/production.py
+++ b/dsa110_continuum/mosaic/production.py
@@ -1,10 +1,22 @@
 """Production hourly-epoch image-domain coadd helpers.
 
-These helpers preserve the current batch production semantics while making the
-package namespace the canonical owner for #77:
+The package namespace is the canonical owner of the production coadd (#77).
+Tiles are combined with a per-pixel inverse-variance (Sault) weighted mean:
 
-- WSClean per-tile ``*-beam-0.fits`` maps are the production PB source.
-- Pixels below 20% peak beam response are blanked before coadd.
+- Input tiles are PB-corrected (``*-image-pb.fits``), so each pixel's variance
+  is sigma_flat^2 / PB^2 and the optimal weight is w_tile * PB^2 with
+  w_tile = 1 / sigma_flat^2. A tile's contribution therefore rolls off
+  smoothly with its beam instead of entering at full weight up to a blanking
+  line.
+- The primary-beam map per tile is recovered exactly as the ratio
+  ``-image.fits`` / ``-image-pb.fits`` (the beam WSClean actually applied;
+  verified pixel-identical to ``-beam-0.fits`` on H17 production tiles,
+  2026-07-04). Fallback: the band-average of all ``*-beam-N.fits`` maps,
+  so the weight stays correct even for products where per-subband beam
+  files do differ.
+- ``PB_CUTOFF`` is a numerical weight floor (weight = 0 below it), not a
+  science decision: with PB^2 weighting the excluded pixels would have
+  carried <~4% weight anyway.
 - RA wrap uses a circular mean so 0/360-degree tile sets stay compact.
 - Day-batch callers can still split disjoint tile sets with a 10-degree RA gap.
 """
@@ -115,16 +127,78 @@ def build_common_wcs(fits_paths: list[str], margin_deg: float = 0.5) -> tuple[WC
     return out_wcs, ny, nx
 
 
-def _beam_path_for_tile(fits_path: str) -> str:
-    """Return the WSClean beam-map companion path for a tile image."""
-    path = fits_path.replace("-image-pb.fits", "-beam-0.fits")
-    if not os.path.exists(path):
-        path = fits_path.replace("-image.fits", "-beam-0.fits")
-    return path
+def _tile_base(fits_path: str) -> str:
+    """Strip the WSClean product suffix from a tile image path."""
+    for suffix in ("-image-pb.fits", "-image.fits"):
+        if fits_path.endswith(suffix):
+            return fits_path[: -len(suffix)]
+    return fits_path.removesuffix(".fits")
+
+
+def _pb_map_for_tile(fits_path: str, data_pb: np.ndarray) -> tuple[np.ndarray | None, str]:
+    """Recover the normalized primary-beam response on the tile's pixel grid.
+
+    Preferred source is the ratio ``-image.fits`` / ``-image-pb.fits``: it is
+    exactly the beam WSClean divided out, with no model assumptions. The ratio
+    is only undefined where the PB-corrected pixel is 0 or non-finite (isolated
+    noise zero-crossings and blanked borders) — those pixels get NaN and drop
+    out of the coadd. Fallback is the band-average of every ``*-beam-N.fits``
+    present; a single subband beam is never used alone.
+    """
+    base = _tile_base(fits_path)
+
+    flat_path = base + "-image.fits"
+    if fits_path.endswith("-image-pb.fits") and os.path.exists(flat_path):
+        with fits.open(flat_path) as hdul:
+            flat = hdul[0].data.squeeze().astype(np.float64)
+        with np.errstate(invalid="ignore", divide="ignore"):
+            pb = np.where(
+                np.isfinite(flat) & np.isfinite(data_pb) & (data_pb != 0),
+                flat / data_pb,
+                np.nan,
+            )
+        finite_frac = float(np.isfinite(pb).mean())
+        if finite_frac > 0.3:
+            peak = np.nanmax(pb)
+            if peak > 0:
+                pb = pb / peak
+            return pb, "image/image-pb ratio"
+        log.warning(
+            "  PB ratio for %s only %.0f%% finite; falling back to beam maps",
+            Path(fits_path).name,
+            finite_frac * 100,
+        )
+
+    beam_paths = sorted(Path(base).parent.glob(Path(base).name + "-beam-*.fits"))
+    if beam_paths:
+        pb_sum: np.ndarray | None = None
+        n_used = 0
+        for beam_path in beam_paths:
+            with fits.open(beam_path) as hdul:
+                beam = hdul[0].data.squeeze().astype(np.float64)
+            if pb_sum is None:
+                pb_sum = np.zeros_like(beam)
+            pb_sum += beam
+            n_used += 1
+        assert pb_sum is not None
+        pb = pb_sum / n_used
+        peak = np.nanmax(pb)
+        if peak > 0:
+            pb = pb / peak
+        return pb, f"band-average of {n_used} beam map(s)"
+
+    return None, "none"
 
 
 def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.ndarray:
-    """Reproject each tile onto the common WCS and do noise-weighted coaddition."""
+    """Reproject tiles onto the common WCS and combine with per-pixel PB^2 weights.
+
+    Inputs are PB-corrected tiles, so each pixel is an unbiased sky estimate
+    with variance sigma_flat^2 / PB^2; the inverse-variance weight is
+    (1 / sigma_flat^2) * PB^2 (Sault weighting). The weighted-numerator and
+    weight planes are reprojected identically and accumulated, and the mosaic
+    is their ratio.
+    """
     try:
         from reproject import reproject_interp
     except ModuleNotFoundError:
@@ -142,37 +216,60 @@ def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.nda
             data = hdul[0].data.squeeze().astype(np.float64)
             hdr = hdul[0].header
 
-        pb_path = _beam_path_for_tile(path)
-        if PB_CUTOFF > 0 and os.path.exists(pb_path):
-            with fits.open(pb_path) as pb_hdul:
-                pb_data = pb_hdul[0].data.squeeze().astype(np.float64)
-            pb_peak = np.nanmax(pb_data)
-            if pb_peak > 0:
-                pb_data /= pb_peak
-            low_beam = (pb_data < PB_CUTOFF) | ~np.isfinite(pb_data)
-            data[low_beam] = np.nan
-            log.info("  PB cutoff (%.0f%%): blanked %d pixels", PB_CUTOFF * 100, low_beam.sum())
-        elif PB_CUTOFF > 0:
-            log.warning("  No WSClean beam map found for %s; skipping beam cutoff", Path(path).name)
+        pb, pb_source = _pb_map_for_tile(path, data)
+        if pb is None:
+            log.warning(
+                "  No PB source for %s (no -image sibling, no beam maps); "
+                "using uniform weight over the tile footprint",
+                Path(path).name,
+            )
+            pb = np.ones_like(data)
+        else:
+            log.info("  PB source: %s", pb_source)
 
+        # Per-tile scalar weight from flat-noise rms: PB-corrected central box
+        # has PB ~ 1 there, so measure on data * pb (the flat-noise plane).
+        flat_plane = data * pb
         cy, cx = data.shape[0] // 2, data.shape[1] // 2
         margin = 200
-        inner = data[
+        inner = flat_plane[
             max(0, cy - margin) : cy + margin,
             max(0, cx - margin) : cx + margin,
         ]
-        noise = np.nanstd(inner[np.isfinite(inner)])
+        inner_finite = inner[np.isfinite(inner)]
+        noise = float(np.std(inner_finite)) if inner_finite.size else 0.0
         if noise <= 0 or not np.isfinite(noise):
             noise = 1.0
-        weight = 1.0 / (noise**2)
+        w_tile = 1.0 / (noise**2)
+
+        # Per-pixel weight plane; PB_CUTOFF is a numerical floor, not blanking
+        # science: below it PB^2 weight is negligible and the ratio-derived PB
+        # gets noisy.
+        wmap = w_tile * pb**2
+        invalid = ~np.isfinite(data) | ~np.isfinite(pb) | (pb < PB_CUTOFF)
+        wmap[invalid] = 0.0
+        num_plane = np.where(invalid, 0.0, wmap * data)
+        n_floor = int(((pb < PB_CUTOFF) & np.isfinite(pb)).sum())
+        log.info(
+            "  Sault weights: sigma_flat=%.4g, floor(PB<%.0f%%) zeroed %d px",
+            noise,
+            PB_CUTOFF * 100,
+            n_floor,
+        )
 
         in_wcs = WCS(hdr).celestial
         if reproject_interp is None:
-            reprojected, footprint = _nearest_reproject(data, in_wcs, out_wcs, (ny, nx))
+            num_reproj, footprint = _nearest_reproject(num_plane, in_wcs, out_wcs, (ny, nx))
+            w_reproj, _ = _nearest_reproject(wmap, in_wcs, out_wcs, (ny, nx))
         else:
             try:
-                reprojected, footprint = reproject_interp(
-                    (data, in_wcs),
+                num_reproj, footprint = reproject_interp(
+                    (num_plane, in_wcs),
+                    out_header,
+                    shape_out=(ny, nx),
+                )
+                w_reproj, _ = reproject_interp(
+                    (wmap, in_wcs),
                     out_header,
                     shape_out=(ny, nx),
                 )
@@ -180,9 +277,9 @@ def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.nda
                 log.warning("Reproject failed for %s: %s; skipping", Path(path).name, exc)
                 continue
 
-        valid = footprint.astype(bool) & np.isfinite(reprojected)
-        sum_image[valid] += weight * reprojected[valid]
-        sum_weight[valid] += weight
+        valid = footprint.astype(bool) & np.isfinite(num_reproj) & np.isfinite(w_reproj)
+        sum_image[valid] += num_reproj[valid]
+        sum_weight[valid] += w_reproj[valid]
 
     with np.errstate(invalid="ignore", divide="ignore"):
         return np.where(sum_weight > 0, sum_image / sum_weight, np.nan)

--- a/dsa110_continuum/mosaic/production.py
+++ b/dsa110_continuum/mosaic/production.py
@@ -17,6 +17,12 @@ Tiles are combined with a per-pixel inverse-variance (Sault) weighted mean:
 - ``PB_CUTOFF`` is a numerical weight floor (weight = 0 below it), not a
   science decision: with PB^2 weighting the excluded pixels would have
   carried <~4% weight anyway.
+- The accumulated weight plane (sum of per-tile inverse-variance weights,
+  units 1/(Jy/beam)^2) is available as a companion product: the effective
+  local noise is 1/sqrt(weight), which lets photometry/source-finding
+  threshold out single-coverage boundary pixels that per-pixel weighting
+  cannot repair (num/den is identically the tile value where only one tile
+  covers).
 - RA wrap uses a circular mean so 0/360-degree tile sets stay compact.
 - Day-batch callers can still split disjoint tile sets with a 10-degree RA gap.
 """
@@ -25,6 +31,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
@@ -35,6 +42,15 @@ CELL_ARCSEC = 6.0
 PB_CUTOFF = 0.2
 
 log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ProductionCoaddResult:
+    """Science mosaic planes on their shared output grid."""
+
+    mosaic: np.ndarray
+    weight: np.ndarray
+    wcs: WCS
 
 
 def _get_tile_center_ra(fits_path: str) -> float:
@@ -190,8 +206,13 @@ def _pb_map_for_tile(fits_path: str, data_pb: np.ndarray) -> tuple[np.ndarray | 
     return None, "none"
 
 
-def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.ndarray:
-    """Reproject tiles onto the common WCS and combine with per-pixel PB^2 weights.
+def coadd_tiles_with_weights(
+    fits_paths: list[str],
+    out_wcs: WCS,
+    ny: int,
+    nx: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return the Sault-weighted mosaic and accumulated inverse-variance plane.
 
     Inputs are PB-corrected tiles, so each pixel is an unbiased sky estimate
     with variance sigma_flat^2 / PB^2; the inverse-variance weight is
@@ -249,6 +270,7 @@ def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.nda
         invalid = ~np.isfinite(data) | ~np.isfinite(pb) | (pb < PB_CUTOFF)
         wmap[invalid] = 0.0
         num_plane = np.where(invalid, 0.0, wmap * data)
+        support_plane = (~invalid).astype(np.float64)
         n_floor = int(((pb < PB_CUTOFF) & np.isfinite(pb)).sum())
         log.info(
             "  Sault weights: sigma_flat=%.4g, floor(PB<%.0f%%) zeroed %d px",
@@ -261,6 +283,12 @@ def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.nda
         if reproject_interp is None:
             num_reproj, footprint = _nearest_reproject(num_plane, in_wcs, out_wcs, (ny, nx))
             w_reproj, _ = _nearest_reproject(wmap, in_wcs, out_wcs, (ny, nx))
+            support_reproj, _ = _nearest_reproject(
+                support_plane,
+                in_wcs,
+                out_wcs,
+                (ny, nx),
+            )
         else:
             try:
                 num_reproj, footprint = reproject_interp(
@@ -273,16 +301,39 @@ def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.nda
                     out_header,
                     shape_out=(ny, nx),
                 )
+                # Interpolating the zeroed weight plane alone can leak weight
+                # back into PB-rejected pixels from valid neighbours. Reproject
+                # the boolean support with nearest-neighbour sampling and use it
+                # as the authoritative cutoff mask on the output grid.
+                support_reproj, _ = reproject_interp(
+                    (support_plane, in_wcs),
+                    out_header,
+                    shape_out=(ny, nx),
+                    order="nearest-neighbor",
+                )
             except Exception as exc:
                 log.warning("Reproject failed for %s: %s; skipping", Path(path).name, exc)
                 continue
 
-        valid = footprint.astype(bool) & np.isfinite(num_reproj) & np.isfinite(w_reproj)
+        valid = (
+            footprint.astype(bool)
+            & np.isfinite(num_reproj)
+            & np.isfinite(w_reproj)
+            & np.isfinite(support_reproj)
+            & (support_reproj >= 0.5)
+        )
         sum_image[valid] += num_reproj[valid]
         sum_weight[valid] += w_reproj[valid]
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        return np.where(sum_weight > 0, sum_image / sum_weight, np.nan)
+        mosaic = np.where(sum_weight > 0, sum_image / sum_weight, np.nan)
+    return mosaic, sum_weight
+
+
+def coadd_tiles(fits_paths: list[str], out_wcs: WCS, ny: int, nx: int) -> np.ndarray:
+    """Compatibility wrapper returning only the Sault-weighted mosaic."""
+    mosaic, _weight = coadd_tiles_with_weights(fits_paths, out_wcs, ny, nx)
+    return mosaic
 
 
 def _nearest_reproject(
@@ -316,5 +367,70 @@ def _nearest_reproject(
 
 def build_epoch_coadd(fits_paths: list[str]) -> tuple[np.ndarray, WCS]:
     """Build the production coadd array and WCS for one hourly-epoch tile set."""
+    result = build_epoch_coadd_products(fits_paths)
+    return result.mosaic, result.wcs
+
+
+def build_epoch_coadd_products(fits_paths: list[str]) -> ProductionCoaddResult:
+    """Build the mosaic, accumulated weight plane, and WCS for one epoch."""
     out_wcs, ny, nx = build_common_wcs(fits_paths)
-    return coadd_tiles(fits_paths, out_wcs, ny, nx), out_wcs
+    mosaic, weight = coadd_tiles_with_weights(fits_paths, out_wcs, ny, nx)
+    return ProductionCoaddResult(mosaic=mosaic, weight=weight, wcs=out_wcs)
+
+
+def weight_path_for_mosaic(mosaic_path: str | Path) -> Path:
+    """Return the stable companion path ``<mosaic>.weights.fits``."""
+    return Path(mosaic_path).with_suffix(".weights.fits")
+
+
+def weight_map_is_valid(
+    weight_path: str | Path,
+    mosaic_path: str | Path,
+) -> bool:
+    """Return whether a companion weight FITS is readable and grid-aligned."""
+    try:
+        with fits.open(weight_path, memmap=True) as weight_hdul:
+            weight_hdu = weight_hdul[0]
+            if weight_hdu.data is None or weight_hdu.header.get("BUNIT") != "1/Jy^2":
+                return False
+            weight_shape = weight_hdu.data.squeeze().shape
+            weight_wcs = WCS(weight_hdu.header).celestial
+
+        with fits.open(mosaic_path, memmap=True) as mosaic_hdul:
+            mosaic_hdu = mosaic_hdul[0]
+            if mosaic_hdu.data is None:
+                return False
+            mosaic_shape = mosaic_hdu.data.squeeze().shape
+            mosaic_wcs = WCS(mosaic_hdu.header).celestial
+
+        return weight_shape == mosaic_shape and all(
+            np.allclose(weight_values, mosaic_values, rtol=0.0, atol=1e-10)
+            for weight_values, mosaic_values in (
+                (weight_wcs.wcs.crpix, mosaic_wcs.wcs.crpix),
+                (weight_wcs.wcs.crval, mosaic_wcs.wcs.crval),
+                (weight_wcs.wcs.cdelt, mosaic_wcs.wcs.cdelt),
+            )
+        )
+    except (OSError, ValueError, IndexError, TypeError):
+        return False
+
+
+def write_weight_map(
+    weight: np.ndarray,
+    out_wcs: WCS,
+    mosaic_path: str | Path,
+) -> Path:
+    """Write an accumulated inverse-variance plane beside its mosaic."""
+    weight_path = weight_path_for_mosaic(mosaic_path)
+    weight_path.parent.mkdir(parents=True, exist_ok=True)
+    header = out_wcs.to_header()
+    header["BUNIT"] = ("1/Jy^2", "Inverse variance of PB-corrected flux")
+    header["EXTNAME"] = ("WEIGHT", "Accumulated inverse-variance plane")
+    header["MOSAIC"] = (Path(mosaic_path).name, "Associated mosaic FITS")
+    header["HISTORY"] = "Effective local noise is 1/sqrt(weight) Jy/beam"
+    fits.PrimaryHDU(data=weight.astype(np.float32), header=header).writeto(
+        weight_path,
+        overwrite=True,
+    )
+    log.info("Epoch weight map written: %s", weight_path)
+    return weight_path

--- a/dsa110_continuum/mosaic/production.py
+++ b/dsa110_continuum/mosaic/production.py
@@ -393,17 +393,31 @@ def weight_map_is_valid(
             weight_hdu = weight_hdul[0]
             if weight_hdu.data is None or weight_hdu.header.get("BUNIT") != "1/Jy^2":
                 return False
-            weight_shape = weight_hdu.data.squeeze().shape
+            weight_data = weight_hdu.data.squeeze()
+            weight_shape = weight_data.shape
             weight_wcs = WCS(weight_hdu.header).celestial
 
         with fits.open(mosaic_path, memmap=True) as mosaic_hdul:
             mosaic_hdu = mosaic_hdul[0]
             if mosaic_hdu.data is None:
                 return False
-            mosaic_shape = mosaic_hdu.data.squeeze().shape
+            mosaic_data = mosaic_hdu.data.squeeze()
+            mosaic_shape = mosaic_data.shape
             mosaic_wcs = WCS(mosaic_hdu.header).celestial
 
-        return weight_shape == mosaic_shape and all(
+        if weight_shape != mosaic_shape or weight_data.ndim != 2:
+            return False
+        has_science_pixel = False
+        for weight_row, mosaic_row in zip(weight_data, mosaic_data, strict=True):
+            if not np.all(np.isfinite(weight_row)) or np.any(weight_row < 0):
+                return False
+            science = np.isfinite(mosaic_row)
+            if np.any(science):
+                has_science_pixel = True
+                if np.any(weight_row[science] <= 0):
+                    return False
+
+        return has_science_pixel and all(
             np.allclose(weight_values, mosaic_values, rtol=0.0, atol=1e-10)
             for weight_values, mosaic_values in (
                 (weight_wcs.wcs.crpix, mosaic_wcs.wcs.crpix),

--- a/dsa110_continuum/mosaic/production.py
+++ b/dsa110_continuum/mosaic/production.py
@@ -412,6 +412,8 @@ def weight_map_is_valid(
             if not np.all(np.isfinite(weight_row)) or np.any(weight_row < 0):
                 return False
             science = np.isfinite(mosaic_row)
+            if np.any(weight_row[~science] != 0):
+                return False
             if np.any(science):
                 has_science_pixel = True
                 if np.any(weight_row[science] <= 0):

--- a/dsa110_continuum/qa/provenance.py
+++ b/dsa110_continuum/qa/provenance.py
@@ -184,6 +184,7 @@ class RunManifest:
             "n_tiles": epoch_result.get("n_tiles"),
             "status": epoch_result.get("status"),
             "mosaic_path": epoch_result.get("mosaic_path"),
+            "weight_path": epoch_result.get("weight_path"),
             "peak": epoch_result.get("peak"),
             "rms": epoch_result.get("rms"),
             "n_sources": epoch_result.get("n_sources"),

--- a/dsa110_continuum/qa/run_report.py
+++ b/dsa110_continuum/qa/run_report.py
@@ -147,8 +147,8 @@ def _render_epoch_summary(manifest: RunManifest) -> str:
     lines = [
         "## Epoch summary",
         "",
-        "| Hour | Status | QA | n_tiles | Peak (Jy/beam) | RMS (mJy/beam) | Sources | Mosaic |",
-        "|---:|---|---|---:|---:|---:|---:|---|",
+        "| Hour | Status | QA | n_tiles | Peak (Jy/beam) | RMS (mJy/beam) | Sources | Mosaic | Weights |",
+        "|---:|---|---|---:|---:|---:|---:|---|---|",
     ]
     for ep in sorted(manifest.epochs, key=_epoch_sort_key):
         hour = ep.get("hour")
@@ -156,6 +156,7 @@ def _render_epoch_summary(manifest: RunManifest) -> str:
         rms = ep.get("rms")
         rms_mjy = (rms * 1000.0) if isinstance(rms, (int, float)) else None
         mosaic = ep.get("mosaic_path") or "(none)"
+        weight = ep.get("weight_path") or "(none)"
         lines.append(
             f"| {_fmt_hour(hour)} | {ep.get('status', '?')} | "
             f"{ep.get('qa_result') or '?'} | "
@@ -163,7 +164,7 @@ def _render_epoch_summary(manifest: RunManifest) -> str:
             f"{_fmt_float(peak, 4)} | "
             f"{_fmt_float(rms_mjy, 2)} | "
             f"{_fmt_int(ep.get('n_sources'))} | "
-            f"`{mosaic}` |"
+            f"`{mosaic}` | `{weight}` |"
         )
     return "\n".join(lines)
 

--- a/dsa110_continuum/validation/package_health.py
+++ b/dsa110_continuum/validation/package_health.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
+
 from dsa110_continuum.config import get_env_path
 
 
@@ -95,6 +96,7 @@ def check_core_dependencies() -> tuple[int, list[str]]:
     core_deps = [
         "numpy",
         "astropy",
+        "reproject",
         "pyuvdata",
         "fastapi",
         "pydantic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pyradiosky>=1.0.0",
     "numpy",
     "astropy",
+    "reproject>=0.19,<0.20",
     "pyuvsim",
     "matvis",
     "fastapi>=0.115.0",  # CVE-2024-38 fix (also pulls starlette>=0.40.0)
@@ -259,4 +260,3 @@ indent-style = "space"
 # These are runtime dependencies that work correctly but lack stubs
 reportMissingModuleSource = false
 reportMissingTypeStubs = false
-

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -106,6 +106,23 @@ def epoch_mosaic_path(paths: dict, date: str, hour: int) -> str:
     return f"{paths['stage_dir']}/{date}T{hour:02d}00_mosaic.fits"
 
 
+def epoch_weight_path(paths: dict, date: str, hour: int) -> str:
+    """Return the accumulated inverse-variance companion for an epoch mosaic."""
+    from dsa110_continuum.mosaic.production import weight_path_for_mosaic
+
+    return str(weight_path_for_mosaic(epoch_mosaic_path(paths, date, hour)))
+
+
+def epoch_weight_is_valid(paths: dict, date: str, hour: int) -> bool:
+    """Return whether an epoch's weight companion is readable and aligned."""
+    from dsa110_continuum.mosaic.production import weight_map_is_valid
+
+    return weight_map_is_valid(
+        epoch_weight_path(paths, date, hour),
+        epoch_mosaic_path(paths, date, hour),
+    )
+
+
 def epoch_phot_path(paths: dict, date: str, hour: int) -> str:
     return f"{paths['products_dir']}/{date}T{hour:02d}00_forced_phot.csv"
 
@@ -707,13 +724,19 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
     epoch_decisions: list[dict] = []
     for hour in epoch_hours:
         mosaic_path = epoch_mosaic_path(paths, date, hour)
+        weight_valid = epoch_weight_is_valid(paths, date, hour)
         rebuild = _epoch_should_rebuild(
             mosaic_path, prior_manifest, hour, args.force_recal,
         )
+        if os.path.exists(mosaic_path) and not weight_valid:
+            rebuild = True
         prior_v = (
             None if prior_manifest is None else prior_manifest.epoch_verdict(hour)
         )
-        if not rebuild:
+        if os.path.exists(mosaic_path) and not weight_valid:
+            reason = "missing or invalid weight companion"
+            action = "rebuild"
+        elif not rebuild:
             reason = f"prior verdict={prior_v}"
             action = "skip"
         elif args.force_recal:
@@ -1060,6 +1083,13 @@ def _build_epoch_coadd(epoch_tiles: list[str]) -> tuple[np.ndarray, WCS]:
     from dsa110_continuum.mosaic.production import build_epoch_coadd
 
     return build_epoch_coadd(epoch_tiles)
+
+
+def _build_epoch_coadd_products(epoch_tiles: list[str]):
+    """Build all production coadd planes through the canonical package entry."""
+    from dsa110_continuum.mosaic.production import build_epoch_coadd_products
+
+    return build_epoch_coadd_products(epoch_tiles)
 
 
 # ── Dec-strip guard ───────────────────────────────────────────────────────────
@@ -1847,8 +1877,10 @@ def main() -> None:
         )
 
         mosaic_path = epoch_mosaic_path(paths, date, hour)
+        weight_path = epoch_weight_path(paths, date, hour)
         phot_csv_path = epoch_phot_path(paths, date, hour)
         mosaic_fits_dst = Path(paths["products_dir"]) / Path(mosaic_path).name
+        weight_fits_dst = Path(paths["products_dir"]) / Path(weight_path).name
 
         # Decide (rebuild vs skip) based on prior-run verdict. A mosaic file
         # that exists but whose prior QA verdict was FAIL (or absent, meaning
@@ -1856,6 +1888,9 @@ def main() -> None:
         should_rebuild = _epoch_should_rebuild(
             mosaic_path, prior_manifest, hour, args.force_recal,
         )
+        if os.path.exists(mosaic_path) and not epoch_weight_is_valid(paths, date, hour):
+            log.warning("  Mosaic companion missing or invalid — rebuilding epoch %s: %s", label, weight_path)
+            should_rebuild = True
 
         # Remove stale epoch-level outputs before rebuilding so the fresh
         # mosaic / photometry CSV is unambiguous. --force-recal and a FAIL
@@ -1863,7 +1898,13 @@ def main() -> None:
         if should_rebuild and os.path.exists(mosaic_path):
             prior_v = None if prior_manifest is None else prior_manifest.epoch_verdict(hour)
             reason = "--force-recal" if args.force_recal else f"prior verdict={prior_v!s}"
-            for stale_path in (mosaic_path, phot_csv_path, str(mosaic_fits_dst)):
+            for stale_path in (
+                mosaic_path,
+                weight_path,
+                phot_csv_path,
+                str(mosaic_fits_dst),
+                str(weight_fits_dst),
+            ):
                 if os.path.exists(stale_path):
                     try:
                         os.remove(stale_path)
@@ -1879,17 +1920,24 @@ def main() -> None:
                 "label": label, "status": "skipped", "n_tiles": len(epoch_tiles),
                 "gaincal_status": _epoch_gaincal_status,
                 "qa_result": prior_v,  # carry prior verdict forward
+                "mosaic_path": mosaic_path,
+                "weight_path": weight_path if os.path.exists(weight_path) else None,
             })
             continue
 
         # Build mosaic
         try:
-            mosaic_arr, out_wcs = _build_epoch_coadd(epoch_tiles)
+            from dsa110_continuum.mosaic.production import write_weight_map
+
+            coadd_result = _build_epoch_coadd_products(epoch_tiles)
+            mosaic_arr, out_wcs = coadd_result.mosaic, coadd_result.wcs
             write_epoch_mosaic(
                 mosaic_arr, out_wcs, epoch_tiles, mosaic_path, date, hour, len(epoch_tiles),
                 cal_date=cal_date, cal_quality=manifest.cal_quality, git_sha=manifest.git_sha,
                 cal_selection=manifest.cal_selection or None,
             )
+            written_weight_path = write_weight_map(coadd_result.weight, out_wcs, mosaic_path)
+            weight_path = str(written_weight_path)
         except Exception as e:
             log.error("  Mosaic failed for epoch %s: %s", label, e)
             epoch_results.append({"label": label, "status": "failed", "n_tiles": len(epoch_tiles), "gaincal_status": _epoch_gaincal_status})
@@ -2010,6 +2058,11 @@ def main() -> None:
         elif mosaic_fits_src.exists() and (not mosaic_fits_dst.exists() or args.force_recal):
             shutil.copy2(str(mosaic_fits_src), str(mosaic_fits_dst))
             log.info("Archived mosaic FITS: %s", mosaic_fits_dst)
+        if should_archive and os.path.exists(weight_path) and (
+            not weight_fits_dst.exists() or args.force_recal
+        ):
+            shutil.copy2(weight_path, str(weight_fits_dst))
+            log.info("Archived mosaic weight FITS: %s", weight_fits_dst)
 
         epoch_results.append({
             "label": label,
@@ -2022,6 +2075,7 @@ def main() -> None:
             "n_sources": n_sources,
             "median_ratio": median_ratio,
             "mosaic_path": mosaic_path,
+            "weight_path": weight_path,
             "gaincal_status": _epoch_gaincal_status,
             "qa_result": epoch_qa.qa_result if epoch_qa else None,
         })

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -127,6 +127,21 @@ def epoch_phot_path(paths: dict, date: str, hour: int) -> str:
     return f"{paths['products_dir']}/{date}T{hour:02d}00_forced_phot.csv"
 
 
+def _archive_epoch_products(
+    mosaic_path: str | Path,
+    weight_path: str | Path,
+    mosaic_destination: str | Path,
+    weight_destination: str | Path,
+) -> None:
+    """Archive a mosaic and its validated weight companion as one product pair."""
+    from dsa110_continuum.mosaic.production import weight_map_is_valid
+
+    if not weight_map_is_valid(weight_path, mosaic_path):
+        raise RuntimeError(f"refusing to archive invalid weight companion: {weight_path}")
+    shutil.copy2(mosaic_path, mosaic_destination)
+    shutil.copy2(weight_path, weight_destination)
+
+
 # ── Timestamp parsing ─────────────────────────────────────────────────────────
 
 def timestamp_from_fits(fits_path: str) -> datetime | None:
@@ -2055,14 +2070,14 @@ def main() -> None:
         if not should_archive:
             log.warning("  QA FAIL — mosaic NOT archived to products: %s", label)
             manifest.gates.append({"gate": "archive", "verdict": "BLOCKED", "reason": f"epoch {label} QA FAIL"})
-        elif mosaic_fits_src.exists() and (not mosaic_fits_dst.exists() or args.force_recal):
-            shutil.copy2(str(mosaic_fits_src), str(mosaic_fits_dst))
-            log.info("Archived mosaic FITS: %s", mosaic_fits_dst)
-        if should_archive and os.path.exists(weight_path) and (
-            not weight_fits_dst.exists() or args.force_recal
-        ):
-            shutil.copy2(weight_path, str(weight_fits_dst))
-            log.info("Archived mosaic weight FITS: %s", weight_fits_dst)
+        elif mosaic_fits_src.exists():
+            _archive_epoch_products(
+                mosaic_fits_src,
+                weight_path,
+                mosaic_fits_dst,
+                weight_fits_dst,
+            )
+            log.info("Archived mosaic FITS pair: %s + %s", mosaic_fits_dst, weight_fits_dst)
 
         epoch_results.append({
             "label": label,

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -38,6 +38,7 @@ from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from uuid import uuid4
 
 # ── Load scripts/.env before anything else ───────────────────────────────────
 _ENV_FILE = Path(__file__).parent / ".env"
@@ -138,8 +139,25 @@ def _archive_epoch_products(
 
     if not weight_map_is_valid(weight_path, mosaic_path):
         raise RuntimeError(f"refusing to archive invalid weight companion: {weight_path}")
-    shutil.copy2(mosaic_path, mosaic_destination)
-    shutil.copy2(weight_path, weight_destination)
+    mosaic_destination = Path(mosaic_destination)
+    weight_destination = Path(weight_destination)
+    transaction_id = f"{os.getpid()}-{uuid4().hex}"
+    mosaic_temp = mosaic_destination.with_name(
+        f".{mosaic_destination.name}.{transaction_id}.tmp"
+    )
+    weight_temp = weight_destination.with_name(
+        f".{weight_destination.name}.{transaction_id}.tmp"
+    )
+    try:
+        # Stage both complete copies before replacing either destination. A
+        # copy failure therefore leaves the previously archived pair intact.
+        shutil.copy2(mosaic_path, mosaic_temp)
+        shutil.copy2(weight_path, weight_temp)
+        os.replace(mosaic_temp, mosaic_destination)
+        os.replace(weight_temp, weight_destination)
+    finally:
+        mosaic_temp.unlink(missing_ok=True)
+        weight_temp.unlink(missing_ok=True)
 
 
 # ── Timestamp parsing ─────────────────────────────────────────────────────────

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -511,6 +511,11 @@ def _should_skip_photometry(
     return False, ""
 
 
+def _should_archive_epoch(qa_verdict: str | None, archive_all: bool) -> bool:
+    """Archive only measured, non-failing QA results unless explicitly overridden."""
+    return archive_all or (qa_verdict is not None and qa_verdict != "FAIL")
+
+
 def _epoch_should_rebuild(
     mosaic_path: str,
     prior_manifest,
@@ -2095,12 +2100,19 @@ def main() -> None:
         except Exception as e:
             log.warning("  Could not write QA summary: %s", e)
 
-        # ── Archive gate — skip archive for QA-FAIL unless --archive-all ──────
+        # ── Archive gate — require a measured, non-failing QA verdict ─────────
         mosaic_fits_src = Path(mosaic_path)
-        should_archive = qa_verdict != "FAIL" or args.archive_all
+        should_archive = _should_archive_epoch(qa_verdict, args.archive_all)
         if not should_archive:
-            log.warning("  QA FAIL — mosaic NOT archived to products: %s", label)
-            manifest.gates.append({"gate": "archive", "verdict": "BLOCKED", "reason": f"epoch {label} QA FAIL"})
+            qa_reason = "QA unavailable" if qa_verdict is None else f"QA {qa_verdict}"
+            log.warning("  %s — mosaic NOT archived to products: %s", qa_reason, label)
+            manifest.gates.append(
+                {
+                    "gate": "archive",
+                    "verdict": "BLOCKED",
+                    "reason": f"epoch {label} {qa_reason}",
+                }
+            )
         elif mosaic_fits_src.exists():
             _archive_epoch_products(
                 mosaic_fits_src,

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -1940,9 +1940,9 @@ def main() -> None:
             log.warning("  Mosaic companion missing or invalid — rebuilding epoch %s: %s", label, weight_path)
             should_rebuild = True
 
-        # Remove stale epoch-level outputs before rebuilding so the fresh
-        # mosaic / photometry CSV is unambiguous. --force-recal and a FAIL
-        # prior verdict both use the same cleanup path.
+        # Remove stale staging outputs before rebuilding so the fresh mosaic /
+        # photometry CSV is unambiguous. Keep the last archived product pair
+        # until a newly QA-accepted pair replaces it transactionally.
         if should_rebuild and os.path.exists(mosaic_path):
             prior_v = None if prior_manifest is None else prior_manifest.epoch_verdict(hour)
             reason = "--force-recal" if args.force_recal else f"prior verdict={prior_v!s}"
@@ -1950,8 +1950,6 @@ def main() -> None:
                 mosaic_path,
                 weight_path,
                 phot_csv_path,
-                str(mosaic_fits_dst),
-                str(weight_fits_dst),
             ):
                 if os.path.exists(stale_path):
                     try:

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -148,16 +148,31 @@ def _archive_epoch_products(
     weight_temp = weight_destination.with_name(
         f".{weight_destination.name}.{transaction_id}.tmp"
     )
+    mosaic_backup = mosaic_destination.with_name(
+        f".{mosaic_destination.name}.{transaction_id}.bak"
+    )
+    mosaic_replaced = False
     try:
         # Stage both complete copies before replacing either destination. A
         # copy failure therefore leaves the previously archived pair intact.
         shutil.copy2(mosaic_path, mosaic_temp)
         shutil.copy2(weight_path, weight_temp)
+        if mosaic_destination.exists():
+            os.link(mosaic_destination, mosaic_backup)
         os.replace(mosaic_temp, mosaic_destination)
+        mosaic_replaced = True
         os.replace(weight_temp, weight_destination)
+    except Exception:
+        if mosaic_replaced:
+            if mosaic_backup.exists():
+                os.replace(mosaic_backup, mosaic_destination)
+            else:
+                mosaic_destination.unlink(missing_ok=True)
+        raise
     finally:
         mosaic_temp.unlink(missing_ok=True)
         weight_temp.unlink(missing_ok=True)
+        mosaic_backup.unlink(missing_ok=True)
 
 
 # ── Timestamp parsing ─────────────────────────────────────────────────────────

--- a/tests/test_mosaic_production_coadd.py
+++ b/tests/test_mosaic_production_coadd.py
@@ -117,3 +117,30 @@ def test_batch_epoch_coadd_helper_calls_package_entry(monkeypatch):
     assert called["tile_paths"] == ["tile-a.fits", "tile-b.fits"]
     assert mosaic.shape == (2, 2)
     assert isinstance(out_wcs, WCS)
+
+
+def test_batch_epoch_product_helper_calls_product_entry(monkeypatch):
+    import batch_pipeline as bp
+    import dsa110_continuum.mosaic.production as production
+
+    expected = production.ProductionCoaddResult(
+        mosaic=np.zeros((2, 2)),
+        weight=np.ones((2, 2)),
+        wcs=WCS(naxis=2),
+    )
+    called: dict[str, list[str]] = {}
+
+    def fake_build_epoch_coadd_products(tile_paths: list[str]):
+        called["tile_paths"] = tile_paths
+        return expected
+
+    monkeypatch.setattr(
+        production,
+        "build_epoch_coadd_products",
+        fake_build_epoch_coadd_products,
+    )
+
+    result = bp._build_epoch_coadd_products(["tile-a.fits", "tile-b.fits"])
+
+    assert called["tile_paths"] == ["tile-a.fits", "tile-b.fits"]
+    assert result is expected

--- a/tests/test_mosaic_production_coadd.py
+++ b/tests/test_mosaic_production_coadd.py
@@ -219,3 +219,50 @@ def test_archive_epoch_products_copy_failure_preserves_existing_pair(tmp_path, m
     assert np.all(fits.getdata(destination_mosaic) == 1.0)
     assert np.all(fits.getdata(destination_weight) == 1.0)
     assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_archive_epoch_products_replace_failure_rolls_back_pair(tmp_path, monkeypatch):
+    import batch_pipeline as bp
+    from dsa110_continuum.mosaic.production import write_weight_map
+
+    source_mosaic = _write_tile(tmp_path / "stage_mosaic.fits", ra_deg=10.0, value=2.0)
+    source_weight = write_weight_map(
+        np.full((16, 16), 4.0),
+        WCS(fits.getheader(source_mosaic)).celestial,
+        source_mosaic,
+    )
+    destination_mosaic = _write_tile(
+        tmp_path / "product_mosaic.fits",
+        ra_deg=10.0,
+        value=1.0,
+    )
+    destination_weight = write_weight_map(
+        np.ones((16, 16)),
+        WCS(fits.getheader(destination_mosaic)).celestial,
+        destination_mosaic,
+    )
+
+    real_replace = bp.os.replace
+    calls = 0
+
+    def fail_second_replace(source, destination):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("synthetic weight replacement failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(bp.os, "replace", fail_second_replace)
+
+    with np.testing.assert_raises_regex(OSError, "synthetic weight replacement failure"):
+        bp._archive_epoch_products(
+            source_mosaic,
+            source_weight,
+            destination_mosaic,
+            destination_weight,
+        )
+
+    assert np.all(fits.getdata(destination_mosaic) == 1.0)
+    assert np.all(fits.getdata(destination_weight) == 1.0)
+    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob(".*.bak"))

--- a/tests/test_mosaic_production_coadd.py
+++ b/tests/test_mosaic_production_coadd.py
@@ -173,3 +173,49 @@ def test_archive_epoch_products_overwrites_mosaic_and_weight_as_a_pair(tmp_path)
 
     assert np.all(fits.getdata(destination_mosaic) == 2.0)
     assert np.all(fits.getdata(destination_weight) == 4.0)
+
+
+def test_archive_epoch_products_copy_failure_preserves_existing_pair(tmp_path, monkeypatch):
+    import batch_pipeline as bp
+    from dsa110_continuum.mosaic.production import write_weight_map
+
+    source_mosaic = _write_tile(tmp_path / "stage_mosaic.fits", ra_deg=10.0, value=2.0)
+    source_weight = write_weight_map(
+        np.full((16, 16), 4.0),
+        WCS(fits.getheader(source_mosaic)).celestial,
+        source_mosaic,
+    )
+    destination_mosaic = _write_tile(
+        tmp_path / "product_mosaic.fits",
+        ra_deg=10.0,
+        value=1.0,
+    )
+    destination_weight = write_weight_map(
+        np.ones((16, 16)),
+        WCS(fits.getheader(destination_mosaic)).celestial,
+        destination_mosaic,
+    )
+
+    real_copy2 = bp.shutil.copy2
+    calls = 0
+
+    def fail_second_copy(source, destination):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("synthetic weight copy failure")
+        return real_copy2(source, destination)
+
+    monkeypatch.setattr(bp.shutil, "copy2", fail_second_copy)
+
+    with np.testing.assert_raises_regex(OSError, "synthetic weight copy failure"):
+        bp._archive_epoch_products(
+            source_mosaic,
+            source_weight,
+            destination_mosaic,
+            destination_weight,
+        )
+
+    assert np.all(fits.getdata(destination_mosaic) == 1.0)
+    assert np.all(fits.getdata(destination_weight) == 1.0)
+    assert not list(tmp_path.glob(".*.tmp"))

--- a/tests/test_mosaic_production_coadd.py
+++ b/tests/test_mosaic_production_coadd.py
@@ -144,3 +144,32 @@ def test_batch_epoch_product_helper_calls_product_entry(monkeypatch):
 
     assert called["tile_paths"] == ["tile-a.fits", "tile-b.fits"]
     assert result is expected
+
+
+def test_archive_epoch_products_overwrites_mosaic_and_weight_as_a_pair(tmp_path):
+    import batch_pipeline as bp
+    from dsa110_continuum.mosaic.production import write_weight_map
+
+    source_mosaic = _write_tile(tmp_path / "stage_mosaic.fits", ra_deg=10.0, value=2.0)
+    source_weight = write_weight_map(
+        np.full((16, 16), 4.0),
+        WCS(fits.getheader(source_mosaic)).celestial,
+        source_mosaic,
+    )
+    destination_mosaic = _write_tile(
+        tmp_path / "product_mosaic.fits",
+        ra_deg=10.0,
+        value=1.0,
+    )
+    destination_weight = tmp_path / "product_mosaic.weights.fits"
+    fits.PrimaryHDU(data=np.ones((16, 16))).writeto(destination_weight)
+
+    bp._archive_epoch_products(
+        source_mosaic,
+        source_weight,
+        destination_mosaic,
+        destination_weight,
+    )
+
+    assert np.all(fits.getdata(destination_mosaic) == 2.0)
+    assert np.all(fits.getdata(destination_weight) == 4.0)

--- a/tests/test_mosaic_sault_coadd.py
+++ b/tests/test_mosaic_sault_coadd.py
@@ -1,0 +1,180 @@
+"""Tests for per-pixel Sault (inverse-variance PB^2) weighting in the production coadd.
+
+Tiles written here are PB-corrected (`-image-pb.fits`) with a flat-noise
+sibling (`-image.fits` = sky * PB), matching the WSClean product layout the
+production coadd consumes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from astropy.wcs import WCS
+from dsa110_continuum.mosaic.production import (
+    PB_CUTOFF,
+    _pb_map_for_tile,
+    coadd_tiles,
+)
+
+SHAPE = (32, 32)
+
+
+def _tile_wcs(ra_deg: float = 10.0, dec_deg: float = 16.0) -> WCS:
+    ny, nx = SHAPE
+    wcs = WCS(naxis=2)
+    wcs.wcs.crpix = [nx / 2 + 0.5, ny / 2 + 0.5]
+    wcs.wcs.crval = [ra_deg, dec_deg]
+    wcs.wcs.cdelt = [-1.0 / 60.0, 1.0 / 60.0]
+    wcs.wcs.ctype = ["RA---SIN", "DEC--SIN"]
+    return wcs
+
+
+def _gaussian_pb(center: tuple[float, float], fwhm_px: float = 20.0) -> np.ndarray:
+    yy, xx = np.indices(SHAPE, dtype=np.float64)
+    r2 = (yy - center[0]) ** 2 + (xx - center[1]) ** 2
+    return np.exp(-4.0 * np.log(2.0) * r2 / fwhm_px**2)
+
+
+def _write_pair(
+    tmp_path: Path,
+    stem: str,
+    sky: np.ndarray,
+    pb: np.ndarray,
+    *,
+    write_flat: bool = True,
+) -> Path:
+    """Write `-image-pb.fits` (= sky) and optionally `-image.fits` (= sky * PB)."""
+    header = _tile_wcs().to_header()
+    pb_path = tmp_path / f"{stem}-image-pb.fits"
+    fits.PrimaryHDU(data=sky.astype(np.float64), header=header).writeto(pb_path)
+    if write_flat:
+        flat_path = tmp_path / f"{stem}-image.fits"
+        fits.PrimaryHDU(data=(sky * pb).astype(np.float64), header=header).writeto(flat_path)
+    return pb_path
+
+
+def _coadd(paths: list[Path]) -> np.ndarray:
+    wcs = _tile_wcs()
+    ny, nx = SHAPE
+    return coadd_tiles([str(p) for p in paths], wcs, ny, nx)
+
+
+def test_pb_ratio_recovers_applied_beam(tmp_path):
+    pb = _gaussian_pb((16.0, 16.0))
+    sky = np.full(SHAPE, 2.5)
+    tile = _write_pair(tmp_path, "t0", sky, pb)
+
+    with fits.open(tile) as hdul:
+        data = hdul[0].data.squeeze().astype(np.float64)
+    recovered, source = _pb_map_for_tile(str(tile), data)
+
+    assert source == "image/image-pb ratio"
+    assert np.allclose(recovered, pb / pb.max(), rtol=1e-10, equal_nan=True)
+
+
+def test_constant_sky_is_flux_preserved(tmp_path):
+    """A constant sky must come back unchanged — catches double PB correction."""
+    sky_value = 3.0
+    sky = np.full(SHAPE, sky_value)
+    tiles = [
+        _write_pair(tmp_path, "a", sky, _gaussian_pb((16.0, 10.0))),
+        _write_pair(tmp_path, "b", sky, _gaussian_pb((16.0, 22.0))),
+    ]
+
+    mosaic = _coadd(tiles)
+
+    covered = np.isfinite(mosaic)
+    assert covered.any()
+    assert np.allclose(mosaic[covered], sky_value, rtol=1e-6)
+
+
+def test_overlap_pixel_matches_pb_squared_formula(tmp_path):
+    """At an overlap pixel the mosaic must equal sum(PB^2 I) / sum(PB^2)."""
+    pb_a = _gaussian_pb((16.0, 10.0))
+    pb_b = _gaussian_pb((16.0, 22.0))
+    tiles = [
+        _write_pair(tmp_path, "a", np.full(SHAPE, 2.0), pb_a),
+        _write_pair(tmp_path, "b", np.full(SHAPE, 6.0), pb_b),
+    ]
+
+    mosaic = _coadd(tiles)
+
+    # Replicate the coadd's own scalar weight: 1 / std(flat-noise plane)^2,
+    # measured over the central box (margin 200 covers the whole 32x32 tile).
+    def w_tile(sky_value: float, pb: np.ndarray) -> float:
+        return 1.0 / float(np.std(sky_value * pb)) ** 2
+
+    probe = (16, 16)
+    wa = w_tile(2.0, pb_a) * pb_a[probe] ** 2
+    wb = w_tile(6.0, pb_b) * pb_b[probe] ** 2
+    assert pb_a[probe] > PB_CUTOFF and pb_b[probe] > PB_CUTOFF
+    expected = (wa * 2.0 + wb * 6.0) / (wa + wb)
+    assert mosaic[probe] == pytest.approx(expected, rel=1e-6)
+
+
+def test_pb_floor_excludes_low_gain_tile(tmp_path):
+    """Below PB_CUTOFF a tile's weight is zero — the other tile wins outright."""
+    pb_a = _gaussian_pb((16.0, 10.0))
+    pb_b = np.full(SHAPE, 0.9)
+    probe = (16, 30)
+    assert pb_a[probe] < PB_CUTOFF
+    tiles = [
+        _write_pair(tmp_path, "a", np.full(SHAPE, 2.0), pb_a),
+        _write_pair(tmp_path, "b", np.full(SHAPE, 6.0), pb_b),
+    ]
+
+    mosaic = _coadd(tiles)
+
+    assert mosaic[probe] == pytest.approx(6.0, rel=1e-6)
+
+
+def test_all_tiles_below_floor_yields_nan(tmp_path):
+    """Preserves the legacy blanking pin: no weight anywhere -> NaN pixel.
+
+    The ratio-derived PB is peak-normalized, so the background is set to 1.0
+    to keep the low pixel's post-normalization value below the floor.
+    """
+    pb = np.full(SHAPE, 1.0)
+    pb[8, 8] = PB_CUTOFF - 0.05
+    tiles = [_write_pair(tmp_path, "a", np.full(SHAPE, 1.0), pb)]
+
+    mosaic = _coadd(tiles)
+
+    assert np.isnan(mosaic[8, 8])
+    assert np.isfinite(mosaic[7, 7])
+
+
+def test_band_average_beam_fallback(tmp_path):
+    """Without a flat sibling, the PB is the mean of all -beam-N maps, not beam-0."""
+    sky = np.full(SHAPE, 1.0)
+    tile = _write_pair(tmp_path, "t0", sky, np.ones(SHAPE), write_flat=False)
+    header = _tile_wcs().to_header()
+    beam0 = np.full(SHAPE, 0.4)
+    beam9 = np.full(SHAPE, 0.8)
+    fits.PrimaryHDU(data=beam0, header=header).writeto(tmp_path / "t0-beam-0.fits")
+    fits.PrimaryHDU(data=beam9, header=header).writeto(tmp_path / "t0-beam-9.fits")
+
+    with fits.open(tile) as hdul:
+        data = hdul[0].data.squeeze().astype(np.float64)
+    pb, source = _pb_map_for_tile(str(tile), data)
+
+    assert "band-average of 2" in source
+    # mean = 0.6, normalized to peak -> flat 1.0 map
+    assert np.allclose(pb, 1.0)
+
+
+def test_no_pb_source_falls_back_to_uniform_weight(tmp_path):
+    """No flat sibling and no beam maps: tiles combine with uniform weight."""
+    tiles = [
+        _write_pair(tmp_path, "a", np.full(SHAPE, 1.0), np.ones(SHAPE), write_flat=False),
+        _write_pair(tmp_path, "b", np.full(SHAPE, 3.0), np.ones(SHAPE), write_flat=False),
+    ]
+
+    mosaic = _coadd(tiles)
+
+    covered = np.isfinite(mosaic)
+    assert covered.any()
+    assert np.allclose(mosaic[covered], 2.0, rtol=1e-6)

--- a/tests/test_mosaic_sault_coadd.py
+++ b/tests/test_mosaic_sault_coadd.py
@@ -278,3 +278,18 @@ def test_weight_map_validation_rejects_unusable_science_weights(tmp_path, bad_va
     fits.PrimaryHDU(data=weight, header=header).writeto(weight_path)
 
     assert not weight_map_is_valid(weight_path, mosaic_path)
+
+
+def test_weight_map_validation_rejects_weight_outside_science_footprint(tmp_path):
+    wcs = _tile_wcs(10.0)
+    mosaic_path = tmp_path / "mosaic.fits"
+    mosaic = np.ones(SHAPE)
+    mosaic[0, 0] = np.nan
+    fits.PrimaryHDU(data=mosaic, header=wcs.to_header()).writeto(mosaic_path)
+
+    weight_path = tmp_path / "mosaic.weights.fits"
+    header = wcs.to_header()
+    header["BUNIT"] = "1/Jy^2"
+    fits.PrimaryHDU(data=np.ones(SHAPE), header=header).writeto(weight_path)
+
+    assert not weight_map_is_valid(weight_path, mosaic_path)

--- a/tests/test_mosaic_sault_coadd.py
+++ b/tests/test_mosaic_sault_coadd.py
@@ -16,7 +16,13 @@ from astropy.wcs import WCS
 from dsa110_continuum.mosaic.production import (
     PB_CUTOFF,
     _pb_map_for_tile,
+    build_epoch_coadd,
+    build_epoch_coadd_products,
     coadd_tiles,
+    coadd_tiles_with_weights,
+    weight_map_is_valid,
+    weight_path_for_mosaic,
+    write_weight_map,
 )
 
 SHAPE = (32, 32)
@@ -178,3 +184,71 @@ def test_no_pb_source_falls_back_to_uniform_weight(tmp_path):
     covered = np.isfinite(mosaic)
     assert covered.any()
     assert np.allclose(mosaic[covered], 2.0, rtol=1e-6)
+
+
+def test_product_result_preserves_legacy_mosaic_and_exposes_weight(tmp_path):
+    """The additive product API must not change the legacy tuple result."""
+    sky = np.full(SHAPE, 3.0)
+    tiles = [
+        _write_pair(tmp_path, "a", sky, _gaussian_pb((16.0, 10.0))),
+        _write_pair(tmp_path, "b", sky, _gaussian_pb((16.0, 22.0))),
+    ]
+    paths = [str(path) for path in tiles]
+
+    result = build_epoch_coadd_products(paths)
+    legacy_mosaic, legacy_wcs = build_epoch_coadd(paths)
+
+    assert np.allclose(result.mosaic, legacy_mosaic, equal_nan=True)
+    assert np.allclose(result.wcs.wcs.crval, legacy_wcs.wcs.crval)
+    assert result.weight.shape == result.mosaic.shape
+    assert np.all(result.weight[np.isfinite(result.mosaic)] > 0)
+
+
+def test_coadd_tiles_with_weights_matches_compatibility_wrapper(tmp_path):
+    sky = np.full(SHAPE, 2.0)
+    tile = _write_pair(tmp_path, "a", sky, _gaussian_pb((16.0, 16.0)))
+    wcs = _tile_wcs()
+
+    mosaic, weight = coadd_tiles_with_weights([str(tile)], wcs, *SHAPE)
+
+    assert np.allclose(mosaic, coadd_tiles([str(tile)], wcs, *SHAPE), equal_nan=True)
+    assert np.nanmax(weight) > 0
+
+
+def test_write_weight_map_uses_stable_name_aligned_wcs_and_units(tmp_path):
+    mosaic_path = tmp_path / "2026-01-25T2200_mosaic.fits"
+    weight = np.full(SHAPE, 4.0, dtype=np.float64)
+    wcs = _tile_wcs()
+    fits.PrimaryHDU(data=np.ones(SHAPE), header=wcs.to_header()).writeto(mosaic_path)
+
+    written = write_weight_map(weight, wcs, mosaic_path)
+
+    assert written == weight_path_for_mosaic(mosaic_path)
+    assert written.name == "2026-01-25T2200_mosaic.weights.fits"
+    with fits.open(written) as hdul:
+        assert np.allclose(hdul[0].data, weight)
+        assert hdul[0].header["BUNIT"] == "1/Jy^2"
+        assert hdul[0].header["MOSAIC"] == mosaic_path.name
+        assert np.allclose(WCS(hdul[0].header).celestial.wcs.crval, wcs.wcs.crval)
+        assert np.allclose(1.0 / np.sqrt(hdul[0].data), 0.5)
+    assert weight_map_is_valid(written, mosaic_path)
+
+
+def test_weight_map_validation_rejects_missing_corrupt_or_misaligned_companion(tmp_path):
+    mosaic_path = tmp_path / "epoch_mosaic.fits"
+    wcs = _tile_wcs()
+    fits.PrimaryHDU(data=np.ones(SHAPE), header=wcs.to_header()).writeto(mosaic_path)
+
+    missing = tmp_path / "missing.weights.fits"
+    assert not weight_map_is_valid(missing, mosaic_path)
+
+    corrupt = tmp_path / "corrupt.weights.fits"
+    corrupt.write_bytes(b"not a FITS file")
+    assert not weight_map_is_valid(corrupt, mosaic_path)
+
+    shifted_wcs = _tile_wcs(ra_deg=11.0)
+    misaligned = tmp_path / "misaligned.weights.fits"
+    header = shifted_wcs.to_header()
+    header["BUNIT"] = "1/Jy^2"
+    fits.PrimaryHDU(data=np.ones(SHAPE), header=header).writeto(misaligned)
+    assert not weight_map_is_valid(misaligned, mosaic_path)

--- a/tests/test_mosaic_sault_coadd.py
+++ b/tests/test_mosaic_sault_coadd.py
@@ -252,3 +252,19 @@ def test_weight_map_validation_rejects_missing_corrupt_or_misaligned_companion(t
     header["BUNIT"] = "1/Jy^2"
     fits.PrimaryHDU(data=np.ones(SHAPE), header=header).writeto(misaligned)
     assert not weight_map_is_valid(misaligned, mosaic_path)
+
+
+@pytest.mark.parametrize("bad_value", [0.0, -1.0, np.nan])
+def test_weight_map_validation_rejects_unusable_science_weights(tmp_path, bad_value):
+    mosaic_path = tmp_path / "epoch_mosaic.fits"
+    weight_path = tmp_path / "epoch_mosaic.weights.fits"
+    wcs = _tile_wcs()
+    fits.PrimaryHDU(data=np.ones(SHAPE), header=wcs.to_header()).writeto(mosaic_path)
+
+    weight = np.ones(SHAPE)
+    weight[8, 8] = bad_value
+    header = wcs.to_header()
+    header["BUNIT"] = "1/Jy^2"
+    fits.PrimaryHDU(data=weight, header=header).writeto(weight_path)
+
+    assert not weight_map_is_valid(weight_path, mosaic_path)

--- a/tests/test_mosaic_sault_coadd.py
+++ b/tests/test_mosaic_sault_coadd.py
@@ -253,6 +253,16 @@ def test_weight_map_validation_rejects_missing_corrupt_or_misaligned_companion(t
     fits.PrimaryHDU(data=np.ones(SHAPE), header=header).writeto(misaligned)
     assert not weight_map_is_valid(misaligned, mosaic_path)
 
+    wrong_projection = tmp_path / "wrong_projection.weights.fits"
+    projection_header = wcs.to_header()
+    projection_header["CTYPE1"] = "RA---TAN"
+    projection_header["CTYPE2"] = "DEC--TAN"
+    projection_header["BUNIT"] = "1/Jy^2"
+    fits.PrimaryHDU(data=np.ones(SHAPE), header=projection_header).writeto(
+        wrong_projection
+    )
+    assert not weight_map_is_valid(wrong_projection, mosaic_path)
+
 
 @pytest.mark.parametrize("bad_value", [0.0, -1.0, np.nan])
 def test_weight_map_validation_rejects_unusable_science_weights(tmp_path, bad_value):

--- a/tests/test_package_health.py
+++ b/tests/test_package_health.py
@@ -1,0 +1,23 @@
+"""Tests for package health dependency checks."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from dsa110_continuum.validation import package_health
+
+
+def test_core_dependency_check_includes_production_reprojection(monkeypatch):
+    imported: list[str] = []
+
+    def fake_import(name: str):
+        imported.append(name)
+        return SimpleNamespace(__version__="test")
+
+    monkeypatch.setattr(package_health.importlib, "import_module", fake_import)
+
+    passed, missing = package_health.check_core_dependencies()
+
+    assert "reproject" in imported
+    assert passed == len(imported)
+    assert missing == []

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -15,7 +15,15 @@ def test_manifest_roundtrip(tmp_path):
     m.gaincal_status = "ok"
     m.record_tile("/stage/ms/a.ms", "/stage/img/a.fits", "ok", 142.3)
     m.record_tile("/stage/ms/b.ms", None, "failed", 1800.0, error="timeout")
-    m.record_epoch(0, {"n_tiles": 13, "status": "ok", "peak": 0.5, "rms": 0.001, "qa_result": "PASS"})
+    m.record_epoch(0, {
+        "n_tiles": 13,
+        "status": "ok",
+        "mosaic_path": "/stage/example_mosaic.fits",
+        "weight_path": "/stage/example_mosaic.weights.fits",
+        "peak": 0.5,
+        "rms": 0.001,
+        "qa_result": "PASS",
+    })
     m.finalize(300.5)
 
     out = m.save(str(tmp_path))
@@ -33,6 +41,7 @@ def test_manifest_roundtrip(tmp_path):
     assert data["wall_time_sec"] == 300.5
     assert len(data["tiles"]) == 2
     assert data["tiles"][0]["status"] == "ok"
+    assert data["epochs"][0]["weight_path"].endswith(".weights.fits")
     assert data["tiles"][1]["error"] == "timeout"
     assert len(data["epochs"]) == 1
     assert data["epochs"][0]["qa_result"] == "PASS"

--- a/tests/test_qa_default_strict.py
+++ b/tests/test_qa_default_strict.py
@@ -85,6 +85,25 @@ def test_warn_verdict_runs_photometry():
         assert skip is False, f"unexpected skip for verdict={verdict!r}"
 
 
+# ─── Archive QA decision matrix ──────────────────────────────────────────────
+
+
+def test_archive_requires_measured_non_failing_qa():
+    import batch_pipeline as bp
+
+    assert bp._should_archive_epoch("PASS", False) is True
+    assert bp._should_archive_epoch("WARN", False) is True
+    assert bp._should_archive_epoch("FAIL", False) is False
+    assert bp._should_archive_epoch(None, False) is False
+
+
+def test_archive_all_overrides_failed_or_unavailable_qa():
+    import batch_pipeline as bp
+
+    assert bp._should_archive_epoch("FAIL", True) is True
+    assert bp._should_archive_epoch(None, True) is True
+
+
 # ─── Lenient-QA gate emission ────────────────────────────────────────────────
 
 

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -36,12 +36,14 @@ def _make_clean_manifest() -> RunManifest:
     m.record_epoch(2, {
         "n_tiles": 11, "status": "ok",
         "mosaic_path": "/stage/img/2026-01-25T0200_mosaic.fits",
+        "weight_path": "/stage/img/2026-01-25T0200_mosaic.weights.fits",
         "peak": 0.523, "rms": 0.0012, "n_sources": 1234,
         "qa_result": "PASS",
     })
     m.record_epoch(22, {
         "n_tiles": 11, "status": "ok",
         "mosaic_path": "/stage/img/2026-01-25T2200_mosaic.fits",
+        "weight_path": "/stage/img/2026-01-25T2200_mosaic.weights.fits",
         "peak": 12.5, "rms": 0.001, "n_sources": 4567,
         "qa_result": "PASS",
     })
@@ -98,6 +100,14 @@ def test_clean_run_qa_fail_section_says_none():
     assert "## QA-FAIL epochs (photometry skipped)" in text
     qa_section = text.split("## QA-FAIL")[1].split("## Quarantined")[0]
     assert "(none)" in qa_section
+
+
+def test_epoch_summary_lists_weight_companions():
+    m = _make_clean_manifest()
+    text = render_run_report(m, "/data/products/2026-01-25")
+
+    assert "2026-01-25T0200_mosaic.weights.fits" in text
+    assert "2026-01-25T2200_mosaic.weights.fits" in text
 
 
 # ─── DEGRADED with gates ─────────────────────────────────────────────────────


### PR DESCRIPTION
Refs #96

## Summary

- add a typed production coadd result while preserving the existing array and `(array, WCS)` compatibility APIs
- write and validate `<mosaic>.weights.fits` inverse-variance companions with matched WCS, support footprint, units, and provenance
- carry mosaic/weight pairs through rebuild, archival, manifests, summaries, and reports with rollback-safe paired replacement
- declare production `reproject>=0.19,<0.20` support and report missing production reprojection in package health

## Validation

- H17 CASA full suite: **1249 passed, 2 skipped**
- scoped Ruff, import migration, glossary verification, and `git diff --check`: passed
- independent final whole-diff review: no actionable findings
- real H17 rebuild of the 11-tile `2026-01-25T2200` Sault reference epoch:
  - output WCS equals the validated baseline
  - weight product is finite, nonnegative, positive on every science pixel, and zero outside the science footprint
  - 99.87% of common science pixels are bit-identical; the 0.13% delta is confined to the intentional PB-cutoff leakage correction (4,370 leaked support pixels removed)
  - median measured/predicted block-noise ratio: 0.82 across 274 blocks

Durable validation evidence is retained on H17 under `/data/dsa110-continuum/outputs/green-refactor-issue-96/`. No long-lived pipeline process requires restart; fresh batch invocations consume the merged behavior.