### PR TITLE
Fix auto-cal convert_groups to accept timestamp-string groups

### DIFF
--- a/dsa110_continuum/conversion/calibrator_ms_generator.py
+++ b/dsa110_continuum/conversion/calibrator_ms_generator.py
@@ -406,7 +406,8 @@ class CalibratorMSGenerator:
         Parameters
         ----------
         groups : Sequence
-            List of SubbandGroup objects or file lists
+            List of group timestamp strings (as returned by
+            ``select_groups_by_position``), SubbandGroup objects, or file lists
         skip_existing : bool
             Skip conversion if MS already exists
 
@@ -421,14 +422,15 @@ class CalibratorMSGenerator:
         ms_paths = []
 
         for group in groups:
-            # Handle both SubbandGroup objects and raw file lists
-            files = group.files if hasattr(group, "files") else group
-            if not files:
-                continue
-
-            # Extract timestamp from first file
-            first_file = Path(files[0])
-            timestamp = first_file.stem.rsplit("_sb", 1)[0]
+            if isinstance(group, str):
+                # Group representative timestamp from select_groups_by_position
+                timestamp = group
+            else:
+                # SubbandGroup object or raw file list
+                files = group.files if hasattr(group, "files") else group
+                if not files:
+                    continue
+                timestamp = Path(files[0]).stem.rsplit("_sb", 1)[0]
 
             # Check if already exists
             ms_path = self.output_dir / f"{timestamp}.ms"

--- a/tests/test_calibrator_ms_generator.py
+++ b/tests/test_calibrator_ms_generator.py
@@ -141,3 +141,27 @@ class TestGenerateMultiple:
             )
         assert result.success
         assert convert.call_args.args[0] == [D1_GROUP]
+
+
+class TestConvertGroupsAcceptsTimestampStrings:
+    """select_groups_by_position returns timestamp strings; convert_groups must
+    treat a string group as the group timestamp, not a file list (regression:
+    it indexed the string, so Time("2", format="isot") raised ValueError and
+    auto-cal table generation always failed)."""
+
+    def test_string_group_uses_full_timestamp_window(self, generator):
+        import astropy.units as u
+
+        def fake_convert(**kwargs):
+            Path(kwargs["output_dir"], f"{kwargs['start_time']}.ms").mkdir(parents=True)
+
+        with patch(
+            "dsa110_continuum.conversion.convert_subband_groups_to_ms",
+            side_effect=fake_convert,
+        ) as conv:
+            ms_paths = generator.convert_groups([D1_GROUP])
+
+        kwargs = conv.call_args.kwargs
+        assert kwargs["start_time"] == D1_GROUP
+        assert kwargs["end_time"] == (Time(D1_GROUP, format="isot") + 2 * u.minute).isot
+        assert ms_paths == [generator.output_dir / f"{D1_GROUP}.ms"]


### PR DESCRIPTION
## Summary

`CalibratorMSGenerator.generate_from_transit` always failed: `select_groups_by_position` returns group **timestamp strings**, but `convert_groups` (`calibrator_ms_generator.py:441`) treated each string as a file list and indexed into it, so `Time("2", format="isot")` raised `ValueError`. Latent since the initial port — existing tests mocked `convert_groups`, so the path was never integration-tested.

Fix: a string group is now used as the group timestamp directly; `SubbandGroup` objects and raw file lists behave as before.

## Validation

- `tests/test_calibrator_ms_generator.py` — 9/9 pass (includes new `TestConvertGroupsAcceptsTimestampStrings` regression test asserting the full timestamp window and MS path).
- `ruff check` clean on both files.
- **Exercised live**: the 2026-07-13 hour-11 slow-vis batch run (campaign `outputs/slowvis-mosaic-campaign-2026-07-14/`) auto-generated same-date 3C454.3 (2253+161) BP/G tables through this exact path (provenance: `outputs/slowvis-mosaic-campaign-2026-07-14/provenance_h11.md`).

## Related

Filed during the same campaign audit: #102, #103, #104, #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)