### PR TITLE
Add conditional RFI mode with fail-closed preflight

### DIFF
--- a/dsa110_continuum/calibration/flagging_rfi.py
+++ b/dsa110_continuum/calibration/flagging_rfi.py
@@ -54,6 +54,7 @@ def flag_rfi(
     extend_flags: bool = True,
     clip_residual: bool = True,
     clip_sigma: float = 7.0,
+    fail_closed: bool = True,
 ) -> None:
     """Flag RFI using CASA or AOFlagger, with optional post-clip.
 
@@ -80,12 +81,20 @@ def flag_rfi(
         (default: True).  Only used when *backend* is ``"aoflagger"``.
     clip_sigma :
         Threshold in MAD-σ units for the residual clip (default: 7.0).
+    fail_closed :
+        Require the validated Stage 1/2/3 chain to complete. Science tile
+        processing uses the default; diagnostic callers may explicitly opt
+        into legacy warning-only behavior.
     """
     require_headless()
     from dsa110_continuum.utils.ms_permissions import ensure_ms_writable
 
     ensure_ms_writable(ms)
     if backend == "aoflagger":
+        if fail_closed and (not clip_residual or not extend_flags):
+            raise ValueError(
+                "fail_closed AOFlagger requires residual clipping and flag extension"
+            )
         flag_rfi_aoflagger(
             ms, datacolumn=datacolumn, aoflagger_path=aoflagger_path, strategy=strategy
         )
@@ -103,6 +112,8 @@ def flag_rfi(
                     "Post-AOFlagger sigma-clip failed; AOFlagger flags are intact.",
                     exc_info=True,
                 )
+                if fail_closed:
+                    raise
 
         # Extend flags after AOFlagger (if enabled)
         # Note: Flag extension may fail when using Docker due to permission issues
@@ -141,6 +152,8 @@ def flag_rfi(
                     logger.warning(
                         f"Flag extension failed: {e}. RFI flags from AOFlagger are still applied."
                     )
+                if fail_closed:
+                    raise
     else:
         # Two-stage RFI flagging using flagdata modes (tfcrop then rflag)
         service = CASAService()
@@ -357,7 +370,11 @@ def flag_rfi_aoflagger(
     cmd = aoflagger_cmd.copy()
 
     # Determine strategy to use
-    strategy_to_use = strategy or os.environ.get("CONTIMG_AOFLAGGER_STRATEGY")
+    strategy_to_use = (
+        strategy
+        or os.environ.get("CONTIMG_AOFLAGGER_STRATEGY")
+        or _get_default_aoflagger_strategy()
+    )
     if strategy_to_use is None or str(strategy_to_use).strip() == "":
         strategy_to_use = None
     logger.info("AOFlagger strategy: %s", strategy_to_use or "auto-detect")

--- a/dsa110_continuum/calibration/rfi_preflight.py
+++ b/dsa110_continuum/calibration/rfi_preflight.py
@@ -1,0 +1,284 @@
+"""Cheap, fail-closed RFI preflight for DSA-110 drift-scan tiles.
+
+The hard thresholds are anchored to the high-band RFI incident in tile
+2026-07-13T11:59:19. Metrics use finite, currently unflagged
+cross-correlations and map DATA_DESC_ID through DATA_DESCRIPTION before
+grouping by spectral window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+import numpy as np
+
+HIGH_MID_RATIO_TRIGGER = 2.0
+HIGH_BAND_FRAC_GT_1_TRIGGER = 0.08
+INTEGRATION_RATIO_TRIGGER = 2.0
+INTEGRATION_OCCUPANCY_TRIGGER = 0.25
+MID_BAND_SPWS = (6, 7, 8, 9)
+HIGH_BAND_SPWS = (14, 15)
+MIN_VALID_SAMPLES_PER_SPW = 1_000
+MIN_VALID_SAMPLES_PER_INTEGRATION = 100
+MIN_VALID_INTEGRATIONS = 4
+PREFLIGHT_POLICY_VERSION = "2026-07-13-highband-v1"
+
+_HISTOGRAM_EDGES = np.concatenate(([0.0], np.geomspace(1e-6, 100.0, 4096), [np.inf]))
+
+
+@dataclass(frozen=True)
+class SpwStats:
+    """Amplitude summaries for one spectral window."""
+
+    median: float
+    mad: float
+    p99: float
+    frac_gt_0_5: float
+    frac_gt_1_0: float
+    n_valid: int
+
+
+@dataclass(frozen=True)
+class PreflightDecision:
+    """Pure threshold decision produced from per-SPW and per-time metrics."""
+
+    triggered: bool
+    reasons: tuple[str, ...]
+    high_mid_ratio: float | None
+    integration_trigger_fraction: float | None
+    metrics_available: bool
+    policy_version: str = PREFLIGHT_POLICY_VERSION
+
+
+@dataclass(frozen=True)
+class PreflightResult:
+    """Measured preflight statistics and their fail-closed decision."""
+
+    spw_stats: Mapping[int, SpwStats]
+    integration_high_mid_ratios: np.ndarray
+    decision: PreflightDecision
+
+
+def evaluate_preflight_thresholds(
+    spw_stats: Mapping[int, SpwStats],
+    integration_high_mid_ratios: np.ndarray,
+) -> PreflightDecision:
+    """Evaluate the incident-derived hard thresholds without MS I/O.
+
+    Missing or undersampled required metrics trigger the full chain. Conditional
+    science processing may skip AOFlagger only when these metrics prove the tile
+    quiet.
+    """
+    reasons: list[str] = []
+    required = MID_BAND_SPWS + HIGH_BAND_SPWS
+    missing = [
+        spw
+        for spw in required
+        if spw not in spw_stats
+        or spw_stats[spw].n_valid < MIN_VALID_SAMPLES_PER_SPW
+        or not np.isfinite(spw_stats[spw].median)
+    ]
+    ratios = np.asarray(integration_high_mid_ratios, dtype=float)
+    ratios = ratios[np.isfinite(ratios)]
+    metrics_available = not missing and ratios.size >= MIN_VALID_INTEGRATIONS
+    if missing:
+        reasons.append(f"unavailable required SPW metrics: {missing}")
+    if ratios.size < MIN_VALID_INTEGRATIONS:
+        reasons.append(
+            f"insufficient per-integration high/mid ratios: "
+            f"{ratios.size} < {MIN_VALID_INTEGRATIONS}"
+        )
+
+    high_mid_ratio: float | None = None
+    integration_fraction: float | None = None
+    if not missing:
+        mid = float(np.median([spw_stats[spw].median for spw in MID_BAND_SPWS]))
+        if not np.isfinite(mid) or mid <= 0:
+            metrics_available = False
+            reasons.append("invalid mid-band denominator")
+        else:
+            high = max(spw_stats[14].median, spw_stats[15].median)
+            high_mid_ratio = float(high / mid)
+            if high_mid_ratio >= HIGH_MID_RATIO_TRIGGER:
+                reasons.append(
+                    f"high/mid ratio {high_mid_ratio:.3f} >= {HIGH_MID_RATIO_TRIGGER:.1f}"
+                )
+
+        high_frac = max(spw_stats[14].frac_gt_1_0, spw_stats[15].frac_gt_1_0)
+        if high_frac >= HIGH_BAND_FRAC_GT_1_TRIGGER:
+            reasons.append(
+                f"high-band frac(|V|>1 Jy) {high_frac:.3f} >= {HIGH_BAND_FRAC_GT_1_TRIGGER:.2f}"
+            )
+
+    if ratios.size:
+        integration_fraction = float(np.mean(ratios >= INTEGRATION_RATIO_TRIGGER))
+        if integration_fraction >= INTEGRATION_OCCUPANCY_TRIGGER:
+            reasons.append(
+                f"integration ratio occupancy {integration_fraction:.3f} "
+                f">= {INTEGRATION_OCCUPANCY_TRIGGER:.2f}"
+            )
+
+    return PreflightDecision(
+        triggered=bool(reasons),
+        reasons=tuple(reasons) if reasons else ("all hard thresholds quiet",),
+        high_mid_ratio=high_mid_ratio,
+        integration_trigger_fraction=integration_fraction,
+        metrics_available=metrics_available,
+    )
+
+
+def _rows_first(values: np.ndarray, nrows: int) -> np.ndarray:
+    """Normalize CASA/casacore row-axis layouts to rows first."""
+    values = np.asarray(values)
+    if values.shape[0] == nrows:
+        return values
+    if values.shape[-1] == nrows:
+        return np.moveaxis(values, -1, 0)
+    raise ValueError(f"Cannot identify row axis in shape {values.shape} for {nrows} rows")
+
+
+def _histogram_quantile(histogram: np.ndarray, quantile: float) -> float:
+    total = int(histogram.sum())
+    if total == 0:
+        return float("nan")
+    index = int(np.searchsorted(np.cumsum(histogram), quantile * total, side="left"))
+    index = min(index, len(_HISTOGRAM_EDGES) - 2)
+    lo = _HISTOGRAM_EDGES[index]
+    hi = _HISTOGRAM_EDGES[index + 1]
+    if not np.isfinite(hi):
+        return float(lo)
+    return float((lo + hi) / 2.0)
+
+
+def _selected_amplitudes(
+    data: np.ndarray,
+    flags: np.ndarray,
+    cross_rows: np.ndarray,
+) -> np.ndarray:
+    selected_data = data[cross_rows]
+    selected_flags = flags[cross_rows]
+    amplitudes = np.abs(selected_data)
+    good = (~selected_flags) & np.isfinite(amplitudes)
+    return amplitudes[good]
+
+
+def measure_rfi_preflight(
+    ms_path: str | Path,
+    *,
+    datacolumn: str = "DATA",
+    chunk_rows: int = 65_536,
+) -> PreflightResult:
+    """Measure chunked per-SPW and per-integration raw-amplitude statistics."""
+    from dsa110_continuum.adapters.casa_tables import table
+
+    ms_path = str(ms_path)
+    with table(f"{ms_path}/DATA_DESCRIPTION", readonly=True, ack=False) as dd_table:
+        dd_to_spw = np.asarray(dd_table.getcol("SPECTRAL_WINDOW_ID"), dtype=int)
+
+    histograms: dict[int, np.ndarray] = {}
+    counts: dict[int, int] = {}
+    counts_gt_0_5: dict[int, int] = {}
+    counts_gt_1_0: dict[int, int] = {}
+    time_histograms: dict[tuple[int, float], np.ndarray] = {}
+
+    with table(ms_path, readonly=True, ack=False) as main:
+        nrows_total = int(main.nrows())
+        for start in range(0, nrows_total, chunk_rows):
+            nrows = min(chunk_rows, nrows_total - start)
+            data = _rows_first(main.getcol(datacolumn, startrow=start, nrow=nrows), nrows)
+            flags = _rows_first(main.getcol("FLAG", startrow=start, nrow=nrows), nrows)
+            ant1 = np.asarray(main.getcol("ANTENNA1", startrow=start, nrow=nrows))
+            ant2 = np.asarray(main.getcol("ANTENNA2", startrow=start, nrow=nrows))
+            ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
+            times = np.asarray(main.getcol("TIME", startrow=start, nrow=nrows), dtype=float)
+            spws = dd_to_spw[ddids]
+            cross = ant1 != ant2
+
+            for spw in np.unique(spws[cross]):
+                spw = int(spw)
+                spw_rows = cross & (spws == spw)
+                amplitudes = _selected_amplitudes(data, flags, spw_rows)
+                if amplitudes.size:
+                    histograms.setdefault(spw, np.zeros(len(_HISTOGRAM_EDGES) - 1, dtype=np.int64))
+                    histograms[spw] += np.histogram(amplitudes, bins=_HISTOGRAM_EDGES)[0]
+                    counts[spw] = counts.get(spw, 0) + int(amplitudes.size)
+                    counts_gt_0_5[spw] = counts_gt_0_5.get(spw, 0) + int(
+                        np.count_nonzero(amplitudes > 0.5)
+                    )
+                    counts_gt_1_0[spw] = counts_gt_1_0.get(spw, 0) + int(
+                        np.count_nonzero(amplitudes > 1.0)
+                    )
+
+                if spw in required_spws_for_time_metrics():
+                    for timestamp in np.unique(times[spw_rows]):
+                        rows = spw_rows & (times == timestamp)
+                        time_amplitudes = _selected_amplitudes(data, flags, rows)
+                        if time_amplitudes.size:
+                            key = (spw, float(timestamp))
+                            time_histograms.setdefault(
+                                key, np.zeros(len(_HISTOGRAM_EDGES) - 1, dtype=np.int64)
+                            )
+                            time_histograms[key] += np.histogram(
+                                time_amplitudes, bins=_HISTOGRAM_EDGES
+                            )[0]
+
+    medians = {spw: _histogram_quantile(hist, 0.5) for spw, hist in histograms.items()}
+    deviation_histograms = {
+        spw: np.zeros(len(_HISTOGRAM_EDGES) - 1, dtype=np.int64) for spw in histograms
+    }
+    with table(ms_path, readonly=True, ack=False) as main:
+        nrows_total = int(main.nrows())
+        for start in range(0, nrows_total, chunk_rows):
+            nrows = min(chunk_rows, nrows_total - start)
+            data = _rows_first(main.getcol(datacolumn, startrow=start, nrow=nrows), nrows)
+            flags = _rows_first(main.getcol("FLAG", startrow=start, nrow=nrows), nrows)
+            ant1 = np.asarray(main.getcol("ANTENNA1", startrow=start, nrow=nrows))
+            ant2 = np.asarray(main.getcol("ANTENNA2", startrow=start, nrow=nrows))
+            ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
+            spws = dd_to_spw[ddids]
+            cross = ant1 != ant2
+            for spw in np.unique(spws[cross]):
+                spw = int(spw)
+                amplitudes = _selected_amplitudes(data, flags, cross & (spws == spw))
+                if amplitudes.size and spw in medians:
+                    deviation_histograms[spw] += np.histogram(
+                        np.abs(amplitudes - medians[spw]), bins=_HISTOGRAM_EDGES
+                    )[0]
+
+    spw_stats = {
+        spw: SpwStats(
+            median=medians[spw],
+            mad=_histogram_quantile(deviation_histograms[spw], 0.5),
+            p99=_histogram_quantile(histograms[spw], 0.99),
+            frac_gt_0_5=counts_gt_0_5.get(spw, 0) / counts[spw],
+            frac_gt_1_0=counts_gt_1_0.get(spw, 0) / counts[spw],
+            n_valid=counts[spw],
+        )
+        for spw in histograms
+        if counts.get(spw, 0) > 0
+    }
+
+    integration_ratios: list[float] = []
+    timestamps = sorted({timestamp for _, timestamp in time_histograms})
+    for timestamp in timestamps:
+        per_spw = {
+            spw: _histogram_quantile(time_histograms[(spw, timestamp)], 0.5)
+            for spw in required_spws_for_time_metrics()
+            if (spw, timestamp) in time_histograms
+            and time_histograms[(spw, timestamp)].sum() >= MIN_VALID_SAMPLES_PER_INTEGRATION
+        }
+        if all(spw in per_spw for spw in MID_BAND_SPWS + HIGH_BAND_SPWS):
+            mid = float(np.median([per_spw[spw] for spw in MID_BAND_SPWS]))
+            if np.isfinite(mid) and mid > 0:
+                integration_ratios.append(max(per_spw[14], per_spw[15]) / mid)
+
+    ratio_array = np.asarray(integration_ratios, dtype=float)
+    decision = evaluate_preflight_thresholds(spw_stats, ratio_array)
+    return PreflightResult(spw_stats, ratio_array, decision)
+
+
+def required_spws_for_time_metrics() -> tuple[int, ...]:
+    """Return SPWs needed for the high/mid per-integration trigger."""
+    return MID_BAND_SPWS + HIGH_BAND_SPWS

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -607,7 +607,9 @@ def _collect_dry_run_plan(
     quarantine_set: set[str],
     skip_epoch_gaincal: bool,
     skip_photometry: bool,
+    skip_rfi_flagging: bool,
     lenient_qa: bool,
+    rfi_mode: str = "full",
 ) -> dict:
     """Build a structured plan dict describing what a normal run would do.
 
@@ -645,6 +647,13 @@ def _collect_dry_run_plan(
         "quarantine_count": n_quarantined,
         "quarantine_ms_paths": sorted(ms for ms in ms_list_after_filters if ms in quarantine_set),
         "phase0_gaincal": "skipped (--skip-epoch-gaincal)" if skip_epoch_gaincal else "would run",
+        "phase1_rfi_flagging": (
+            "off (DEGRADED; no RFI chain)"
+            if skip_rfi_flagging or rfi_mode == "off"
+            else "conditional (Stage 0; Stage 1/2/3 on hard trigger)"
+            if rfi_mode == "conditional"
+            else "full (Stage 0 + mandatory Stage 1/2/3)"
+        ),
         "phase1_tiles_to_attempt": n_to_attempt,
         "phase1_tiles_quarantined": n_quarantined,
         "phase2_epochs_to_rebuild": n_epoch_rebuild,
@@ -683,6 +692,7 @@ def _format_dry_run_plan(plan: dict) -> list[str]:
         )
     lines.extend([
         f"Phase 0 (gaincal):    {plan['phase0_gaincal']}",
+        f"Phase 1 RFI:          {plan['phase1_rfi_flagging']}",
         f"Phase 1 (per-tile):   would attempt {plan['phase1_tiles_to_attempt']} tiles "
         f"({plan['phase1_tiles_quarantined']} quarantined)",
         f"Phase 2 (mosaic):     {plan['phase2_epochs_to_rebuild']} rebuild, "
@@ -823,7 +833,9 @@ def _dry_run_main(args, date: str, cal_date: str, obs_dec_deg: float | None) -> 
         quarantine_set=quarantine_set,
         skip_epoch_gaincal=args.skip_epoch_gaincal,
         skip_photometry=args.skip_photometry,
+        skip_rfi_flagging=False,
         lenient_qa=args.lenient_qa,
+        rfi_mode=getattr(args, "rfi_mode", "off" if args.no_rfi_flagging else "full"),
     )
     for line in _format_dry_run_plan(plan):
         log.info("%s", line)
@@ -1259,6 +1271,24 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--rfi-mode",
+        choices=("full", "conditional", "off"),
+        default=None,
+        help=(
+            "RFI policy: full runs Stage 0+1/2/3 (default), conditional runs "
+            "Stage 0 and triggers Stage 1/2/3 from preflight, off bypasses the chain."
+        ),
+    )
+    parser.add_argument(
+        "--no-rfi-flagging",
+        action="store_true",
+        default=False,
+        help=(
+            "Deprecated alias for --rfi-mode off. This bypasses Stage 0 and "
+            "Stage 1/2/3 and marks the run DEGRADED."
+        ),
+    )
+    parser.add_argument(
         "--start-hour",
         type=int,
         default=None,
@@ -1319,6 +1349,12 @@ def main() -> None:
             "gate so the run finishes with pipeline_verdict=DEGRADED. Use only "
             "for investigative re-runs; the default is strict (skip)."
         ),
+    )
+    parser.add_argument(
+        "--include-qa-failed-tiles",
+        action="store_true",
+        default=False,
+        help="Diagnostic override: include tiles that fail the 50 mJy MAD gate.",
     )
     parser.add_argument(
         "--archive-all",
@@ -1392,6 +1428,12 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+    from mosaic_day import resolve_rfi_mode  # type: ignore
+
+    try:
+        args.rfi_mode = resolve_rfi_mode(args.rfi_mode, args.no_rfi_flagging)
+    except ValueError as error:
+        parser.error(str(error))
 
     date = args.date
     cal_date = args.cal_date if args.cal_date is not None else date
@@ -1561,6 +1603,18 @@ def main() -> None:
         image_dir=paths["stage_dir"],
         products_dir=paths["products_dir"],
     )
+    cfg = cfg.replace(
+        rfi_mode=args.rfi_mode,
+        include_qa_failed_tiles=args.include_qa_failed_tiles,
+    )
+    log.info("Per-tile RFI mode: %s", args.rfi_mode)
+    if args.rfi_mode == "off":
+        log.error("DEGRADED: RFI chain disabled; outputs have no science-promotion semantics")
+        manifest.add_gate(
+            gate="rfi_mode",
+            verdict="DEGRADED",
+            reason="RFI mode off: Stage 0 and Stage 1/2/3 bypassed",
+        )
 
     # ── Phase 1: Find + validate MS files ────────────────────────────────────
     ms_list = _md.find_valid_ms(cfg)
@@ -1902,6 +1956,25 @@ def main() -> None:
         "Tiles: %d imaged, %d already done, %d failed, %d quarantined",
         n_imaged, n_skipped_tiles, n_failed_tiles, n_quarantined,
     )
+
+    # Final safety net for checkpoint/resume state: every path is revalidated
+    # immediately before epoch binning, even if it entered from an older cache.
+    qa_accepted_tiles: list[str] = []
+    for tile_path in tile_fits:
+        accepted, reason = _md.validate_tile_for_coadd(
+            tile_path, cfg, Path(tile_path).stem
+        )
+        if accepted:
+            qa_accepted_tiles.append(tile_path)
+        else:
+            log.error("Excluding tile from every coadd: %s (%s)", tile_path, reason)
+            manifest.add_gate(
+                gate="tile_mad",
+                verdict="BLOCKED",
+                reason=reason,
+                tile_path=tile_path,
+            )
+    tile_fits = qa_accepted_tiles
 
     if len(tile_fits) < 2:
         log.error("Too few tiles to mosaic (%d) — aborting", len(tile_fits))

--- a/scripts/mosaic_day.py
+++ b/scripts/mosaic_day.py
@@ -26,6 +26,7 @@ import os
 import shutil
 import sys
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 from astropy.io import fits
@@ -48,6 +49,10 @@ logging.basicConfig(
     datefmt="%H:%M:%S",
 )
 log = logging.getLogger(__name__)
+
+RfiMode = Literal["full", "conditional", "off"]
+RFI_MODES = ("full", "conditional", "off")
+TILE_MAD_MAX_MJY = 50.0
 
 
 # ── Cal-path resolution (inlined to avoid dependency on untracked ensure.py) ─
@@ -85,7 +90,17 @@ class TileConfig:
     products_dir: str
     bp_table: str
     g_table: str
-    rfi_flagging: bool = True
+    rfi_mode: RfiMode = "full"
+    include_qa_failed_tiles: bool = False
+
+    def __post_init__(self) -> None:
+        if self.rfi_mode not in RFI_MODES:
+            raise ValueError(f"Invalid RFI mode {self.rfi_mode!r}; choose from {RFI_MODES}")
+
+    @property
+    def rfi_flagging(self) -> bool:
+        """Compatibility view: any mode except ``off`` performs RFI work."""
+        return self.rfi_mode != "off"
 
     @staticmethod
     def build(
@@ -267,10 +282,144 @@ def _fits_is_valid(fits_path: str) -> bool:
         with fits.open(fits_path) as hdul:
             if len(hdul) < 1 or hdul[0].data is None:
                 return False
-            _ = hdul[0].data.shape  # triggers decompression, catches truncation
+            _ = hdul[0].data.shape
             return True
     except Exception:
         return False
+
+
+def resolve_rfi_mode(rfi_mode: str | None, no_rfi_flagging: bool) -> RfiMode:
+    """Resolve the explicit mode and deprecated bypass alias without ambiguity."""
+    if no_rfi_flagging and rfi_mode not in (None, "off"):
+        raise ValueError(
+            "--no-rfi-flagging is a deprecated alias for --rfi-mode off and "
+            f"cannot be combined with --rfi-mode {rfi_mode}"
+        )
+    if no_rfi_flagging:
+        return "off"
+    return rfi_mode or "full"
+
+
+def tile_mad_rms_mjy(data: np.ndarray) -> float | None:
+    """Return finite-pixel MAD RMS in mJy, or None when no pixels are usable."""
+    valid = np.asarray(data)[np.isfinite(data)]
+    if valid.size == 0:
+        return None
+    median = float(np.median(valid))
+    return float(1.4826 * np.median(np.abs(valid - median)) * 1000.0)
+
+
+def tile_mad_gate(
+    data: np.ndarray,
+    *,
+    include_qa_failed_tiles: bool = False,
+    max_mad_rms_mjy: float = TILE_MAD_MAX_MJY,
+) -> tuple[bool, str]:
+    """Pure pre-coadd absolute MAD gate used by cached and fresh tile paths."""
+    mad_rms_mjy = tile_mad_rms_mjy(data)
+    if mad_rms_mjy is None:
+        return False, "no valid pixels"
+    if mad_rms_mjy > max_mad_rms_mjy:
+        reason = f"MAD RMS {mad_rms_mjy:.1f} mJy > {max_mad_rms_mjy:.0f} mJy"
+        if include_qa_failed_tiles:
+            return True, f"diagnostic override: {reason}"
+        return False, reason
+    return True, f"MAD RMS {mad_rms_mjy:.1f} mJy"
+
+
+def validate_tile_for_coadd(fits_path: str, cfg: TileConfig, tag: str) -> tuple[bool, str]:
+    """Apply structural image QA and the strict MAD gate before coaddition."""
+    from dsa110_continuum.validation.image_validator import validate_image_quality
+
+    tile_ok, tile_errors = validate_image_quality(
+        Path(fits_path),
+        min_snr=3.0,
+        max_flagged_fraction=0.5,
+        max_mad_rms_mjy=TILE_MAD_MAX_MJY,
+    )
+    if tile_ok:
+        return True, "tile QA passed"
+    for error in tile_errors:
+        log.warning("[%s] Tile QA: %s", tag, error)
+    always_fatal = [
+        error
+        for error in tile_errors
+        if "all zeros" in error.lower() or "no valid pixels" in error.lower()
+    ]
+    mad_failures = [error for error in tile_errors if "mad rms too high" in error.lower()]
+    if always_fatal:
+        return False, "; ".join(always_fatal)
+    if mad_failures and not cfg.include_qa_failed_tiles:
+        return False, "; ".join(mad_failures)
+    if mad_failures:
+        log.error(
+            "[%s] DEGRADED: including MAD-failed tile via --include-qa-failed-tiles",
+            tag,
+        )
+    return True, "; ".join(tile_errors)
+
+
+def _run_stage0(ms_path: str) -> None:
+    """Run the conservative pre-calibration Stage-0 flagging sequence."""
+    from dsa110_continuum.calibration.flagging import (
+        detect_and_flag_dead_antennas,
+        flag_autocorrelations,
+        flag_clip_amplitude,
+        flag_zeros,
+    )
+
+    flag_zeros(ms_path, datacolumn="data")
+    flag_autocorrelations(ms_path, datacolumn="data")
+    flag_clip_amplitude(ms_path, threshold_max=0.5, datacolumn="data")
+    detect_and_flag_dead_antennas(ms_path, threshold=0.95, dry_run=False)
+
+
+def _rfi_sentinel_path(meridian_ms: str, mode: RfiMode) -> str:
+    """Return a policy-versioned completion sentinel for RFI processing."""
+    from dsa110_continuum.calibration.rfi_preflight import PREFLIGHT_POLICY_VERSION
+
+    return f"{meridian_ms.rstrip('/')}.rfi_{PREFLIGHT_POLICY_VERSION}_{mode}_done"
+
+
+def _execute_rfi_policy(meridian_ms: str, mode: RfiMode, tag: str) -> None:
+    """Execute Stage 0 and, when selected, the mandatory full RFI chain."""
+    from dsa110_continuum.calibration.flagging_rfi import flag_rfi
+    from dsa110_continuum.calibration.rfi_preflight import measure_rfi_preflight
+
+    run_full_chain = mode == "full"
+    if mode == "conditional":
+        try:
+            preflight = measure_rfi_preflight(meridian_ms, datacolumn="DATA")
+            run_full_chain = preflight.decision.triggered
+            log.info(
+                "[%s] Conditional RFI preflight: trigger=%s; %s",
+                tag,
+                run_full_chain,
+                "; ".join(preflight.decision.reasons),
+            )
+        except Exception as preflight_error:
+            run_full_chain = True
+            log.error(
+                "[%s] Conditional RFI preflight unavailable; failing closed to full chain: %s",
+                tag,
+                preflight_error,
+            )
+
+    log.info("[%s] Running conservative RFI Stage 0", tag)
+    _run_stage0(meridian_ms)
+    if run_full_chain:
+        log.info("[%s] Applying mandatory RFI Stage 1/2/3 chain", tag)
+        flag_rfi(
+            meridian_ms,
+            datacolumn="data",
+            backend="aoflagger",
+            clip_residual=True,
+            clip_sigma=7.0,
+            extend_flags=True,
+            fail_closed=True,
+        )
+    else:
+        log.info("[%s] Preflight quiet: Stage 0 only", tag)
 
 
 def generate_windows(
@@ -342,11 +491,19 @@ def process_ms(
     # Skip if already fully processed — unless force_recal requests a fresh run
     if not force_recal:
         if _fits_is_valid(pbcor_fits):
-            log.info("[%s] PB-corrected image already exists — skipping", tag)
-            return TileResult("cached", fits_path=pbcor_fits)
+            accepted, reason = validate_tile_for_coadd(pbcor_fits, cfg, tag)
+            if accepted:
+                log.info("[%s] PB-corrected image already exists — skipping", tag)
+                return TileResult("cached", fits_path=pbcor_fits)
+            log.error("[%s] Cached tile rejected before coadd: %s", tag, reason)
+            return TileResult("failed", failed_stage="qa", error=reason)
         if _fits_is_valid(image_fits):
-            log.info("[%s] Image already exists (no pbcor) — skipping", tag)
-            return TileResult("cached", fits_path=image_fits)
+            accepted, reason = validate_tile_for_coadd(image_fits, cfg, tag)
+            if accepted:
+                log.info("[%s] Image already exists (no pbcor) — skipping", tag)
+                return TileResult("cached", fits_path=image_fits)
+            log.error("[%s] Cached tile rejected before coadd: %s", tag, reason)
+            return TileResult("failed", failed_stage="qa", error=reason)
         # Remove partial/corrupt FITS so imaging reruns cleanly
         for partial in (pbcor_fits, image_fits):
             if os.path.isfile(partial):
@@ -364,6 +521,8 @@ def process_ms(
         # Invalidate stale sentinel — the MS it referred to is gone
         if os.path.isfile(sentinel):
             os.remove(sentinel)
+        for stale_rfi_sentinel in glob.glob(f"{meridian_ms}.rfi_*_done"):
+            os.remove(stale_rfi_sentinel)
         if os.path.isdir(meridian_ms):
             log.warning(
                 "[%s] Corrupt or incomplete meridian MS detected — removing: %s", tag, meridian_ms
@@ -388,21 +547,30 @@ def process_ms(
             "trusting sentinel (use --force-recal to override)",
             tag,
         )
-    if applycal_needed:
-        if os.path.isfile(sentinel):
-            os.remove(sentinel)  # clear stale sentinel before starting
-        if cfg.rfi_flagging:
-            log.info("[%s] Applying two-stage RFI flagging before calibration ...", tag)
-            try:
-                # This is deliberately before applycal and imaging.  RFI left in
-                # the raw visibility data produces non-deconvolvable snapshot
-                # sidelobes; post-imaging clipping cannot repair that corruption.
-                from dsa110_continuum.calibration.flagging_rfi import flag_rfi
 
-                flag_rfi(meridian_ms, datacolumn="data", backend="aoflagger")
+    if cfg.rfi_mode == "off":
+        log.error(
+            "[%s] DEGRADED: RFI mode off; skipping Stage 0 and Stage 1/2/3. "
+            "Tile is diagnostic/emergency output only.",
+            tag,
+        )
+    else:
+        rfi_sentinel = _rfi_sentinel_path(meridian_ms, cfg.rfi_mode)
+        if force_recal or not os.path.isfile(rfi_sentinel):
+            try:
+                _execute_rfi_policy(meridian_ms, cfg.rfi_mode, tag)
+                Path(rfi_sentinel).write_text(
+                    f"mode={cfg.rfi_mode}\ncompleted=stage0-and-policy-action\n"
+                )
             except Exception as e:
                 log.error("[%s] RFI flagging failed: %s", tag, e)
                 return TileResult("failed", failed_stage="rfi_flagging", error=str(e))
+        else:
+            log.info("[%s] RFI policy already completed: %s", tag, rfi_sentinel)
+
+    if applycal_needed:
+        if os.path.isfile(sentinel):
+            os.remove(sentinel)  # clear stale sentinel before starting
         log.info("[%s] Applying calibration (force_recal=%s) ...", tag, force_recal)
         try:
             apply_to_target(
@@ -475,20 +643,10 @@ def process_ms(
         return TileResult("failed", failed_stage="no_output", error="no FITS after WSClean")
 
     # ── Per-tile image QA ─────────────────────────────────────────────────
-    from dsa110_continuum.validation.image_validator import validate_image_quality
-
-    tile_ok, tile_errors = validate_image_quality(
-        Path(result_fits), min_snr=3.0, max_flagged_fraction=0.5
-    )
+    tile_ok, tile_reason = validate_tile_for_coadd(result_fits, cfg, tag)
     if not tile_ok:
-        for err in tile_errors:
-            log.warning("[%s] Tile QA: %s", tag, err)
-        fatal = [
-            e for e in tile_errors if "all zeros" in e.lower() or "no valid pixels" in e.lower()
-        ]
-        if fatal:
-            log.error("[%s] Tile rejected by image QA", tag)
-            return TileResult("failed", failed_stage="qa", error="; ".join(fatal))
+        log.error("[%s] Tile rejected before coadd: %s", tag, tile_reason)
+        return TileResult("failed", failed_stage="qa", error=tile_reason)
 
     # ── Cleanup: delete meridian MS + sentinel now that imaging succeeded ─────
     if not keep_intermediates and os.path.isdir(meridian_ms):
@@ -500,6 +658,11 @@ def process_ms(
         if os.path.isfile(sentinel):
             try:
                 os.remove(sentinel)
+            except OSError:
+                pass
+        for completed_rfi_sentinel in glob.glob(f"{meridian_ms}.rfi_*_done"):
+            try:
+                os.remove(completed_rfi_sentinel)
             except OSError:
                 pass
 
@@ -787,6 +950,27 @@ def main():
         help="Keep *_meridian.ms files and skip moving the mosaic to products/ (useful for debugging).",
     )
     parser.add_argument(
+        "--rfi-mode",
+        choices=RFI_MODES,
+        default=None,
+        help=(
+            "RFI policy: full runs Stage 0+1/2/3 (default), conditional runs "
+            "Stage 0 and triggers Stage 1/2/3 from preflight, off bypasses all RFI flagging."
+        ),
+    )
+    parser.add_argument(
+        "--no-rfi-flagging",
+        action="store_true",
+        default=False,
+        help="Deprecated alias for --rfi-mode off.",
+    )
+    parser.add_argument(
+        "--include-qa-failed-tiles",
+        action="store_true",
+        default=False,
+        help="Diagnostic override: include tiles that fail the 50 mJy MAD gate.",
+    )
+    parser.add_argument(
         "--window-tiles",
         type=int,
         default=12,
@@ -817,6 +1001,10 @@ def main():
         ),
     )
     args = parser.parse_args()
+    try:
+        rfi_mode = resolve_rfi_mode(args.rfi_mode, args.no_rfi_flagging)
+    except ValueError as error:
+        parser.error(str(error))
     keep = args.keep_intermediates
 
     # ── Validate windowing parameters ─────────────────────────────────────────
@@ -828,7 +1016,12 @@ def main():
             sys.exit(1)
 
     # Build immutable config from CLI args
-    cfg = TileConfig.build(date=args.date, cal_date=args.cal_date)
+    cfg = TileConfig.build(date=args.date, cal_date=args.cal_date).replace(
+        rfi_mode=rfi_mode,
+        include_qa_failed_tiles=args.include_qa_failed_tiles,
+    )
+    if rfi_mode == "off":
+        log.error("DEGRADED: --rfi-mode off selected; outputs are diagnostic only")
 
     # ── Cal-table validation (ABORT early if missing) ─────────────────────────
     _missing = [t for t in [cfg.bp_table, cfg.g_table] if not os.path.exists(t)]

--- a/tests/test_batch_e2_hygiene.py
+++ b/tests/test_batch_e2_hygiene.py
@@ -324,6 +324,7 @@ def test_dry_run_main_handles_missing_ms_dir(tmp_path, monkeypatch, caplog):
         quarantine_after_failures=3,
         skip_epoch_gaincal=False,
         skip_photometry=False,
+        no_rfi_flagging=False,
         lenient_qa=False,
         start_hour=None,
         end_hour=None,

--- a/tests/test_batch_pipeline_dry_run_quarantine.py
+++ b/tests/test_batch_pipeline_dry_run_quarantine.py
@@ -175,6 +175,7 @@ def test_collect_plan_basic_fields():
         quarantine_set={"/ms/c.ms"},
         skip_epoch_gaincal=False,
         skip_photometry=False,
+        skip_rfi_flagging=False,
         lenient_qa=False,
     )
     assert plan["date"] == "2026-04-27"
@@ -203,6 +204,7 @@ def test_collect_plan_lenient_qa_field():
         quarantine_threshold=3, quarantine_set=set(),
         skip_epoch_gaincal=False,
         skip_photometry=False,
+        skip_rfi_flagging=False,
         lenient_qa=True,
     )
     assert "lenient" in plan["phase3_photometry"]
@@ -221,7 +223,8 @@ def test_format_plan_includes_quarantine_lines():
         prior_manifest_verdict="DEGRADED", prior_manifest_present=True,
         checkpoint_completed=0, checkpoint_failures=[],
         quarantine_threshold=3, quarantine_set={"/ms/q.ms"},
-        skip_epoch_gaincal=False, skip_photometry=False, lenient_qa=False,
+        skip_epoch_gaincal=False, skip_photometry=False,
+        skip_rfi_flagging=False, lenient_qa=False,
     )
     lines = bp._format_dry_run_plan(plan)
     text = "\n".join(lines)
@@ -365,6 +368,7 @@ def test_dry_run_does_not_create_products_or_log(tmp_path, monkeypatch, caplog):
         quarantine_after_failures=3,
         skip_epoch_gaincal=False,
         skip_photometry=False,
+        no_rfi_flagging=False,
         lenient_qa=False,
         start_hour=None,
         end_hour=None,

--- a/tests/test_rfi_mode.py
+++ b/tests/test_rfi_mode.py
@@ -1,0 +1,113 @@
+"""RFI mode and fail-closed chain tests."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from dsa110_continuum.calibration.flagging_rfi import flag_rfi, flag_rfi_aoflagger
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from mosaic_day import RFI_MODES, TileConfig, resolve_rfi_mode
+
+
+def _config(rfi_mode="full") -> TileConfig:
+    return TileConfig(
+        date="2026-07-13",
+        ms_dir="/ms",
+        image_dir="/images",
+        mosaic_out="/images/mosaic.fits",
+        products_dir="/products",
+        bp_table="/ms/test.b",
+        g_table="/ms/test.g",
+        rfi_mode=rfi_mode,
+    )
+
+
+@pytest.mark.parametrize("mode", RFI_MODES)
+def test_tile_config_accepts_explicit_modes(mode):
+    cfg = _config(mode)
+    assert cfg.rfi_mode == mode
+    assert cfg.rfi_flagging is (mode != "off")
+
+
+def test_full_is_default_and_conditional_is_opt_in():
+    assert resolve_rfi_mode(None, False) == "full"
+    assert resolve_rfi_mode("conditional", False) == "conditional"
+
+
+def test_deprecated_no_rfi_alias_means_off_only():
+    assert resolve_rfi_mode(None, True) == "off"
+    assert resolve_rfi_mode("off", True) == "off"
+    with pytest.raises(ValueError, match="deprecated alias"):
+        resolve_rfi_mode("conditional", True)
+
+
+def test_batch_cli_rejects_conflicting_rfi_flags(monkeypatch):
+    import batch_pipeline
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "batch_pipeline.py",
+            "--rfi-mode",
+            "conditional",
+            "--no-rfi-flagging",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        batch_pipeline.main()
+
+    assert error.value.code == 2
+
+
+def _run_flag_rfi_with(stage2=None, stage3=None):
+    with (
+        patch("dsa110_continuum.calibration.flagging_rfi.require_headless"),
+        patch("dsa110_continuum.utils.ms_permissions.ensure_ms_writable"),
+        patch("dsa110_continuum.calibration.flagging_rfi.flag_rfi_aoflagger"),
+        patch(
+            "dsa110_continuum.calibration.flagging_rfi.flag_residual_rfi_clip",
+            side_effect=stage2,
+        ),
+        patch(
+            "dsa110_continuum.calibration.flagging_rfi.flag_extend",
+            side_effect=stage3,
+        ),
+        patch("dsa110_continuum.calibration.flagging_rfi.time.sleep"),
+    ):
+        flag_rfi(str(Path("fake.ms")), backend="aoflagger", fail_closed=True)
+
+
+def test_stage2_failure_is_fatal_for_science_chain():
+    with pytest.raises(RuntimeError, match="stage 2"):
+        _run_flag_rfi_with(stage2=RuntimeError("stage 2 failed"))
+
+
+def test_stage3_failure_is_fatal_for_science_chain():
+    with pytest.raises(RuntimeError, match="stage 3"):
+        _run_flag_rfi_with(stage3=RuntimeError("stage 3 failed"))
+
+
+def test_aoflagger_uses_tuned_default_strategy_when_unset(monkeypatch):
+    monkeypatch.delenv("CONTIMG_AOFLAGGER_STRATEGY", raising=False)
+    with (
+        patch("dsa110_continuum.calibration.flagging_rfi.require_headless"),
+        patch(
+            "dsa110_continuum.calibration.flagging_rfi.shutil.which",
+            side_effect=lambda name: "/usr/bin/aoflagger" if name == "aoflagger" else None,
+        ),
+        patch(
+            "dsa110_continuum.calibration.flagging_rfi._get_default_aoflagger_strategy",
+            return_value="/data/dsa110-contimg/config/dsa110-default.lua",
+        ),
+        patch("dsa110_continuum.calibration.flagging_rfi.subprocess.run") as run,
+    ):
+        flag_rfi_aoflagger("fake.ms")
+
+    command = run.call_args.args[0]
+    assert command[command.index("-strategy") + 1] == (
+        "/data/dsa110-contimg/config/dsa110-default.lua"
+    )

--- a/tests/test_rfi_preflight.py
+++ b/tests/test_rfi_preflight.py
@@ -1,0 +1,57 @@
+"""Synthetic tests for the conditional RFI hard thresholds."""
+
+import numpy as np
+from dsa110_continuum.calibration.rfi_preflight import (
+    SpwStats,
+    evaluate_preflight_thresholds,
+)
+
+
+def _stats(high_median: float, high_frac: float) -> dict[int, SpwStats]:
+    stats = {spw: SpwStats(0.05, 0.005, 0.09, 0.01, 0.02, 20_000) for spw in range(16)}
+    stats[14] = SpwStats(high_median * 0.95, 0.01, 1.2, 0.1, high_frac, 20_000)
+    stats[15] = SpwStats(high_median, 0.01, 1.5, 0.1, high_frac, 20_000)
+    return stats
+
+
+def test_quiet_tile_does_not_trigger():
+    decision = evaluate_preflight_thresholds(
+        _stats(high_median=0.0685, high_frac=0.034),
+        np.array([1.1] * 23 + [2.1]),
+    )
+
+    assert not decision.triggered
+    assert decision.metrics_available
+
+
+def test_1159_like_tile_triggers_all_incident_signals():
+    decision = evaluate_preflight_thresholds(
+        _stats(high_median=0.26, high_frac=0.153),
+        np.full(24, 5.2),
+    )
+
+    assert decision.triggered
+    assert decision.high_mid_ratio >= 5.0
+    assert decision.integration_trigger_fraction == 1.0
+    assert len(decision.reasons) == 3
+
+
+def test_1204_like_episode_tail_still_triggers():
+    decision = evaluate_preflight_thresholds(
+        _stats(high_median=0.12, high_frac=0.085),
+        np.array([2.4] * 8 + [1.6] * 16),
+    )
+
+    assert decision.triggered
+    assert decision.high_mid_ratio >= 2.0
+    assert decision.integration_trigger_fraction >= 0.25
+
+
+def test_missing_required_metrics_fail_closed():
+    stats = _stats(high_median=0.06, high_frac=0.01)
+    del stats[15]
+
+    decision = evaluate_preflight_thresholds(stats, np.array([]))
+
+    assert decision.triggered
+    assert not decision.metrics_available

--- a/tests/test_stage_checkpoint.py
+++ b/tests/test_stage_checkpoint.py
@@ -74,6 +74,7 @@ def _make_cfg(tmp_path):
         products_dir=str(tmp_path / "products"),
         bp_table=bp,
         g_table=ga,
+        rfi_mode="off",
     )
 
 

--- a/tests/test_tile_mad_gate.py
+++ b/tests/test_tile_mad_gate.py
@@ -1,0 +1,43 @@
+"""Synthetic tests for the pre-coadd tile MAD gate."""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from mosaic_day import tile_mad_gate
+
+
+def test_745_mjy_tile_is_rejected_before_coadd():
+    amplitude_jy = 0.0745 / 1.4826
+    tile = np.tile(np.array([-amplitude_jy, amplitude_jy]), 10_000)
+    coadd_helper = Mock()
+
+    accepted, reason = tile_mad_gate(tile)
+    if accepted:
+        coadd_helper(["bad-tile.fits"])
+
+    assert not accepted
+    assert "74.5 mJy" in reason
+    coadd_helper.assert_not_called()
+
+
+def test_quiet_tile_passes_gate():
+    amplitude_jy = 0.005 / 1.4826
+    tile = np.tile(np.array([-amplitude_jy, amplitude_jy]), 10_000)
+
+    accepted, _ = tile_mad_gate(tile)
+
+    assert accepted
+
+
+def test_diagnostic_override_is_separate_and_explicit():
+    amplitude_jy = 0.0745 / 1.4826
+    tile = np.tile(np.array([-amplitude_jy, amplitude_jy]), 10_000)
+
+    accepted, reason = tile_mad_gate(tile, include_qa_failed_tiles=True)
+
+    assert accepted
+    assert "diagnostic override" in reason


### PR DESCRIPTION
## Summary
- Adds `--rfi-mode {full,conditional,off}` to `mosaic_day` and `batch_pipeline` (`full` remains default; `--no-rfi-flagging` is a deprecated alias for `off`).
- Introduces fail-closed raw-data preflight (`rfi_preflight.py`) so `conditional` runs Stage 0 always and Stage 1/2/3 only on hard trigger or unavailable metrics.
- Adds tile MAD coadd gating plus mode-specific RFI sentinels; AOFlagger path now fails closed by default for science tiles.

## Test plan
- [x] `pytest tests/test_rfi_preflight.py tests/test_rfi_mode.py tests/test_tile_mad_gate.py tests/test_stage_checkpoint.py tests/test_batch_e2_hygiene.py tests/test_batch_pipeline_dry_run_quarantine.py` (53 passed)
- [ ] Smoke: `scripts/batch_pipeline.py --date … --dry-run --rfi-mode conditional`
- [ ] Optional on-sky: `--rfi-mode conditional` vs `full` on a known quiet and known dirty tile


Made with [Cursor](https://cursor.com)