### PR TITLE
Recover static monitor deployment and freshness

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,13 @@ on:
     branches: [main]
     paths:
       - "docs/quarto/**"
+      - "tools/dsacamera-monitor/**"
       - ".github/workflows/docs.yml"
   pull_request:
     branches: [main]
     paths:
       - "docs/quarto/**"
+      - "tools/dsacamera-monitor/**"
       - ".github/workflows/docs.yml"
   schedule:
     - cron: "*/15 * * * *"
@@ -46,6 +48,13 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: "1.6.39"
+
+      - name: Test monitor scanner
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install "./tools/dsacamera-monitor[dev]"
+          python -m pytest tools/dsacamera-monitor/tests -q
 
       - name: Render site
         working-directory: docs/quarto

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,18 +12,24 @@ on:
       - "docs/quarto/**"
       - ".github/workflows/docs.yml"
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "*/15 * * * *"
   workflow_dispatch:
+    inputs:
+      fast_recovery:
+        description: "Force stat-free, metadata-free recovery output"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Only one deployment at a time; keep in-progress runs to avoid partial churn.
+# Only the newest monitor deployment is useful; cancel obsolete work promptly.
 concurrency:
   group: "pages-multi-monitor"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   pr_render:
@@ -97,6 +103,8 @@ jobs:
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
       MONITOR_OUT_DIR: .monitor_site
+      POINTING_METADATA_ENABLED: ${{ vars.MONITOR_POINTING_METADATA_ENABLED }}
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -118,7 +126,32 @@ jobs:
           set -euo pipefail
           rm -rf "${MONITOR_OUT_DIR}"
           mkdir -p "${MONITOR_OUT_DIR}"
-          dsacamera-incoming-scan --root "${{ matrix.source_root }}" --out "${MONITOR_OUT_DIR}" --pointing-timeseries --pointing-timeseries-max-files 5000
+          scan_args=(
+            --root "${{ matrix.source_root }}"
+            --out "${MONITOR_OUT_DIR}"
+            --no-stat
+          )
+
+          metadata_enabled="${POINTING_METADATA_ENABLED:-false}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.fast_recovery }}" == "true" ]]; then
+            metadata_enabled="false"
+          fi
+
+          if [[ "${metadata_enabled,,}" == "true" ]]; then
+            cache_path="${HOME}/.cache/dsa110-continuum/monitor/${{ matrix.monitor_slug }}-pointing.sqlite3"
+            mkdir -p "$(dirname "${cache_path}")"
+            scan_args+=(
+              --pointing-timeseries
+              --pointing-timeseries-max-files 5000
+              --metadata-cache "${cache_path}"
+              --metadata-update-limit 100
+              --metadata-retry-seconds 3600
+            )
+          else
+            scan_args+=(--no-hdf5-metadata)
+          fi
+
+          dsacamera-incoming-scan "${scan_args[@]}"
 
       - name: Validate monitor artifact contract
         shell: bash
@@ -152,8 +185,39 @@ jobs:
               raise SystemExit("manifest schema_version must be int")
           if not isinstance(manifest.get("by_day"), list):
               raise SystemExit("manifest by_day must be list")
-          if manifest.get("options", {}).get("no_stat", True):
-              raise SystemExit("manifest options.no_stat must be false for KPI size/mtime support")
+          options = manifest.get("options", {})
+          if options.get("no_stat") is not True:
+              raise SystemExit("monitor workflow requires stat-free manifests")
+          if options.get("hdf5_metadata"):
+              cache = manifest.get("metadata_cache")
+              if not isinstance(cache, dict):
+                  raise SystemExit("metadata-enabled manifest missing metadata_cache progress")
+          PY
+
+      - name: Summarize monitor mode and cache progress
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "${GITHUB_STEP_SUMMARY}"
+          import json
+          from pathlib import Path
+
+          manifest = json.loads(Path(".monitor_site/manifest.json").read_text())
+          options = manifest["options"]
+          mode = "incremental pointing metadata" if options.get("hdf5_metadata") else "fast recovery"
+          print(f"### {manifest['source_root']} monitor")
+          print(f"- Mode: **{mode}**")
+          print(f"- Files enumerated: **{manifest['totals']['file_count']}**")
+          cache = manifest.get("metadata_cache")
+          if cache:
+              print(
+                  "- Metadata cache: "
+                  f"{cache['cached']} cached, {cache['pending']} pending, "
+                  f"{cache['failed']} failed, {cache['retried']} retried, "
+                  f"{cache['emitted']} emitted"
+              )
+              if cache.get("error"):
+                  print(f"- Cache warning: `{cache['error']}`")
           PY
 
       - name: Upload monitor artifact
@@ -225,7 +289,7 @@ jobs:
             <h1>${slug} live monitor unavailable</h1>
             <p>The ${slug} monitor build failed for this run; no fresh artifact is available.</p>
             <p>See the <a href="${RUN_URL}">Actions run</a> (job "Build ${slug} monitor") for the specific failure.</p>
-            <p>This page will self-heal on the next successful run (scheduled every 5 minutes).</p>
+            <p>This page will self-heal on the next successful run (scheduled every 15 minutes).</p>
           </body>
           </html>
           EOF
@@ -288,7 +352,76 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  smoke_pages:
+    name: Verify deployed monitor routes
+    needs: deploy
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Verify deployed monitor routes
+        env:
+          PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_url="${PAGE_URL%/}/"
+          work_dir="$(mktemp -d)"
+          trap 'rm -rf "${work_dir}"' EXIT
+
+          for attempt in $(seq 1 15); do
+            ok=true
+            curl --fail --location --silent --show-error --output /dev/null "${base_url}" || ok=false
+            for route in \
+              dsacamera-live-monitor/manifest.json \
+              h17-live-monitor/manifest.json
+            do
+              slug="${route%%-*}"
+              url="${base_url}${route}"
+              curl --fail --location --silent --show-error \
+                --output "${work_dir}/${slug}.json" "${url}" || ok=false
+            done
+
+            if [[ "${ok}" == "true" ]] && python - "${work_dir}" <<'PY'
+          import json
+          import sys
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          required = {
+              "schema_version", "generated_at", "source_root", "totals",
+              "by_day", "by_beam", "gaps", "freshness", "options",
+          }
+          now = datetime.now(timezone.utc)
+          for path in sorted(Path(sys.argv[1]).glob("*.json")):
+              manifest = json.loads(path.read_text())
+              missing = required - manifest.keys()
+              if missing:
+                  raise SystemExit(f"{path.name}: missing {sorted(missing)}")
+              generated = datetime.fromisoformat(
+                  manifest["generated_at"].replace("Z", "+00:00")
+              )
+              age_seconds = (now - generated).total_seconds()
+              if age_seconds < 0 or age_seconds > 1800:
+                  raise SystemExit(f"{path.name}: generated_at age {age_seconds:.0f}s")
+          PY
+            then
+              echo "Pages root and both monitor manifests are fresh and valid."
+              exit 0
+            fi
+
+            if [[ "${attempt}" -lt 15 ]]; then
+              echo "Pages has not converged yet (attempt ${attempt}/15); retrying in 30s."
+              sleep 30
+            fi
+          done
+
+          echo "Pages did not converge to fresh monitor manifests within the smoke window." >&2
+          exit 1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,8 +53,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python -m pip install "./tools/dsacamera-monitor[dev]"
-          python -m pytest tools/dsacamera-monitor/tests -q
+          python -m pip install "./tools/dsacamera-monitor[dev]" PyYAML
+          python -m pytest tests/test_docs_monitor_workflow.py tools/dsacamera-monitor/tests -q
 
       - name: Render site
         working-directory: docs/quarto
@@ -265,6 +265,7 @@ jobs:
         run: quarto render
 
       - name: Download monitor artifacts
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: monitor-*
@@ -370,7 +371,7 @@ jobs:
 
   smoke_pages:
     name: Verify deployed monitor routes
-    needs: deploy
+    needs: [deploy, prepare_monitor_matrix]
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -378,6 +379,7 @@ jobs:
       - name: Verify deployed monitor routes
         env:
           PAGE_URL: ${{ needs.deploy.outputs.page_url }}
+          ENABLED_SLUGS: ${{ needs.prepare_monitor_matrix.outputs.enabled_slugs }}
         shell: bash
         run: |
           set -euo pipefail
@@ -388,11 +390,8 @@ jobs:
           for attempt in $(seq 1 15); do
             ok=true
             curl --fail --location --silent --show-error --output /dev/null "${base_url}" || ok=false
-            for route in \
-              dsacamera-live-monitor/manifest.json \
-              h17-live-monitor/manifest.json
-            do
-              slug="${route%%-*}"
+            for slug in ${ENABLED_SLUGS//,/ }; do
+              route="${slug}-live-monitor/manifest.json"
               url="${base_url}${route}"
               curl --fail --location --silent --show-error \
                 --output "${work_dir}/${slug}.json" "${url}" || ok=false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "docs/quarto/**"
       - "tools/dsacamera-monitor/**"
+      - "tests/test_docs_monitor_workflow.py"
       - ".github/workflows/docs.yml"
   pull_request:
     branches: [main]
     paths:
       - "docs/quarto/**"
       - "tools/dsacamera-monitor/**"
+      - "tests/test_docs_monitor_workflow.py"
       - ".github/workflows/docs.yml"
   schedule:
     - cron: "*/15 * * * *"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ permissions:
 
 # Only the newest monitor deployment is useful; cancel obsolete work promptly.
 concurrency:
-  group: "pages-multi-monitor"
+  group: "pages-multi-monitor-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'deploy' }}"
   cancel-in-progress: true
 
 jobs:

--- a/docs/quarto/dsacamera-live-monitor.qmd
+++ b/docs/quarto/dsacamera-live-monitor.qmd
@@ -3,7 +3,10 @@ title: "DSACamera Live Monitor"
 ---
 
 This page embeds the near-real-time `/data/incoming` inventory monitor generated on the `dsacamera` runner.
-Scheduled refreshes target a 5-minute cadence (plus GitHub Pages deployment latency).
+Scheduled refreshes target a 15-minute cadence. A healthy published manifest is no more than
+30 minutes old, including GitHub Pages deployment latency. Pointing charts may temporarily say
+**Metadata warming/unavailable** while the bounded host-local cache fills; file counts, filename
+freshness, daily grouping, and gaps remain available during warm-up.
 
 If the embedded dashboard does not load in your browser, open it directly:
 [Open DSACamera live monitor](dsacamera-live-monitor/).

--- a/docs/quarto/h17-live-monitor.qmd
+++ b/docs/quarto/h17-live-monitor.qmd
@@ -3,7 +3,10 @@ title: "H17 Live Monitor"
 ---
 
 This page embeds the near-real-time `/data/incoming` inventory monitor generated on the `h17` runner.
-Scheduled refreshes target a 5-minute cadence (plus GitHub Pages deployment latency).
+Scheduled refreshes target a 15-minute cadence. A healthy published manifest is no more than
+30 minutes old, including GitHub Pages deployment latency. Pointing charts may temporarily say
+**Metadata warming/unavailable** while the bounded host-local cache fills; file counts, filename
+freshness, daily grouping, and gaps remain available during warm-up.
 
 If the embedded dashboard does not load in your browser, open it directly:
 [Open H17 live monitor](h17-live-monitor/).

--- a/docs/superpowers/specs/2026-04-21-live-monitor-integration-design.md
+++ b/docs/superpowers/specs/2026-04-21-live-monitor-integration-design.md
@@ -10,8 +10,8 @@ Integrate the `dsacamera-monitor` near-real-time dashboard into the existing `ds
 
 - Add a `Live Monitor` entry to the Quarto sidebar.
 - Publish the generated monitor app at `.../live-monitor/` inside the same Pages artifact as Quarto docs.
-- Add near-real-time scheduled refreshes (5-minute cadence) in the docs deployment workflow.
-- Support a manual full refresh mode that includes file size and mtime metadata.
+- Add near-real-time scheduled refreshes (15-minute cadence) in the docs deployment workflow.
+- Keep scheduled and manual recovery scans stat-free; restore pointing metadata incrementally.
 - Add CI checks that fail fast if monitor artifacts are missing or malformed.
 
 ### Out of scope
@@ -45,13 +45,13 @@ This preserves the existing monitor frontend behavior while giving users a nativ
 
 - Reuse `dsacamera-incoming-scan` to generate monitor output.
 - Scheduled and push-triggered runs use `--no-stat` for speed.
-- Manual dispatch supports `full_scan=true` to run without `--no-stat`.
+- Manual dispatch defaults to fast recovery with HDF5 metadata disabled.
 
 ### Workflow orchestration layer
 
 In `.github/workflows/docs.yml`:
 
-- Add `schedule: "*/5 * * * *"` and `workflow_dispatch` input `full_scan` (boolean).
+- Add `schedule: "*/15 * * * *"` and a `workflow_dispatch` fast-recovery input.
 - Use self-hosted runner labels that can read `/data/incoming` (for example `self-hosted`, `linux`, `dsacamera`).
 - Build monitor output in a staging path.
 - Render Quarto.
@@ -64,8 +64,9 @@ In `.github/workflows/docs.yml`:
 2. Checkout repository.
 3. Install Python tooling needed for scanner invocation.
 4. Build monitor files:
-   - `full_scan=true` and manual dispatch: full scan.
-   - otherwise: fast scan (`--no-stat`).
+- all modes use stat-free enumeration;
+- fast recovery opens no HDF5 files;
+- optional pointing metadata uses a bounded host-local SQLite cache.
 5. Render Quarto docs to `docs/quarto/_site`.
 6. Validate monitor artifact integrity before merge into final site.
 7. Copy monitor directory into `docs/quarto/_site/live-monitor/`.
@@ -100,8 +101,8 @@ Result: one coherent site with docs and monitor updated together.
 
 ### Operational validation
 
-- Scheduled runs update roughly every 5 minutes plus Pages latency.
-- Manual `full_scan=true` path is exercised periodically to prevent drift/failure in the slow path.
+- Scheduled runs target 15 minutes and published manifests remain younger than 30 minutes.
+- Manual fast recovery is exercised periodically; cache mode can be disabled independently.
 
 ## Success Criteria
 

--- a/tests/test_docs_monitor_workflow.py
+++ b/tests/test_docs_monitor_workflow.py
@@ -58,7 +58,8 @@ def test_scanner_changes_trigger_pr_validation() -> None:
     assert "tools/dsacamera-monitor/**" in triggers["push"]["paths"]
     assert "tools/dsacamera-monitor/**" in triggers["pull_request"]["paths"]
     script = _step_script(workflow, "pr_render", "Test monitor scanner")
-    assert "pytest tools/dsacamera-monitor/tests" in script
+    assert "tools/dsacamera-monitor/tests" in script
+    assert "tests/test_docs_monitor_workflow.py" in script
 
 
 def test_monitor_artifact_validator_accepts_stat_free_manifests() -> None:
@@ -73,10 +74,20 @@ def test_monitor_artifact_validator_accepts_stat_free_manifests() -> None:
 def test_post_deploy_smoke_requires_fresh_root_and_both_manifests() -> None:
     workflow = _workflow()
     smoke = workflow["jobs"]["smoke_pages"]
-    assert smoke["needs"] == "deploy"
+    assert set(smoke["needs"]) == {"deploy", "prepare_monitor_matrix"}
     assert smoke["timeout-minutes"] == 10
     script = _step_script(workflow, "smoke_pages", "Verify deployed monitor routes")
-    assert "dsacamera-live-monitor/manifest.json" in script
-    assert "h17-live-monitor/manifest.json" in script
+    assert "ENABLED_SLUGS" in script
+    assert '${slug}-live-monitor/manifest.json' in script
     assert "1800" in script
     assert "curl" in script
+
+
+def test_aggregate_can_render_placeholders_when_artifacts_are_missing() -> None:
+    workflow = _workflow()
+    download = next(
+        step
+        for step in workflow["jobs"]["aggregate_site"]["steps"]
+        if step.get("name") == "Download monitor artifacts"
+    )
+    assert download["continue-on-error"] is True

--- a/tests/test_docs_monitor_workflow.py
+++ b/tests/test_docs_monitor_workflow.py
@@ -32,6 +32,7 @@ def test_monitor_schedule_and_concurrency_recovery_contract() -> None:
     triggers = _triggers(workflow)
     assert {row["cron"] for row in triggers["schedule"]} == {"*/15 * * * *"}
     assert workflow["concurrency"]["cancel-in-progress"] is True
+    assert "github.event_name" in workflow["concurrency"]["group"]
     fast_recovery = triggers["workflow_dispatch"]["inputs"]["fast_recovery"]
     assert fast_recovery["type"] == "boolean"
     assert fast_recovery["default"] is True

--- a/tests/test_docs_monitor_workflow.py
+++ b/tests/test_docs_monitor_workflow.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 import yaml
 
-
 WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "docs.yml"
 
 
@@ -50,6 +49,15 @@ def test_monitor_host_scans_are_stat_free_bounded_and_timeout() -> None:
     assert "--metadata-update-limit 100" in script
     assert "--metadata-retry-seconds 3600" in script
     assert "fast_recovery" in WORKFLOW_PATH.read_text()
+
+
+def test_scanner_changes_trigger_pr_validation() -> None:
+    workflow = _workflow()
+    triggers = _triggers(workflow)
+    assert "tools/dsacamera-monitor/**" in triggers["push"]["paths"]
+    assert "tools/dsacamera-monitor/**" in triggers["pull_request"]["paths"]
+    script = _step_script(workflow, "pr_render", "Test monitor scanner")
+    assert "pytest tools/dsacamera-monitor/tests" in script
 
 
 def test_monitor_artifact_validator_accepts_stat_free_manifests() -> None:

--- a/tests/test_docs_monitor_workflow.py
+++ b/tests/test_docs_monitor_workflow.py
@@ -1,0 +1,73 @@
+"""Durable service-level contracts for the static monitor Pages workflow."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+WORKFLOW_PATH = Path(__file__).parent.parent / ".github" / "workflows" / "docs.yml"
+
+
+def _workflow() -> dict:
+    parsed = yaml.safe_load(WORKFLOW_PATH.read_text())
+    assert isinstance(parsed, dict)
+    return parsed
+
+
+def _triggers(workflow: dict) -> dict:
+    # PyYAML 1.1 interprets the unquoted key `on` as boolean true.
+    return workflow.get("on", workflow.get(True, {}))
+
+
+def _step_script(workflow: dict, job: str, step_name: str) -> str:
+    for step in workflow["jobs"][job]["steps"]:
+        if step.get("name") == step_name:
+            return step.get("run", "")
+    raise AssertionError(f"missing {job!r} step {step_name!r}")
+
+
+def test_monitor_schedule_and_concurrency_recovery_contract() -> None:
+    workflow = _workflow()
+    triggers = _triggers(workflow)
+    assert {row["cron"] for row in triggers["schedule"]} == {"*/15 * * * *"}
+    assert workflow["concurrency"]["cancel-in-progress"] is True
+    fast_recovery = triggers["workflow_dispatch"]["inputs"]["fast_recovery"]
+    assert fast_recovery["type"] == "boolean"
+    assert fast_recovery["default"] is True
+
+
+def test_monitor_host_scans_are_stat_free_bounded_and_timeout() -> None:
+    workflow = _workflow()
+    job = workflow["jobs"]["build_monitors"]
+    assert job["timeout-minutes"] == 10
+    script = _step_script(workflow, "build_monitors", "Build monitor output")
+    assert "--no-stat" in script
+    assert "--no-hdf5-metadata" in script
+    assert "MONITOR_POINTING_METADATA_ENABLED" in WORKFLOW_PATH.read_text()
+    assert "--metadata-cache" in script
+    assert "--metadata-update-limit 100" in script
+    assert "--metadata-retry-seconds 3600" in script
+    assert "fast_recovery" in WORKFLOW_PATH.read_text()
+
+
+def test_monitor_artifact_validator_accepts_stat_free_manifests() -> None:
+    workflow = _workflow()
+    script = _step_script(workflow, "build_monitors", "Validate monitor artifact contract")
+    assert 'get("no_stat") is not True' in script
+    assert 'get("hdf5_metadata")' in script
+    assert '"metadata_cache"' in script
+    assert "must be false" not in script
+
+
+def test_post_deploy_smoke_requires_fresh_root_and_both_manifests() -> None:
+    workflow = _workflow()
+    smoke = workflow["jobs"]["smoke_pages"]
+    assert smoke["needs"] == "deploy"
+    assert smoke["timeout-minutes"] == 10
+    script = _step_script(workflow, "smoke_pages", "Verify deployed monitor routes")
+    assert "dsacamera-live-monitor/manifest.json" in script
+    assert "h17-live-monitor/manifest.json" in script
+    assert "1800" in script
+    assert "curl" in script

--- a/tests/test_docs_monitor_workflow.py
+++ b/tests/test_docs_monitor_workflow.py
@@ -57,6 +57,8 @@ def test_scanner_changes_trigger_pr_validation() -> None:
     triggers = _triggers(workflow)
     assert "tools/dsacamera-monitor/**" in triggers["push"]["paths"]
     assert "tools/dsacamera-monitor/**" in triggers["pull_request"]["paths"]
+    assert "tests/test_docs_monitor_workflow.py" in triggers["push"]["paths"]
+    assert "tests/test_docs_monitor_workflow.py" in triggers["pull_request"]["paths"]
     script = _step_script(workflow, "pr_render", "Test monitor scanner")
     assert "tools/dsacamera-monitor/tests" in script
     assert "tests/test_docs_monitor_workflow.py" in script

--- a/tools/dsacamera-monitor/README.md
+++ b/tools/dsacamera-monitor/README.md
@@ -23,6 +23,7 @@ This repository was split out from `dsa110-FLITS`; the CLI was renamed from `dsa
 | `freshness` | Earliest/latest timestamp from filenames; mtime range when not `no_stat` |
 | `pointing` | When metadata scan is on: global Dec min/max, unique rounded strip count, and file counters |
 | `pointing_timeseries` | When `--pointing-timeseries` is used: `{ file, row_count, truncated }` pointing at `pointing_timeseries.json` |
+| `metadata_cache` | Incremental cache progress: cached, pending, failed, retried, emitted, and isolated cache error counts |
 
 Filenames must match:
 
@@ -52,6 +53,7 @@ python -m dsacamera_monitor.scan --root /data/incoming --out /path/to/out
 - By default each matching `.hdf5` is opened once to read phase-center **Declination** from UVH5 headers (cheap metadata only; no visibilities). Use `--no-hdf5-metadata` to skip that (faster on huge trees, no Dec in manifest).
 - Optional `--pointing-timeseries` writes `pointing_timeseries.json` (per file: median time, RA, Dec) with rows capped by `--pointing-timeseries-max-files` (default 5000). RA may be derived from `ha_phase_center` + LST at median time, matching the main pipeline’s HDF5 convention.
 - **Performance:** metadata extraction is O(number of files) and uses one `h5py.File` open per file (Dec and optional timeseries fields are extracted in that single pass). On slow NFS, prefer cron spacing or metadata-off for smoke tests.
+- Production scheduled scans use stat-free enumeration plus a host-local SQLite cache. The cache opens at most 100 newest uncached or retryable files per run, reuses successful rows without opening HDF5, and retries read failures after one hour.
 - Open `out/index.html` in a browser (or serve the directory with any static file server).
 
 ### Fast count-only (no `stat`)
@@ -61,6 +63,22 @@ Large trees: skip `stat()` to reduce I/O; bytes and mtime will be empty/zero:
 ```bash
 dsacamera-incoming-scan --root /data/incoming --out /path/to/out --no-stat
 ```
+
+### Incremental pointing metadata
+
+```bash
+dsacamera-incoming-scan \
+  --root /data/incoming \
+  --out /path/to/out \
+  --no-stat \
+  --pointing-timeseries \
+  --metadata-cache "$HOME/.cache/dsa110-continuum/monitor/dsacamera-pointing.sqlite3" \
+  --metadata-update-limit 100 \
+  --metadata-retry-seconds 3600
+```
+
+Cache failures never block count/freshness output. Rows for files no longer present are ignored,
+and emitted pointing rows are deterministically ordered and capped at 5,000.
 
 ### Output location
 
@@ -113,13 +131,17 @@ This repo can publish the static dashboard the same way continuum publishes Quar
 
 1. On GitHub: **Settings → Pages → Build and deployment → Source: GitHub Actions** (not “Deploy from a branch” unless you prefer that).
 2. Register a **self-hosted runner on dsacamera** with labels `self-hosted`, `linux`, and `dsacamera`.
-3. Push to **`main`** or **`master`**; the workflow runs on code changes and on a **5-minute schedule**.
+3. Push to **`main`**; the workflow runs on code changes and on a **15-minute schedule**.
 
 **URL shape** matches your other project sites, e.g. `https://code.deepsynoptic.org/dsacamera-monitor/`, once your org’s GitHub / custom domain is set up the same way as [DSA-110 Continuum](http://code.deepsynoptic.org/dsa110-continuum/) (separate from this repo; same Pages pattern).
 
-**Near real-time mode:** scheduled runs use `--no-stat` for faster updates and lower I/O overhead. This gives near-real-time freshness (about every 5 minutes + deployment latency).
+**Near real-time mode:** every scheduled run uses `--no-stat`. The operational SLA is a
+15-minute schedule with published `generated_at` no more than 30 minutes old.
 
-**Manual full refresh:** use **Actions → Build and deploy GitHub Pages → Run workflow**, set `full_scan=true` to include bytes + mtime stats (slower, higher I/O).
+**Manual recovery:** use **Actions → Render and deploy Quarto docs → Run workflow** with
+`fast_recovery=true`. This forces metadata-free output even if incremental metadata is enabled.
+To roll back a failing cache rollout, set repository variable
+`MONITOR_POINTING_METADATA_ENABLED=false`; the fast count/freshness monitor remains active.
 
 For one-off local scans on dsacamera:
 

--- a/tools/dsacamera-monitor/docs/hosting-deepsynoptic.md
+++ b/tools/dsacamera-monitor/docs/hosting-deepsynoptic.md
@@ -8,9 +8,10 @@ After you enable **Pages → GitHub Actions** in the `dsacamera-monitor` reposit
 
 This repository is now configured for a **self-hosted runner on dsacamera** (`runs-on: [self-hosted, linux, dsacamera]`) so the workflow performs a **real** scan:
 
-- Scheduled every 5 minutes (`cron: */5 * * * *`) using `--no-stat` for speed.
-- Push-triggered deploys also use `--no-stat` for fast turnaround.
-- Manual runs can set `full_scan=true` to include file sizes/mtime (slower).
+- Scheduled every 15 minutes (`cron: */15 * * * *`) using stat-free enumeration.
+- Obsolete runs are cancelled and each host build is bounded to ten minutes.
+- Pointing metadata is optional and warms through a persistent SQLite cache at no more than 100 HDF5 opens per host per run.
+- Manual runs default to `fast_recovery=true`, which forces metadata-free output.
 
 ### Self-hosted runner setup checklist
 
@@ -22,12 +23,15 @@ This repository is now configured for a **self-hosted runner on dsacamera** (`ru
 
 ### About “real-time”
 
-GitHub Pages deployments are **not true streaming real-time**. With a 5-minute schedule you typically get updates in:
+GitHub Pages deployments are **not true streaming real-time**. The operational contract is:
 
-- scan time
-- plus artifact upload/deploy latency
+- a 15-minute scheduled scan,
+- a ten-minute host timeout, and
+- published `generated_at` no more than 30 minutes old after artifact/deploy latency.
 
-So “near real-time” is realistic; sub-minute updates usually require a direct web service rather than Pages.
+If pointing metadata is unavailable, the dashboard continues publishing counts, filename
+freshness, daily grouping, and gaps. Disable `MONITOR_POINTING_METADATA_ENABLED` to roll back
+cache mode without reverting the recovered fast monitor.
 
 ---
 

--- a/tools/dsacamera-monitor/dsacamera_monitor/hdf5_pointing.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/hdf5_pointing.py
@@ -20,6 +20,7 @@ try:
 
     # Keep metadata scans independent of network/IERS download state.
     iers.conf.auto_download = False
+    iers.conf.auto_max_age = None
     _OVRO_LOCATION = EarthLocation.from_geodetic(
         lon=_OVRO_LON_DEG * u.deg, lat=_OVRO_LAT_DEG * u.deg, height=_OVRO_ALT_M * u.m
     )

--- a/tools/dsacamera-monitor/dsacamera_monitor/manifest.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/manifest.py
@@ -68,6 +68,13 @@ class ScanAccum:
     global_decs_rounded: set[float] = field(default_factory=set)
     timeseries_rows: list[dict[str, Any]] = field(default_factory=list)
     timeseries_truncated: bool = False
+    metadata_cache_enabled: bool = False
+    metadata_cached: int = 0
+    metadata_pending: int = 0
+    metadata_failed: int = 0
+    metadata_retried: int = 0
+    metadata_emitted: int = 0
+    metadata_cache_error: str | None = None
 
 
 def build_manifest(
@@ -143,6 +150,7 @@ def build_manifest(
         "no_stat": no_stat,
         "hdf5_metadata": hdf5_metadata,
         "pointing_timeseries": pointing_timeseries,
+        "metadata_cache": accum.metadata_cache_enabled,
     }
 
     manifest: dict[str, Any] = {
@@ -175,5 +183,14 @@ def build_manifest(
             "file": "pointing_timeseries.json",
             "row_count": len(accum.timeseries_rows),
             "truncated": accum.timeseries_truncated,
+        }
+    if accum.metadata_cache_enabled:
+        manifest["metadata_cache"] = {
+            "cached": accum.metadata_cached,
+            "pending": accum.metadata_pending,
+            "failed": accum.metadata_failed,
+            "retried": accum.metadata_retried,
+            "emitted": accum.metadata_emitted,
+            "error": accum.metadata_cache_error,
         }
     return manifest

--- a/tools/dsacamera-monitor/dsacamera_monitor/metadata_cache.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/metadata_cache.py
@@ -1,0 +1,106 @@
+"""Durable SQLite cache for incremental HDF5 pointing metadata reads."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def _iso_utc(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class MetadataCache:
+    """Small transactional cache keyed by the HDF5 filename."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.connection: sqlite3.Connection | None = None
+
+    def __enter__(self) -> MetadataCache:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.path, timeout=5.0)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA synchronous=NORMAL")
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS pointing_metadata (
+                filename TEXT PRIMARY KEY,
+                t_mid_utc TEXT,
+                ra_deg REAL,
+                dec_deg REAL,
+                dec_status TEXT NOT NULL,
+                pointing_status TEXT NOT NULL,
+                error TEXT,
+                attempt_count INTEGER NOT NULL,
+                last_attempt_at TEXT NOT NULL
+            )
+            """
+        )
+        connection.commit()
+        self.connection = connection
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        if self.connection is not None:
+            self.connection.close()
+            self.connection = None
+
+    def _connection(self) -> sqlite3.Connection:
+        if self.connection is None:
+            raise RuntimeError("metadata cache is not open")
+        return self.connection
+
+    def load_rows(self) -> dict[str, dict[str, Any]]:
+        """Return every cached row keyed by filename."""
+        rows = self._connection().execute(
+            """
+            SELECT filename, t_mid_utc, ra_deg, dec_deg, dec_status,
+                   pointing_status, error, attempt_count, last_attempt_at
+            FROM pointing_metadata
+            """
+        )
+        return {str(row["filename"]): dict(row) for row in rows}
+
+    def write_attempts(self, records: list[dict[str, Any]], attempted_at: datetime) -> None:
+        """Commit one metadata batch atomically, incrementing prior attempt counts."""
+        if not records:
+            return
+        attempted_at_iso = _iso_utc(attempted_at)
+        connection = self._connection()
+        with connection:
+            connection.executemany(
+                """
+                INSERT INTO pointing_metadata (
+                    filename, t_mid_utc, ra_deg, dec_deg, dec_status,
+                    pointing_status, error, attempt_count, last_attempt_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+                ON CONFLICT(filename) DO UPDATE SET
+                    t_mid_utc = excluded.t_mid_utc,
+                    ra_deg = excluded.ra_deg,
+                    dec_deg = excluded.dec_deg,
+                    dec_status = excluded.dec_status,
+                    pointing_status = excluded.pointing_status,
+                    error = excluded.error,
+                    attempt_count = pointing_metadata.attempt_count + 1,
+                    last_attempt_at = excluded.last_attempt_at
+                """,
+                [
+                    (
+                        record["filename"],
+                        record.get("t_mid_utc"),
+                        record.get("ra_deg"),
+                        record.get("dec_deg"),
+                        record["dec_status"],
+                        record["pointing_status"],
+                        record.get("error"),
+                        attempted_at_iso,
+                    )
+                    for record in records
+                ],
+            )

--- a/tools/dsacamera-monitor/dsacamera_monitor/scan.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/scan.py
@@ -120,7 +120,10 @@ def _scan_incremental_metadata(
                 key=lambda candidate: (candidate.timestamp, candidate.path.name),
                 reverse=True,
             )
-            selected = (uncached + retryable)[: max(0, update_limit)]
+            # Eligible failures must not starve behind a multi-day cold-cache
+            # backlog. Retry them first, then spend the remaining bounded
+            # budget on newest uncached files.
+            selected = (retryable + uncached)[: max(0, update_limit)]
             accum.metadata_retried = sum(
                 candidate.path.name in rows for candidate in selected
             )

--- a/tools/dsacamera-monitor/dsacamera_monitor/scan.py
+++ b/tools/dsacamera-monitor/dsacamera_monitor/scan.py
@@ -7,8 +7,10 @@ import json
 import os
 import shutil
 import sys
-from datetime import date, datetime, timezone
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 from dsacamera_monitor.hdf5_pointing import DEC_ROUND_DIGITS, read_pointing_metadata
 from dsacamera_monitor.manifest import (
@@ -18,6 +20,16 @@ from dsacamera_monitor.manifest import (
     build_manifest,
     try_parse_filename,
 )
+from dsacamera_monitor.metadata_cache import MetadataCache
+
+
+@dataclass(frozen=True)
+class MetadataCandidate:
+    """One enumerated HDF5 file eligible for a metadata cache lookup."""
+
+    path: Path
+    timestamp: datetime
+    day: date
 
 
 def _record_dec(accum: ScanAccum, day: date, dec: float) -> None:
@@ -39,6 +51,122 @@ def _record_dec(accum: ScanAccum, day: date, dec: float) -> None:
         dagg.dec_max = max(dagg.dec_max, dec)
 
 
+def _record_metadata(accum: ScanAccum, day: date, meta: dict[str, Any]) -> None:
+    if meta["dec_status"] == "ok":
+        dec = meta["dec_deg"]
+        assert dec is not None
+        accum.files_with_dec += 1
+        _record_dec(accum, day, dec)
+    elif meta["dec_status"] == "missing":
+        accum.files_dec_missing += 1
+    else:
+        accum.files_dec_read_failed += 1
+    if meta["pointing_status"] == "read_failed":
+        accum.files_pointing_read_failed += 1
+
+
+def _parse_cache_time(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _cache_row_failed(row: dict[str, Any]) -> bool:
+    return row["dec_status"] == "read_failed" or row["pointing_status"] == "read_failed"
+
+
+def _scan_incremental_metadata(
+    accum: ScanAccum,
+    candidates: list[MetadataCandidate],
+    *,
+    cache_path: Path,
+    update_limit: int,
+    retry_seconds: int,
+    pointing_timeseries: bool,
+    pointing_timeseries_max_files: int,
+    now: datetime,
+) -> None:
+    """Update and consume a bounded persistent metadata cache."""
+    accum.metadata_cache_enabled = True
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    now = now.astimezone(timezone.utc)
+    retry_cutoff = now - timedelta(seconds=max(0, retry_seconds))
+    candidates_by_name = {candidate.path.name: candidate for candidate in candidates}
+
+    try:
+        with MetadataCache(cache_path) as cache:
+            rows = cache.load_rows()
+            uncached = sorted(
+                (candidate for candidate in candidates if candidate.path.name not in rows),
+                key=lambda candidate: (candidate.timestamp, candidate.path.name),
+                reverse=True,
+            )
+            retryable = sorted(
+                (
+                    candidate
+                    for candidate in candidates
+                    if candidate.path.name in rows
+                    and _cache_row_failed(rows[candidate.path.name])
+                    and (
+                        (last_attempt := _parse_cache_time(rows[candidate.path.name]["last_attempt_at"]))
+                        is None
+                        or last_attempt <= retry_cutoff
+                    )
+                ),
+                key=lambda candidate: (candidate.timestamp, candidate.path.name),
+                reverse=True,
+            )
+            selected = (uncached + retryable)[: max(0, update_limit)]
+            accum.metadata_retried = sum(
+                candidate.path.name in rows for candidate in selected
+            )
+            updates = [read_pointing_metadata(candidate.path) for candidate in selected]
+            cache.write_attempts(updates, now)
+            rows = cache.load_rows()
+    except Exception as exc:
+        accum.metadata_cache_error = f"{type(exc).__name__}: {exc}"
+        accum.metadata_pending = len(candidates)
+        return
+
+    current_rows = {
+        name: rows[name] for name in candidates_by_name if name in rows
+    }
+    accum.metadata_cached = len(current_rows)
+    accum.metadata_pending = len(candidates) - accum.metadata_cached
+    accum.metadata_failed = sum(_cache_row_failed(row) for row in current_rows.values())
+
+    for name, row in current_rows.items():
+        _record_metadata(accum, candidates_by_name[name].day, row)
+
+    if pointing_timeseries:
+        eligible = [
+            (candidates_by_name[name], row)
+            for name, row in current_rows.items()
+            if not _cache_row_failed(row)
+            and any(row.get(key) is not None for key in ("t_mid_utc", "ra_deg", "dec_deg"))
+        ]
+        newest = sorted(
+            eligible,
+            key=lambda item: (item[0].timestamp, item[0].path.name),
+            reverse=True,
+        )[:pointing_timeseries_max_files]
+        for candidate, row in reversed(newest):
+            accum.timeseries_rows.append(
+                {
+                    "filename": candidate.path.name,
+                    "t_mid_utc": row["t_mid_utc"],
+                    "ra_deg": row["ra_deg"],
+                    "dec_deg": row["dec_deg"],
+                }
+            )
+        accum.timeseries_truncated = len(eligible) > len(newest)
+    accum.metadata_emitted = len(accum.timeseries_rows)
+
+
 def scan_directory(
     root: Path,
     *,
@@ -46,9 +174,14 @@ def scan_directory(
     hdf5_metadata: bool = True,
     pointing_timeseries: bool = False,
     pointing_timeseries_max_files: int = 5000,
+    metadata_cache_path: Path | None = None,
+    metadata_update_limit: int = 100,
+    metadata_retry_seconds: int = 3600,
+    metadata_now: datetime | None = None,
 ) -> ScanAccum:
     """Single pass over directory entries; only matching *.hdf5 names are counted."""
     accum = ScanAccum()
+    metadata_candidates: list[MetadataCandidate] = []
     with os.scandir(root) as it:
         for entry in it:
             if not entry.is_file():
@@ -95,17 +228,9 @@ def scan_directory(
 
             accum.file_count += 1
 
-            if hdf5_metadata:
+            if hdf5_metadata and metadata_cache_path is None:
                 meta = read_pointing_metadata(full_path)
-                if meta["dec_status"] == "ok":
-                    dec = meta["dec_deg"]
-                    assert dec is not None
-                    accum.files_with_dec += 1
-                    _record_dec(accum, day, dec)
-                elif meta["dec_status"] == "missing":
-                    accum.files_dec_missing += 1
-                else:
-                    accum.files_dec_read_failed += 1
+                _record_metadata(accum, day, meta)
 
                 if pointing_timeseries and len(accum.timeseries_rows) < pointing_timeseries_max_files:
                     accum.timeseries_rows.append(
@@ -116,10 +241,23 @@ def scan_directory(
                             "dec_deg": meta["dec_deg"],
                         }
                     )
-                if meta["pointing_status"] == "read_failed":
-                    accum.files_pointing_read_failed += 1
+            elif hdf5_metadata:
+                metadata_candidates.append(
+                    MetadataCandidate(path=full_path, timestamp=dt_utc, day=day)
+                )
 
-    if pointing_timeseries and hdf5_metadata and accum.file_count > len(accum.timeseries_rows):
+    if hdf5_metadata and metadata_cache_path is not None:
+        _scan_incremental_metadata(
+            accum,
+            metadata_candidates,
+            cache_path=metadata_cache_path,
+            update_limit=metadata_update_limit,
+            retry_seconds=metadata_retry_seconds,
+            pointing_timeseries=pointing_timeseries,
+            pointing_timeseries_max_files=pointing_timeseries_max_files,
+            now=metadata_now or datetime.now(timezone.utc),
+        )
+    elif pointing_timeseries and hdf5_metadata and accum.file_count > len(accum.timeseries_rows):
         accum.timeseries_truncated = True
 
     return accum
@@ -134,6 +272,9 @@ def build_out(
     hdf5_metadata: bool = True,
     pointing_timeseries: bool = False,
     pointing_timeseries_max_files: int = 5000,
+    metadata_cache_path: Path | None = None,
+    metadata_update_limit: int = 100,
+    metadata_retry_seconds: int = 3600,
 ) -> tuple[Path, bool]:
     """Scan, write manifest.json, optional pointing_timeseries.json, copy static site into out_dir."""
     accum = scan_directory(
@@ -142,6 +283,9 @@ def build_out(
         hdf5_metadata=hdf5_metadata,
         pointing_timeseries=pointing_timeseries,
         pointing_timeseries_max_files=pointing_timeseries_max_files,
+        metadata_cache_path=metadata_cache_path,
+        metadata_update_limit=metadata_update_limit,
+        metadata_retry_seconds=metadata_retry_seconds,
     )
     manifest = build_manifest(
         source_root=str(root.resolve()),
@@ -218,6 +362,26 @@ def main(argv: list[str] | None = None) -> int:
         help="Cap rows in pointing_timeseries.json (default: 5000)",
     )
     parser.add_argument(
+        "--metadata-cache",
+        type=Path,
+        default=None,
+        help="Persistent SQLite cache for bounded incremental HDF5 metadata reads",
+    )
+    parser.add_argument(
+        "--metadata-update-limit",
+        type=int,
+        default=100,
+        metavar="N",
+        help="Maximum uncached or retryable HDF5 files to open per run (default: 100)",
+    )
+    parser.add_argument(
+        "--metadata-retry-seconds",
+        type=int,
+        default=3600,
+        metavar="SECONDS",
+        help="Delay before retrying failed metadata reads (default: 3600)",
+    )
+    parser.add_argument(
         "--site",
         type=Path,
         default=None,
@@ -246,6 +410,9 @@ def main(argv: list[str] | None = None) -> int:
         hdf5_metadata=hdf5_metadata,
         pointing_timeseries=pointing_ts,
         pointing_timeseries_max_files=max(1, args.pointing_timeseries_max_files),
+        metadata_cache_path=args.metadata_cache,
+        metadata_update_limit=max(0, args.metadata_update_limit),
+        metadata_retry_seconds=max(0, args.metadata_retry_seconds),
     )
     print(f"Wrote {args.out / 'manifest.json'}")
     if pointing_ts and wrote_timeseries:

--- a/tools/dsacamera-monitor/dsacamera_monitor/site/index.html
+++ b/tools/dsacamera-monitor/dsacamera_monitor/site/index.html
@@ -20,8 +20,8 @@
     <div class="kpi"><span class="label">Generated (UTC)</span><span class="value" id="kpi-generated">—</span></div>
     <div class="kpi"><span class="label">Filename span (UTC)</span><span class="value" id="kpi-span">—</span></div>
     <div class="kpi"><span class="label">mtime span (UTC)</span><span class="value" id="kpi-mtime">—</span></div>
-    <div class="kpi" id="kpi-dec-wrap" style="display:none"><span class="label">Phase-center Dec (°)</span><span class="value" id="kpi-dec">—</span></div>
-    <div class="kpi" id="kpi-dec-files-wrap" style="display:none"><span class="label">Dec metadata</span><span class="value" id="kpi-dec-files">—</span></div>
+    <div class="kpi" id="kpi-dec-wrap"><span class="label">Phase-center Dec (°)</span><span class="value" id="kpi-dec">Metadata warming/unavailable</span></div>
+    <div class="kpi" id="kpi-dec-files-wrap"><span class="label">Dec metadata</span><span class="value" id="kpi-dec-files">Metadata warming/unavailable</span></div>
   </section>
 
   <section class="panel">
@@ -34,17 +34,19 @@
     <div class="chart-wrap"><canvas id="chart-cum" height="120"></canvas></div>
   </section>
 
-  <section class="panel" id="panel-dec-by-day" style="display:none">
+  <section class="panel" id="panel-dec-by-day">
     <h2>Declination by day (phase center)</h2>
     <p class="hint">Min/max Dec (°) from HDF5 headers per calendar day, when metadata scan is enabled.</p>
-    <div class="chart-wrap"><canvas id="chart-dec" height="120"></canvas></div>
+    <p class="hint" id="dec-metadata-status">Metadata warming/unavailable</p>
+    <div class="chart-wrap" id="dec-chart-wrap" style="display:none"><canvas id="chart-dec" height="120"></canvas></div>
   </section>
 
-  <section class="panel" id="panel-pointing-series" style="display:none">
+  <section class="panel" id="panel-pointing-series">
     <h2>Pointing vs time (per file, median integration time)</h2>
     <p class="hint">From <code>pointing_timeseries.json</code> when generated. RA may be derived from HA + LST.</p>
+    <p class="hint" id="pointing-metadata-status">Metadata warming/unavailable</p>
     <p class="hint" id="ts-trunc" style="display:none"></p>
-    <div class="chart-wrap"><canvas id="chart-pointing" height="140"></canvas></div>
+    <div class="chart-wrap" id="pointing-chart-wrap" style="display:none"><canvas id="chart-pointing" height="140"></canvas></div>
   </section>
 
   <section class="panel">

--- a/tools/dsacamera-monitor/dsacamera_monitor/site/js/dashboard.js
+++ b/tools/dsacamera-monitor/dsacamera_monitor/site/js/dashboard.js
@@ -32,6 +32,15 @@ function dayIterator(startStr, endStr) {
   return out;
 }
 
+function metadataStateText(m) {
+  const cache = m.metadata_cache;
+  if (cache) {
+    const progress = `${cache.cached} cached · ${cache.pending} pending · ${cache.failed} failed`;
+    return cache.error ? `Metadata warming/unavailable · ${progress}` : `Metadata warming · ${progress}`;
+  }
+  return "Metadata warming/unavailable";
+}
+
 function fillKpis(m) {
   document.getElementById("kpi-files").textContent = String(m.totals.file_count);
   document.getElementById("kpi-bytes").textContent =
@@ -74,8 +83,11 @@ function fillKpis(m) {
         : "—";
     document.getElementById("kpi-dec-files").textContent = `${m.pointing.files_with_dec} with Dec · ${m.pointing.files_dec_missing} missing`;
   } else {
-    document.getElementById("kpi-dec-wrap").style.display = "none";
-    document.getElementById("kpi-dec-files-wrap").style.display = "none";
+    document.getElementById("kpi-dec-wrap").style.display = "block";
+    document.getElementById("kpi-dec-files-wrap").style.display = "block";
+    const state = metadataStateText(m);
+    document.getElementById("kpi-dec").textContent = state;
+    document.getElementById("kpi-dec-files").textContent = state;
   }
 }
 
@@ -147,13 +159,20 @@ function renderDailyAndCumulative(m) {
 
 function renderDecByDay(m) {
   const panel = document.getElementById("panel-dec-by-day");
+  const status = document.getElementById("dec-metadata-status");
+  const chartWrap = document.getElementById("dec-chart-wrap");
   const has =
     m.pointing && m.by_day && m.by_day.some((r) => r.dec_deg_min != null && r.dec_deg_max != null);
   if (!has) {
-    panel.style.display = "none";
+    panel.style.display = "block";
+    status.style.display = "block";
+    status.textContent = metadataStateText(m);
+    chartWrap.style.display = "none";
     return;
   }
   panel.style.display = "block";
+  status.style.display = "none";
+  chartWrap.style.display = "block";
   const labels = m.by_day.map((r) => r.date);
   const mins = m.by_day.map((r) => (r.dec_deg_min != null ? r.dec_deg_min : null));
   const maxs = m.by_day.map((r) => (r.dec_deg_max != null ? r.dec_deg_max : null));
@@ -212,11 +231,18 @@ function renderDecByDay(m) {
 function renderPointingTimeseries(m, rows) {
   const panel = document.getElementById("panel-pointing-series");
   const note = document.getElementById("ts-trunc");
+  const status = document.getElementById("pointing-metadata-status");
+  const chartWrap = document.getElementById("pointing-chart-wrap");
   if (!rows || !Array.isArray(rows) || rows.length === 0) {
-    panel.style.display = "none";
+    panel.style.display = "block";
+    status.style.display = "block";
+    status.textContent = metadataStateText(m);
+    chartWrap.style.display = "none";
     return;
   }
   panel.style.display = "block";
+  status.style.display = "none";
+  chartWrap.style.display = "block";
   if (m.pointing_timeseries && m.pointing_timeseries.truncated) {
     note.style.display = "block";
     note.textContent = "Rows capped; scan omitted some files (see manifest pointing_timeseries).";

--- a/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
+++ b/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from dsacamera_monitor.gaps import compute_gaps, gaps_from_by_day_rows
@@ -196,3 +196,330 @@ def test_scan_counts_read_failures(tmp_path: Path) -> None:
     assert accum.files_dec_read_failed == 1
     assert accum.files_pointing_read_failed == 1
     assert len(accum.timeseries_rows) == 1
+
+
+def _cached_meta(path: Path, *, failed: bool = False) -> dict:
+    if failed:
+        return {
+            "filename": path.name,
+            "t_mid_utc": None,
+            "ra_deg": None,
+            "dec_deg": None,
+            "dec_status": "read_failed",
+            "pointing_status": "read_failed",
+            "error": "OSError: corrupt fixture",
+        }
+    parsed = try_parse_filename(path.name)
+    assert parsed is not None
+    timestamp, _ = parsed
+    return {
+        "filename": path.name,
+        "t_mid_utc": timestamp.isoformat().replace("+00:00", "Z"),
+        "ra_deg": float(timestamp.hour),
+        "dec_deg": 16.1,
+        "dec_status": "ok",
+        "pointing_status": "ok",
+        "error": None,
+    }
+
+
+def _make_named_files(root: Path, timestamps: list[str]) -> list[Path]:
+    paths = []
+    for timestamp in timestamps:
+        path = root / f"{timestamp}_sb00.hdf5"
+        path.write_bytes(b"fixture")
+        paths.append(path)
+    return paths
+
+
+def test_incremental_cache_cold_warm_and_one_new_file(tmp_path: Path, monkeypatch) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    root = tmp_path / "incoming"
+    root.mkdir()
+    _make_named_files(root, ["2025-01-01T00:00:00", "2025-01-01T01:00:00"])
+    cache = tmp_path / "pointing.sqlite3"
+    opened: list[str] = []
+
+    def fake_read(path: Path) -> dict:
+        opened.append(path.name)
+        return _cached_meta(path)
+
+    monkeypatch.setattr("dsacamera_monitor.scan.read_pointing_metadata", fake_read)
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    cold = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_update_limit=100,
+        metadata_now=now,
+    )
+    assert len(opened) == 2
+    assert cold.metadata_cached == 2
+    assert cold.metadata_pending == 0
+    assert cold.metadata_emitted == 2
+
+    opened.clear()
+    warm = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_update_limit=100,
+        metadata_now=now + timedelta(minutes=5),
+    )
+    assert opened == []
+    assert warm.metadata_cached == 2
+
+    _make_named_files(root, ["2025-01-01T02:00:00"])
+    opened.clear()
+    updated = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_update_limit=100,
+        metadata_now=now + timedelta(minutes=10),
+    )
+    assert opened == ["2025-01-01T02:00:00_sb00.hdf5"]
+    assert updated.metadata_cached == 3
+
+
+def test_incremental_cache_bounds_newest_first_and_emits_deterministically(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    root = tmp_path / "incoming"
+    root.mkdir()
+    _make_named_files(
+        root,
+        [
+            "2025-01-01T00:00:00",
+            "2025-01-01T01:00:00",
+            "2025-01-01T02:00:00",
+        ],
+    )
+    opened: list[str] = []
+
+    def fake_read(path: Path) -> dict:
+        opened.append(path.name)
+        return _cached_meta(path)
+
+    monkeypatch.setattr("dsacamera_monitor.scan.read_pointing_metadata", fake_read)
+    accum = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        pointing_timeseries_max_files=2,
+        metadata_cache_path=tmp_path / "cache.sqlite3",
+        metadata_update_limit=2,
+        metadata_now=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    assert opened == [
+        "2025-01-01T02:00:00_sb00.hdf5",
+        "2025-01-01T01:00:00_sb00.hdf5",
+    ]
+    assert accum.metadata_pending == 1
+    assert [row["filename"] for row in accum.timeseries_rows] == [
+        "2025-01-01T01:00:00_sb00.hdf5",
+        "2025-01-01T02:00:00_sb00.hdf5",
+    ]
+
+
+def test_incremental_cache_retries_failures_after_interval(tmp_path: Path, monkeypatch) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    root = tmp_path / "incoming"
+    root.mkdir()
+    path = _make_named_files(root, ["2025-01-01T00:00:00"])[0]
+    opened: list[str] = []
+    attempts = 0
+
+    def fake_read(candidate: Path) -> dict:
+        nonlocal attempts
+        attempts += 1
+        opened.append(candidate.name)
+        return _cached_meta(candidate, failed=attempts == 1)
+
+    monkeypatch.setattr("dsacamera_monitor.scan.read_pointing_metadata", fake_read)
+    cache = tmp_path / "cache.sqlite3"
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    first = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_retry_seconds=3600,
+        metadata_now=now,
+    )
+    assert first.metadata_failed == 1
+
+    opened.clear()
+    before_retry = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_retry_seconds=3600,
+        metadata_now=now + timedelta(minutes=59),
+    )
+    assert opened == []
+    assert before_retry.metadata_retried == 0
+
+    after_retry = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_retry_seconds=3600,
+        metadata_now=now + timedelta(hours=1),
+    )
+    assert opened == [path.name]
+    assert after_retry.metadata_retried == 1
+    assert after_retry.metadata_failed == 0
+
+
+def test_incremental_cache_ignores_removed_files_and_reports_manifest_progress(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    root = tmp_path / "incoming"
+    root.mkdir()
+    paths = _make_named_files(root, ["2025-01-01T00:00:00", "2025-01-01T01:00:00"])
+    monkeypatch.setattr(
+        "dsacamera_monitor.scan.read_pointing_metadata",
+        lambda path: _cached_meta(path),
+    )
+    cache = tmp_path / "cache.sqlite3"
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_now=now,
+    )
+    paths[0].unlink()
+    accum = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=cache,
+        metadata_now=now + timedelta(minutes=5),
+    )
+    manifest = build_manifest(
+        source_root=str(root),
+        accum=accum,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        generated_at=now,
+    )
+    assert accum.file_count == 1
+    assert [row["filename"] for row in accum.timeseries_rows] == [paths[1].name]
+    assert manifest["metadata_cache"] == {
+        "cached": 1,
+        "pending": 0,
+        "failed": 0,
+        "retried": 0,
+        "emitted": 1,
+        "error": None,
+    }
+
+
+def test_incremental_cache_does_not_retry_missing_metadata(tmp_path: Path, monkeypatch) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    root = tmp_path / "incoming"
+    root.mkdir()
+    _make_named_files(root, ["2025-01-01T00:00:00"])
+    opened: list[str] = []
+
+    def missing_read(path: Path) -> dict:
+        opened.append(path.name)
+        meta = _cached_meta(path)
+        meta.update(
+            t_mid_utc=None,
+            ra_deg=None,
+            dec_deg=None,
+            dec_status="missing",
+            pointing_status="missing",
+        )
+        return meta
+
+    monkeypatch.setattr("dsacamera_monitor.scan.read_pointing_metadata", missing_read)
+    cache = tmp_path / "cache.sqlite3"
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    first = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        metadata_cache_path=cache,
+        metadata_now=now,
+    )
+    assert first.files_dec_missing == 1
+    opened.clear()
+    second = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        metadata_cache_path=cache,
+        metadata_now=now + timedelta(days=1),
+    )
+    assert opened == []
+    assert second.files_dec_missing == 1
+
+
+def test_cache_failure_still_produces_count_inventory(tmp_path: Path, monkeypatch) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    root = tmp_path / "incoming"
+    root.mkdir()
+    _make_named_files(root, ["2025-01-01T00:00:00"])
+    monkeypatch.setattr(
+        "dsacamera_monitor.scan.MetadataCache.load_rows",
+        lambda self: (_ for _ in ()).throw(OSError("synthetic cache failure")),
+    )
+    accum = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        pointing_timeseries=True,
+        metadata_cache_path=tmp_path / "cache.sqlite3",
+    )
+    assert accum.file_count == 1
+    assert accum.by_day[date(2025, 1, 1)].count == 1
+    assert accum.metadata_pending == 1
+    assert accum.metadata_cache_error == "OSError: synthetic cache failure"
+
+
+def test_metadata_cache_batch_write_is_atomic(tmp_path: Path) -> None:
+    import sqlite3
+
+    from dsacamera_monitor.metadata_cache import MetadataCache
+
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    valid = _cached_meta(tmp_path / "2025-01-01T00:00:00_sb00.hdf5")
+    invalid = _cached_meta(tmp_path / "2025-01-01T01:00:00_sb00.hdf5")
+    invalid["dec_status"] = None
+    cache_path = tmp_path / "cache.sqlite3"
+    with MetadataCache(cache_path) as cache:
+        try:
+            cache.write_attempts([valid, invalid], now)
+        except sqlite3.IntegrityError:
+            pass
+        else:
+            raise AssertionError("invalid cache batch unexpectedly committed")
+        assert cache.load_rows() == {}

--- a/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
+++ b/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
@@ -7,7 +7,11 @@ from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 from dsacamera_monitor.gaps import compute_gaps, gaps_from_by_day_rows
-from dsacamera_monitor.hdf5_pointing import read_phase_center_dec_deg, read_pointing_ra_dec_deg
+from dsacamera_monitor.hdf5_pointing import (
+    read_phase_center_dec_deg,
+    read_pointing_metadata,
+    read_pointing_ra_dec_deg,
+)
 from dsacamera_monitor.manifest import (
     BeamAgg,
     DayAgg,
@@ -197,6 +201,29 @@ def test_pointing_fallback_header_keys(tmp_path: Path) -> None:
     ra, dec = read_pointing_ra_dec_deg(p)
     assert ra is not None and abs(ra - 230.5) < 1e-6
     assert dec is not None and abs(dec - 15.25) < 1e-6
+
+
+def test_pointing_ha_fallback_allows_offline_predictive_iers(tmp_path: Path) -> None:
+    import h5py
+    import numpy as np
+
+    path = tmp_path / "2026-03-15T00:00:00_sb01.hdf5"
+    with h5py.File(path, "w") as handle:
+        handle.create_dataset(
+            "Header/extra_keywords/phase_center_dec",
+            data=np.float64(np.deg2rad(16.1)),
+        )
+        handle.create_dataset(
+            "Header/extra_keywords/ha_phase_center",
+            data=np.float64(0.01),
+        )
+        handle.create_dataset("Header/time_array", data=np.array([2461114.5, 2461114.6]))
+
+    metadata = read_pointing_metadata(path)
+    assert metadata["pointing_status"] == "ok"
+    assert metadata["t_mid_utc"] is not None
+    assert metadata["ra_deg"] is not None
+    assert metadata["error"] is None
 
 
 def test_scan_counts_read_failures(tmp_path: Path) -> None:
@@ -401,6 +428,48 @@ def test_incremental_cache_retries_failures_after_interval(tmp_path: Path, monke
     assert opened == [path.name]
     assert after_retry.metadata_retried == 1
     assert after_retry.metadata_failed == 0
+
+
+def test_retryable_failure_is_not_starved_by_uncached_backlog(tmp_path: Path, monkeypatch) -> None:
+    from dsacamera_monitor.scan import scan_directory
+
+    root = tmp_path / "incoming"
+    root.mkdir()
+    old_path = _make_named_files(root, ["2025-01-01T00:00:00"])[0]
+    attempts: dict[str, int] = {}
+    opened: list[str] = []
+
+    def fake_read(path: Path) -> dict:
+        opened.append(path.name)
+        attempts[path.name] = attempts.get(path.name, 0) + 1
+        return _cached_meta(path, failed=attempts[path.name] == 1)
+
+    monkeypatch.setattr("dsacamera_monitor.scan.read_pointing_metadata", fake_read)
+    cache = tmp_path / "cache.sqlite3"
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        metadata_cache_path=cache,
+        metadata_update_limit=1,
+        metadata_now=now,
+    )
+    new_path = _make_named_files(root, ["2025-01-01T01:00:00"])[0]
+    opened.clear()
+    retried = scan_directory(
+        root,
+        no_stat=True,
+        hdf5_metadata=True,
+        metadata_cache_path=cache,
+        metadata_update_limit=1,
+        metadata_retry_seconds=3600,
+        metadata_now=now + timedelta(hours=1),
+    )
+    assert opened == [old_path.name]
+    assert new_path.name not in opened
+    assert retried.metadata_retried == 1
+    assert retried.metadata_pending == 1
 
 
 def test_incremental_cache_ignores_removed_files_and_reports_manifest_progress(

--- a/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
+++ b/tools/dsacamera-monitor/tests/test_dsacamera_monitor.py
@@ -137,6 +137,21 @@ def test_build_out_copies_site(tmp_path: Path) -> None:
     assert '"schema_version": 2' in man
 
 
+def test_dashboard_explains_unavailable_or_warming_metadata(tmp_path: Path) -> None:
+    from dsacamera_monitor.scan import build_out
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "2025-01-01T00:00:00_sb01.hdf5").write_bytes(b"x")
+    out = tmp_path / "out"
+    build_out(root=src, out_dir=out, no_stat=True, hdf5_metadata=False)
+    html = (out / "index.html").read_text()
+    javascript = (out / "js" / "dashboard.js").read_text()
+    assert 'id="dec-metadata-status"' in html
+    assert 'id="pointing-metadata-status"' in html
+    assert "Metadata warming/unavailable" in javascript
+
+
 def test_pointing_timeseries_file(tmp_path: Path) -> None:
     import h5py
     import numpy as np


### PR DESCRIPTION
Refs #96

## Summary

- recover monitor generation with a 15-minute schedule, obsolete-run cancellation, stat-free scans, and ten-minute host timeouts
- add a durable host-local SQLite pointing cache with a 100-file update bound, one-hour failed-read retry, deterministic 5,000-row emission, and isolated cache failures
- make metadata-free dashboards explicitly show a warming/unavailable state while preserving counts, filename freshness, daily grouping, beams, and gaps
- validate post-deploy root and enabled monitor manifests for HTTP success, JSON contract, and `generated_at` age under 30 minutes
- document the recovery SLA, cache warm-up, manual dispatch, and variable rollback procedure

## Validation

- combined H17 CASA suite: **1,277 passed, 2 skipped**
- focused monitor/workflow suite: **28 passed**
- scoped Ruff, JS syntax, import migration, glossary verification, diff, and closeout gates passed
- independent final review: no actionable findings
- production-sized H17 fast scan: **73,587 files in 9.7s** with no stat/HDF5 metadata reads
- real cache evidence: bounded 100-file retry batch in 15.1s; warm 200-file scan in 4.8s with zero new HDF5 attempts

## Rollout

`MONITOR_POINTING_METADATA_ENABLED` is currently unset, so merge initially deploys metadata-free fast recovery. After two healthy scheduled cycles and fresh HTTP manifests, the variable can be enabled for bounded cache warm-up. Disabling it rolls back metadata reads without reverting the recovered count/freshness monitor.

Durable H17 evidence is under `/data/dsa110-continuum/outputs/green-refactor-issue-96/`.