### PR TITLE
Harden conversion + photometry: fail-loud guards, canonical metric tests, latent-bug fixes

### DIFF
--- a/dsa110_continuum/conversion/calibrator_ms_generator.py
+++ b/dsa110_continuum/conversion/calibrator_ms_generator.py
@@ -47,6 +47,11 @@ logger = logging.getLogger(__name__)
 DEFAULT_DB_PATH = Path("/data/dsa110-contimg/state/db/pipeline.sqlite3")
 DEFAULT_VLA_CATALOG = Path("/data/dsa110-contimg/state/catalogs/vla_calibrators.sqlite3")
 
+# Mean sidereal day = 86164.0905 s. In drift scan the same RA transits once
+# per sidereal day, so transit-time scoping can only disambiguate adjacent
+# transits if the tolerance stays below half this period.
+SIDEREAL_DAY_MINUTES = 86164.0905 / 60.0
+
 
 @dataclass
 class CalibratorInfo:
@@ -351,11 +356,23 @@ class CalibratorMSGenerator:
         ------
         ValueError
             If ``transit_time`` is given and no positionally matched group
-            falls within the tolerance.
+            falls within the tolerance, or if ``max_transit_offset_minutes``
+            is not in ``(0, SIDEREAL_DAY_MINUTES / 2)`` — beyond half a
+            sidereal day the scoping can silently accept groups from an
+            adjacent transit date.
         """
         from dsa110_continuum.database.hdf5_index import (
             select_hdf5_groups_by_position,
         )
+
+        if transit_time is not None and not (
+            0 < max_transit_offset_minutes < SIDEREAL_DAY_MINUTES / 2
+        ):
+            raise ValueError(
+                f"max_transit_offset_minutes={max_transit_offset_minutes:.1f} must be in "
+                f"(0, {SIDEREAL_DAY_MINUTES / 2:.1f}) min; beyond half a sidereal day the "
+                f"scoping cannot distinguish adjacent transit dates."
+            )
 
         # The legacy selector caps to n_groups BEFORE we can time-scope, so
         # wrong-date candidates could crowd out the requested date. When

--- a/dsa110_continuum/conversion/helpers_coordinates.py
+++ b/dsa110_continuum/conversion/helpers_coordinates.py
@@ -284,6 +284,13 @@ def compute_and_set_uvw(uvdata, pt_dec: u.Quantity) -> None:
                 float(tel_latlonalt[2].to(u.m).value),
             )
 
+    if tel_latlonalt is None:
+        raise ValueError(
+            "compute_and_set_uvw: UVData object exposes no telescope location "
+            "(telescope_location_lat_lon_alt or telescope.location_lat_lon_alt); "
+            "cannot reconstruct UVW coordinates."
+        )
+
     tel_frame = getattr(uvdata, "_telescope_location", None)
     tel_frame = getattr(tel_frame, "frame", None)
 
@@ -343,12 +350,14 @@ def compute_and_set_uvw(uvdata, pt_dec: u.Quantity) -> None:
             app_ra_unique[i] = float(new_app_ra[0])
             app_dec_unique[i] = float(new_app_dec[0])
             frame_pa_unique[i] = float(new_frame_pa[0])
-        except (ValueError, IndexError, TypeError):
-            # ValueError: coordinate transformation failures
-            # IndexError: array access issues, TypeError: type conversion
-            app_ra_unique[i] = float(ra_icrs.to_value(u.rad))
-            app_dec_unique[i] = float(dec_icrs.to_value(u.rad))
-            frame_pa_unique[i] = 0.0
+        except (ValueError, IndexError, TypeError) as exc:
+            raise ValueError(
+                f"compute_and_set_uvw: pyuvdata apparent-coordinate computation "
+                f"failed for time index {i} ({type(exc).__name__}: {exc}). "
+                "Refusing to fall back to frame_pa=0: UVWs would silently carry "
+                "an uncorrected ICRS<->apparent sky rotation (~2 arcmin at 2026 "
+                "epochs)."
+            ) from exc
 
     app_ra_all = app_ra_unique[uinvert]
     app_dec_all = app_dec_unique[uinvert]

--- a/dsa110_continuum/photometry/source.py
+++ b/dsa110_continuum/photometry/source.py
@@ -19,36 +19,20 @@ import pandas as pd
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-
-try:
-    from dsa110_continuum.catalog.multiwavelength import (
-        check_all_services,
-        check_atnf,
-        check_first,
-        check_gaia,
-        check_nvss,
-        check_pulsarscraper,
-        check_simbad,
-    )
-    from dsa110_continuum.photometry.variability import (
-        calculate_eta_metric,
-        calculate_m_metric,
-        calculate_vs_metric,
-    )
-except ImportError:
-    # Fallback
-    def check_all_services(*args, **kwargs):
-        return {}
-
-    def calculate_eta_metric(*args, **kwargs):
-        return 0.0
-
-    def calculate_vs_metric(*args, **kwargs):
-        return 0.0
-
-    def calculate_m_metric(*args, **kwargs):
-        return 0.0
-
+from dsa110_continuum.catalog.multiwavelength import (
+    check_all_services,
+    check_atnf,
+    check_first,
+    check_gaia,
+    check_nvss,
+    check_pulsarscraper,
+    check_simbad,
+)
+from dsa110_continuum.photometry.variability import (
+    calculate_eta_metric,
+    calculate_m_metric,
+    calculate_vs_metric,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -594,6 +578,7 @@ class Source:
             return {}
 
         # Transpose to (n_epochs, n_neighbors)
+        neighbor_fluxes = np.array(neighbor_flux_matrix).T
         neighbor_errors = np.array(neighbor_error_matrix).T
 
         # 3. Calculate Relative Flux

--- a/dsa110_continuum/photometry/variability.py
+++ b/dsa110_continuum/photometry/variability.py
@@ -169,9 +169,9 @@ def calculate_m_metric(flux_a: float, flux_b: float) -> float:
 def calculate_v_metric(fluxes: np.ndarray) -> float:
     """Calculate V metric (coefficient of variation).
 
-        The V metric is the fractional variability: std / mean.
-        This is already implemented in DSA-110's variability_stats table,
-        but provided here for completeness.
+        The V metric is the fractional variability: std / mean, using the
+        sample standard deviation (ddof=1) per the VAST convention.
+        Delegates to the canonical photometry/metrics.py implementation.
 
     Parameters
     ----------
@@ -183,18 +183,9 @@ def calculate_v_metric(fluxes: np.ndarray) -> float:
         float
         V metric value
     """
-    if len(fluxes) == 0:
-        return 0.0
+    from dsa110_continuum.photometry.metrics import calculate_v_metric as canonical_v_metric
 
-    valid_fluxes = fluxes[np.isfinite(fluxes)]
-    if len(valid_fluxes) < 2:
-        return 0.0
-
-    mean_flux = np.mean(valid_fluxes)
-    if mean_flux == 0:
-        return 0.0
-
-    return float(np.std(valid_fluxes) / mean_flux)
+    return canonical_v_metric(np.asarray(fluxes, dtype=float))
 
 
 def calculate_sigma_deviation(

--- a/dsa110_continuum/utils/numba_accel.py
+++ b/dsa110_continuum/utils/numba_accel.py
@@ -63,7 +63,7 @@ except ImportError:
 
 
 # =============================================================================
-# Angular Separation (Haversine formula)
+# Angular Separation (spherical law of cosines)
 # =============================================================================
 
 
@@ -74,10 +74,14 @@ def angular_separation_jit(
     ra2: np.ndarray,
     dec2: np.ndarray,
 ) -> np.ndarray:
-    """Compute angular separation using Haversine formula (JIT-compiled).
+    """Compute angular separation using the spherical law of cosines (JIT-compiled).
 
         This is significantly faster than astropy's angular_separation for
         large arrays due to JIT compilation and avoiding Python overhead.
+
+        Unlike the haversine form, arccos conditioning imposes a ~2.1e-8 rad
+        (4.3 mas) floor on the smallest resolvable separations — negligible
+        for this pipeline's arcsecond-level cross-matching.
 
     Parameters
     ----------
@@ -95,7 +99,6 @@ def angular_separation_jit(
         array_like
         Angular separation in radians
     """
-    # Haversine formula for angular separation
     sin_dec1 = np.sin(dec1)
     sin_dec2 = np.sin(dec2)
     cos_dec1 = np.cos(dec1)

--- a/tests/test_calibrator_ms_generator.py
+++ b/tests/test_calibrator_ms_generator.py
@@ -141,3 +141,158 @@ class TestGenerateMultiple:
             )
         assert result.success
         assert convert.call_args.args[0] == [D1_GROUP]
+
+
+class TestSiderealDayScoping:
+    """Correctness criterion (analytic): in drift scan the same RA transits
+    once per mean sidereal day (86164.0905 s = 1436.07 min). A positionally
+    matched group exactly one sidereal day from the requested transit belongs
+    to a different date and MUST be rejected; a group within the beam-crossing
+    time (~15 min at Dec 16° for the 3.5° beam) MUST be kept. This requires
+    beam-crossing < tolerance < sidereal_day / 2 (= 718.03 min)."""
+
+    def _group_at(self, offset_minutes):
+        import astropy.units as u
+
+        return (TRANSIT_D1 + offset_minutes * u.minute).isot
+
+    def test_default_tolerance_in_analytic_safe_range(self):
+        import inspect
+
+        from dsa110_continuum.conversion.calibrator_ms_generator import SIDEREAL_DAY_MINUTES
+
+        sig = inspect.signature(CalibratorMSGenerator.select_groups_by_position)
+        default_tol = sig.parameters["max_transit_offset_minutes"].default
+        beam_crossing_min = 3.5 / 15.0 * 60.0  # FWHM / drift rate at Dec 0
+        assert beam_crossing_min < default_tol < SIDEREAL_DAY_MINUTES / 2
+
+    def test_rejects_group_exactly_one_sidereal_day_away(self, generator):
+        adjacent_transit = self._group_at(86164.0905 / 60.0)
+        with patch(LEGACY_SELECTOR, return_value=[adjacent_transit]):
+            with pytest.raises(ValueError, match="different transit date"):
+                generator.select_groups_by_position(
+                    source_ra_deg=CAL.ra_deg,
+                    source_dec_deg=CAL.dec_deg,
+                    transit_time=TRANSIT_D1,
+                )
+
+    def test_keeps_in_beam_group_drops_adjacent_day(self, generator):
+        in_beam = self._group_at(10.0)
+        adjacent = self._group_at(86164.0905 / 60.0)
+        with patch(LEGACY_SELECTOR, return_value=[adjacent, in_beam]):
+            groups = generator.select_groups_by_position(
+                source_ra_deg=CAL.ra_deg,
+                source_dec_deg=CAL.dec_deg,
+                transit_time=TRANSIT_D1,
+            )
+        assert groups == [in_beam]
+
+    def test_tolerance_boundary_semantics(self, generator):
+        """Pins the default 360 min tolerance to ±1 min without asserting
+        exact float equality at the boundary."""
+        just_inside = self._group_at(359.0)
+        just_outside = self._group_at(361.0)
+        with patch(LEGACY_SELECTOR, return_value=[just_outside, just_inside]):
+            groups = generator.select_groups_by_position(
+                source_ra_deg=CAL.ra_deg,
+                source_dec_deg=CAL.dec_deg,
+                transit_time=TRANSIT_D1,
+            )
+        assert groups == [just_inside]
+
+    def test_unsafe_tolerance_raises(self, generator):
+        """Fail-loud guard: a tolerance ≥ half a sidereal day would silently
+        re-admit wrong-date groups (the issue #72 failure mode)."""
+        with patch(LEGACY_SELECTOR, return_value=[D1_GROUP]):
+            with pytest.raises(ValueError, match="sidereal"):
+                generator.select_groups_by_position(
+                    source_ra_deg=CAL.ra_deg,
+                    source_dec_deg=CAL.dec_deg,
+                    transit_time=TRANSIT_D1,
+                    max_transit_offset_minutes=800.0,
+                )
+
+    def test_nonpositive_tolerance_raises(self, generator):
+        with patch(LEGACY_SELECTOR, return_value=[D1_GROUP]):
+            with pytest.raises(ValueError, match="sidereal"):
+                generator.select_groups_by_position(
+                    source_ra_deg=CAL.ra_deg,
+                    source_dec_deg=CAL.dec_deg,
+                    transit_time=TRANSIT_D1,
+                    max_transit_offset_minutes=0.0,
+                )
+
+    def test_tolerance_unchecked_without_transit_time(self, generator):
+        """Without a transit_time there is no scoping, so no guard applies."""
+        with patch(LEGACY_SELECTOR, return_value=[D1_GROUP]):
+            groups = generator.select_groups_by_position(
+                source_ra_deg=CAL.ra_deg,
+                source_dec_deg=CAL.dec_deg,
+                max_transit_offset_minutes=800.0,
+            )
+        assert groups == [D1_GROUP]
+
+
+class TestConvertGroupsBehavior:
+    """Behavioral invariants of convert_groups: group-type dispatch,
+    skip_existing short-circuit, and per-group failure isolation (one bad
+    group must not abort the remaining conversions)."""
+
+    CONVERTER = "dsa110_continuum.conversion.convert_subband_groups_to_ms"
+
+    def test_subband_group_object_timestamp_from_sb_stem(self, generator):
+        class FakeSubbandGroup:
+            files = [f"/data/incoming/{D1_GROUP}_sb00.hdf5"]
+
+        with patch(self.CONVERTER) as conv:
+            generator.convert_groups([FakeSubbandGroup()])
+        assert conv.call_args.kwargs["start_time"] == D1_GROUP
+
+    def test_empty_file_list_skipped(self, generator):
+        with patch(self.CONVERTER) as conv:
+            ms_paths = generator.convert_groups([[]])
+        assert conv.call_count == 0
+        assert ms_paths == []
+
+    def test_skip_existing_returns_without_converting(self, generator):
+        existing = generator.output_dir / f"{D1_GROUP}.ms"
+        existing.mkdir(parents=True)
+        with patch(self.CONVERTER) as conv:
+            ms_paths = generator.convert_groups([[f"/data/incoming/{D1_GROUP}_sb00.hdf5"]])
+        assert conv.call_count == 0
+        assert ms_paths == [existing]
+
+    def test_failed_group_does_not_abort_remaining(self, generator):
+        calls = []
+
+        def fake_convert(**kwargs):
+            calls.append(kwargs["start_time"])
+            if kwargs["start_time"] == D1_GROUP:
+                raise RuntimeError("conversion blew up")
+            Path(kwargs["output_dir"], f"{kwargs['start_time']}.ms").mkdir(parents=True)
+
+        groups = [
+            [f"/data/incoming/{D1_GROUP}_sb00.hdf5"],
+            [f"/data/incoming/{D2_GROUP}_sb00.hdf5"],
+        ]
+        with patch(self.CONVERTER, side_effect=fake_convert):
+            ms_paths = generator.convert_groups(groups)
+
+        assert calls == [D1_GROUP, D2_GROUP]
+        assert ms_paths == [generator.output_dir / f"{D2_GROUP}.ms"]
+
+
+class TestFailLoudPaths:
+    def test_find_last_transit_raises_when_no_transits(self, generator):
+        with patch.object(generator, "find_transits", return_value=[]):
+            with pytest.raises(RuntimeError, match="No transits"):
+                generator.find_last_transit(CAL)
+
+    def test_verify_calibrator_absent_returns_false(self, generator):
+        with patch(
+            "dsa110_continuum.calibration.selection.select_bandpass_from_catalog",
+            side_effect=RuntimeError("no calibrator in MS"),
+        ):
+            present, peak = generator.verify_calibrator_in_ms(Path("x.ms"), CAL)
+        assert present is False
+        assert peak is None

--- a/tests/test_conversion_coordinates_hardening.py
+++ b/tests/test_conversion_coordinates_hardening.py
@@ -1,0 +1,574 @@
+"""Hardening tests for conversion-side coordinate / UVW helpers.
+
+Targets (all pure Python + numpy/astropy/pyuvdata; no MS, no casacore):
+
+- ``conversion.helpers_coordinates.get_meridian_coords`` — phase-centre
+  computation used by ``phase_to_meridian`` and ``ms_utils`` in production
+  conversion.
+- ``conversion.helpers_coordinates.angular_separation`` (and the numba kernel
+  ``utils.numba_accel.angular_separation_jit``) — used by ``merge_spws`` and
+  ``helpers_validation`` phase-centre coherence checks.
+- ``utils.numba_accel.approx_lst_jit`` — the ``fast=True`` path of
+  ``get_meridian_coords``.
+- ``utils.numba_accel.compute_uvw_rotation_matrix`` /
+  ``rotate_xyz_to_uvw_jit`` — exported pure-math UVW rotation.
+- ``conversion.helpers_coordinates.compute_and_set_uvw`` — the production UVW
+  reconstruction (via a minimal duck-typed UVData; exercises real pyuvdata).
+- ``utils.numba_accel.compute_phase_corrections_jit`` — w-offset phase
+  rotation sign convention.
+
+Correctness criteria and their analytic bases are stated in each test-class
+docstring. All expected values are derived from first principles or from an
+independent reference implementation (astropy); nothing here is an
+unverified regression pin.
+
+Reference epoch MJD 58300 (2018-07-01) is used so astropy's *bundled* IERS-B
+table covers all test times (hermetic: IERS auto-download is disabled for
+the module).
+"""
+
+from __future__ import annotations
+
+import astropy.units as u
+import numpy as np
+import pytest
+from astropy.coordinates import ITRS, SkyCoord
+from astropy.coordinates import angular_separation as astropy_angular_separation
+from astropy.time import Time
+from astropy.utils import iers
+from dsa110_continuum.conversion import helpers_coordinates
+from dsa110_continuum.conversion.helpers_coordinates import (
+    angular_separation,
+    compute_and_set_uvw,
+    get_meridian_coords,
+)
+from dsa110_continuum.utils.constants import DSA110_LOCATION
+from dsa110_continuum.utils.numba_accel import (
+    angular_separation_jit,
+    approx_lst_jit,
+    compute_phase_corrections_jit,
+    compute_uvw_rotation_matrix,
+    rotate_xyz_to_uvw_jit,
+)
+
+MJD0 = 58300.0  # 2018-07-01, inside astropy's bundled IERS-B table
+PT_DEC_RAD = np.deg2rad(16.1)  # DSA-110 Dec strip
+SIDEREAL_RATE_RAD_PER_HR = 2.0 * np.pi * 1.00273790935 / 24.0
+C_LIGHT_M_S = 299792458.0  # SI definition, matches numba_accel.compute_phase_corrections_jit
+
+LAT_RAD = float(DSA110_LOCATION.lat.to_value(u.rad))
+LON_RAD = float(DSA110_LOCATION.lon.to_value(u.rad))
+ALT_M = float(DSA110_LOCATION.height.to_value(u.m))
+
+# Local ENU unit vectors at DSA-110 expressed in the ECEF/ITRS frame.
+EAST_ECEF = np.array([-np.sin(LON_RAD), np.cos(LON_RAD), 0.0])
+NORTH_ECEF = np.array(
+    [-np.sin(LAT_RAD) * np.cos(LON_RAD), -np.sin(LAT_RAD) * np.sin(LON_RAD), np.cos(LAT_RAD)]
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _no_iers_download():
+    with iers.conf.set_temp("auto_download", False):
+        yield
+
+
+def _apparent_lst_rad(jd_array: np.ndarray) -> np.ndarray:
+    return (
+        Time(np.atleast_1d(jd_array), format="jd")
+        .sidereal_time("apparent", longitude=DSA110_LOCATION.lon)
+        .to_value(u.rad)
+    )
+
+
+class _MockUVData:
+    """Minimal duck-typed UVData carrying only what compute_and_set_uvw reads."""
+
+    def __init__(self, ant_pos, ant_1_array, ant_2_array, time_array_jd):
+        self.telescope_location_lat_lon_alt = (LAT_RAD, LON_RAD, ALT_M)
+        self.antenna_positions = np.asarray(ant_pos, dtype=float)
+        self.antenna_numbers = np.arange(len(ant_pos))
+        self.ant_1_array = np.asarray(ant_1_array)
+        self.ant_2_array = np.asarray(ant_2_array)
+        self.time_array = np.asarray(time_array_jd, dtype=float)
+        self.lst_array = _apparent_lst_rad(self.time_array)
+        self.uvw_array = np.zeros((self.time_array.size, 3))
+
+
+def _icrs_sky_basis_in_itrs(ra_rad: float, dec_rad: float, t: Time):
+    """Independent astropy construction of the (east, north, source) UVW basis.
+
+    The source unit vector is the astropy ICRS->ITRS transform; the on-sky
+    east/north unit vectors (ICRS-north convention, matching pyuvdata's
+    frame_pa) are central finite differences of that transform in RA/Dec.
+    """
+    eps = 1e-6
+
+    def itrs_unit(ra, dec):
+        sc = SkyCoord(ra=ra * u.rad, dec=dec * u.rad, frame="icrs").transform_to(
+            ITRS(obstime=t)
+        )
+        v = np.array([sc.x.value, sc.y.value, sc.z.value])
+        return v / np.linalg.norm(v)
+
+    s = itrs_unit(ra_rad, dec_rad)
+    north = (itrs_unit(ra_rad, dec_rad + eps) - itrs_unit(ra_rad, dec_rad - eps)) / (2 * eps)
+    east = (
+        itrs_unit(ra_rad + eps / np.cos(dec_rad), dec_rad)
+        - itrs_unit(ra_rad - eps / np.cos(dec_rad), dec_rad)
+    ) / (2 * eps)
+    return east, north, s
+
+
+@pytest.fixture(scope="module")
+def uvw_case():
+    """One compute_and_set_uvw run on a random 5-antenna array, 2 times."""
+    rng = np.random.default_rng(7)
+    ant_pos = rng.uniform(-1500.0, 1500.0, (5, 3))
+    ant_pos -= ant_pos.mean(axis=0)
+    a1 = np.array([0, 0, 0, 0, 1, 1, 2, 3])
+    a2 = np.array([1, 2, 3, 4, 2, 4, 3, 4])
+    jd = Time(MJD0 + np.arange(2) * 12.0 / 86400.0, format="mjd").jd
+    uv = _MockUVData(ant_pos, np.tile(a1, 2), np.tile(a2, 2), np.repeat(jd, a1.size))
+    compute_and_set_uvw(uv, PT_DEC_RAD * u.rad)
+    return uv, ant_pos, jd
+
+
+class TestGetMeridianCoords:
+    """Phase-centre computation for the drift-scan meridian.
+
+    Criteria
+    --------
+    1. Round-trip inverse: the returned ICRS coordinate, transformed back to
+       the HADec frame at the same time/location, must recover HA = 0 and
+       Dec = pt_dec. Analytic basis: frame round-trips are exact inverses;
+       ERFA forward/backward chains agree to sub-microarcsecond (measured
+       residual <= 4e-13 rad). Tolerance 1e-10 rad (~20 uas) gives >100x
+       headroom while staying ~6 orders below the pipeline's arcsecond-level
+       astrometric budget.
+    2. Sidereal rate: meridian ICRS RA must advance by ~1.00273791 * 15 deg/hr.
+       The apparent<->ICRS RA offset itself varies across the 15 deg hourly
+       sweep by up to ~30 arcsec (annual-precession n*dt*d(sin RA)*tan Dec at
+       ~2 decades from J2000, Dec 16 deg), so the bound is 60 arcsec/hr
+       (2.9e-4 rad). A solar-rate bug differs by 147 arcsec/hr and a sign bug
+       by ~2 rad, both far outside the bound.
+    3. Unit handling: a plain-float pt_dec (multiprocessing path) must give
+       the identical result as the Quantity path (pure dispatch, no numerics).
+    """
+
+    @pytest.mark.parametrize("mjd", [MJD0, MJD0 + 0.3, MJD0 + 123.456])
+    def test_round_trip_back_to_hadec_recovers_ha_zero_and_pt_dec(self, mjd):
+        ra, dec = get_meridian_coords(PT_DEC_RAD * u.rad, mjd)
+        hadec_frame = SkyCoord(
+            ha=0 * u.hourangle,
+            dec=PT_DEC_RAD * u.rad,
+            frame="hadec",
+            obstime=Time(mjd, format="mjd"),
+            location=DSA110_LOCATION,
+        ).frame
+        back = SkyCoord(ra=ra, dec=dec, frame="icrs").transform_to(hadec_frame)
+        ha_rad = (back.ha.to_value(u.rad) + np.pi) % (2 * np.pi) - np.pi
+        np.testing.assert_allclose(ha_rad, 0.0, atol=1e-10)
+        np.testing.assert_allclose(back.dec.to_value(u.rad), PT_DEC_RAD, rtol=0, atol=1e-10)
+
+    def test_meridian_ra_advances_at_sidereal_rate(self):
+        ra1, _ = get_meridian_coords(PT_DEC_RAD * u.rad, MJD0)
+        ra2, _ = get_meridian_coords(PT_DEC_RAD * u.rad, MJD0 + 1.0 / 24.0)
+        dra = (ra2 - ra1).to_value(u.rad) % (2 * np.pi)
+        np.testing.assert_allclose(dra, SIDEREAL_RATE_RAD_PER_HR, rtol=0, atol=2.9e-4)
+
+    def test_float_pt_dec_matches_quantity_pt_dec(self):
+        ra_q, dec_q = get_meridian_coords(PT_DEC_RAD * u.rad, MJD0)
+        ra_f, dec_f = get_meridian_coords(PT_DEC_RAD, MJD0)
+        np.testing.assert_allclose(ra_f.to_value(u.rad), ra_q.to_value(u.rad), rtol=0, atol=1e-15)
+        np.testing.assert_allclose(
+            dec_f.to_value(u.rad), dec_q.to_value(u.rad), rtol=0, atol=1e-15
+        )
+
+
+class TestAngularSeparation:
+    """Great-circle separation vs the independent astropy reference.
+
+    astropy.coordinates.angular_separation implements the Vincenty formula,
+    which is well-conditioned at all separations, so it is a valid reference
+    everywhere. The kernel under test uses the arccos (spherical law of
+    cosines) formula, whose conditioning floor near s=0 (and s=pi) is
+    sqrt(2*eps) ~ 2.1e-8 rad in float64.
+
+    Criteria
+    --------
+    1. Random sphere pairs (separations >~ 1e-3 rad): agreement within
+       atol=1e-11 rad. Basis: arccos error ~ eps/sin(s) <= ~2e-13 for
+       s >= 1e-3; 50x headroom for fastmath reassociation (measured 2.7e-14).
+    2. Small separations (1e-9..1e-4 rad): agreement within atol=2.5e-8 rad
+       — the arccos conditioning floor above, NOT a tunable bound (measured
+       2.06e-8). This documents the kernel's precision floor.
+    3. Invariants: symmetry, zero self-separation, range [0, pi].
+    4. The pure-numpy dispatcher fallback must match the numba path within
+       the same conditioning floor.
+    """
+
+    @staticmethod
+    def _random_pairs(n=5000, seed=42):
+        rng = np.random.default_rng(seed)
+        ra_a = rng.uniform(0, 2 * np.pi, n)
+        dec_a = np.arcsin(rng.uniform(-1, 1, n))
+        ra_b = rng.uniform(0, 2 * np.pi, n)
+        dec_b = np.arcsin(rng.uniform(-1, 1, n))
+        return ra_a, dec_a, ra_b, dec_b
+
+    def test_matches_astropy_on_random_sphere_pairs(self):
+        ra_a, dec_a, ra_b, dec_b = self._random_pairs()
+        ref = np.asarray(astropy_angular_separation(ra_a, dec_a, ra_b, dec_b))
+        got = angular_separation_jit(ra_a, dec_a, ra_b, dec_b)
+        keep = ref > 1e-3  # arccos conditioning valid regime; small seps tested separately
+        np.testing.assert_allclose(got[keep], ref[keep], rtol=0, atol=1e-11)
+
+    def test_small_separation_conditioning_floor(self):
+        rng = np.random.default_rng(11)
+        n = 5000
+        ra_a = rng.uniform(0, 2 * np.pi, n)
+        dec_a = np.arcsin(rng.uniform(-0.98, 0.98, n))
+        offset = 10.0 ** rng.uniform(-9, -4, n)
+        pa = rng.uniform(0, 2 * np.pi, n)
+        ra_b = ra_a + offset * np.sin(pa) / np.cos(dec_a)
+        dec_b = dec_a + offset * np.cos(pa)
+        ref = np.asarray(astropy_angular_separation(ra_a, dec_a, ra_b, dec_b))
+        got = angular_separation_jit(ra_a, dec_a, ra_b, dec_b)
+        np.testing.assert_allclose(got, ref, rtol=0, atol=2.5e-8)
+
+    def test_symmetry_identity_and_range(self):
+        ra_a, dec_a, ra_b, dec_b = self._random_pairs(n=2000, seed=3)
+        fwd = angular_separation_jit(ra_a, dec_a, ra_b, dec_b)
+        rev = angular_separation_jit(ra_b, dec_b, ra_a, dec_a)
+        np.testing.assert_allclose(fwd, rev, rtol=0, atol=1e-14)
+        # Self-separation sits exactly at the arccos conditioning floor
+        # sqrt(2*eps) ~ 2.1e-8 (rounding in sin^2+cos^2 makes cos_sep < 1).
+        self_sep = angular_separation_jit(ra_a, dec_a, ra_a, dec_a)
+        np.testing.assert_allclose(self_sep, 0.0, rtol=0, atol=2.5e-8)
+        assert np.all(fwd >= 0.0) and np.all(fwd <= np.pi + 1e-14)
+
+    def test_numpy_fallback_matches_numba_path(self, monkeypatch):
+        ra_a, dec_a, ra_b, dec_b = self._random_pairs(n=500, seed=5)
+        jit_result = angular_separation(ra_a, dec_a, ra_b, dec_b)
+        monkeypatch.setattr(helpers_coordinates, "_USE_NUMBA_ANGULAR_SEP", False)
+        numpy_result = angular_separation(ra_a, dec_a, ra_b, dec_b)
+        np.testing.assert_allclose(
+            np.asarray(numpy_result, dtype=float),
+            np.asarray(jit_result, dtype=float),
+            rtol=0,
+            atol=2.5e-8,
+        )
+
+
+class TestApproxLst:
+    """Fast LST approximation vs astropy mean sidereal time (reference).
+
+    Criteria
+    --------
+    1. Agreement with astropy ``sidereal_time('mean')`` at DSA-110 within
+       atol=1e-4 rad (~20.6 arcsec). Error budget: the Meeus linear GMST
+       formula takes UTC as UT1 (|UT1-UTC| <= 0.9 s = 6.6e-5 rad of rotation)
+       and truncates the T^2 GMST term (< 1e-6 rad within the test epoch
+       range). Measured max residual over 2017-2020: 1.8e-5 rad. This bound
+       is consistent with the documented use ("phase center tracking where
+       sub-arcsecond precision is not required").
+    2. Output normalized to [0, 2*pi).
+
+    Differences are compared on the circle (via angle of the complex ratio)
+    to avoid 2*pi wrap artifacts.
+    """
+
+    def test_matches_astropy_mean_sidereal_time(self):
+        rng = np.random.default_rng(19)
+        mjds = np.sort(rng.uniform(58000.0, 58800.0, 40))
+        got = approx_lst_jit(mjds, LON_RAD)
+        ref = (
+            Time(mjds, format="mjd")
+            .sidereal_time("mean", longitude=DSA110_LOCATION.lon)
+            .to_value(u.rad)
+        )
+        circular_diff = np.angle(np.exp(1j * (got - ref)))
+        np.testing.assert_allclose(circular_diff, 0.0, rtol=0, atol=1e-4)
+
+    def test_output_in_principal_range(self):
+        mjds = np.linspace(58000.0, 58800.0, 200)
+        got = approx_lst_jit(mjds, LON_RAD)
+        assert np.all(got >= 0.0) and np.all(got < 2 * np.pi)
+
+
+class TestUvwRotation:
+    """Pure-math XYZ->UVW rotation (numba_accel).
+
+    Convention under test (Thompson-Moran-Swenson): XYZ equatorial with X at
+    (HA=0, Dec=0), Y East (HA=-6h), Z at the NCP; u East on sky, v North on
+    sky, w toward the source at (HA, Dec).
+
+    Criteria
+    --------
+    1. Rotation-matrix orthonormality and det=+1 for random (HA, Dec):
+       atol=1e-13 (pure trig products accumulate ~4 eps ~ 1e-15; measured
+       3.3e-16).
+    2. The batched JIT kernel must equal the matrix product R @ xyz
+       (atol=1e-10 m on <=1.5 km baselines; fastmath reassociation ~10 eps *
+       scale = 3e-13 m measured 4.5e-13) and preserve baseline norms
+       (rtol=1e-12; rotations are isometries).
+    3. Analytic transit cases (exact trig values, atol=1e-12*|b|):
+       - East-West baseline (0, L, 0) at HA=0 maps to (L, 0, 0); in
+         particular w=0 for ANY declination.
+       - A baseline in the meridian plane (x, 0, z) has u=0 at HA=0.
+       - The NCP direction (0, 0, 1) maps to (0, cos Dec, sin Dec).
+    4. Zenith case: a horizontal baseline at latitude phi observing the
+       zenith (HA=0, Dec=phi) has w=0 analytically (the baseline is
+       perpendicular to the vertical): atol=1e-12*|b|.
+    5. Independent basis cross-check: u = b . east, v = b . north, w = b . s
+       where east/north are CENTRAL FINITE DIFFERENCES of the source unit
+       vector s(HA, Dec) — independent of the coded trig identities, so a
+       sign/row swap cannot cancel. atol=1e-6 m: central-difference
+       truncation is h^2*|b|/6 ~ 2.5e-8 m at h=1e-5, |b|<=1.5 km (measured
+       ~9e-9 m); 40x headroom.
+    6. Linearity/antisymmetry: rotate(-b) = -rotate(b), atol=1e-12*|b|.
+    """
+
+    def test_rotation_matrix_is_orthonormal_with_unit_determinant(self):
+        rng = np.random.default_rng(23)
+        for _ in range(100):
+            ha = rng.uniform(-np.pi, np.pi)
+            dec = rng.uniform(-np.pi / 2, np.pi / 2)
+            r_mat = compute_uvw_rotation_matrix(ha, dec)
+            np.testing.assert_allclose(r_mat @ r_mat.T, np.eye(3), rtol=0, atol=1e-13)
+            np.testing.assert_allclose(np.linalg.det(r_mat), 1.0, rtol=0, atol=1e-13)
+
+    def test_jit_rotation_matches_matrix_and_preserves_norm(self):
+        rng = np.random.default_rng(29)
+        xyz = rng.uniform(-1500.0, 1500.0, (200, 3))
+        ha_arr = rng.uniform(-np.pi, np.pi, 200)
+        uvw = rotate_xyz_to_uvw_jit(xyz, ha_arr, PT_DEC_RAD)
+        expected = np.einsum(
+            "nij,nj->ni",
+            np.stack([compute_uvw_rotation_matrix(h, PT_DEC_RAD) for h in ha_arr]),
+            xyz,
+        )
+        np.testing.assert_allclose(uvw, expected, rtol=0, atol=1e-10)
+        np.testing.assert_allclose(
+            np.linalg.norm(uvw, axis=1), np.linalg.norm(xyz, axis=1), rtol=1e-12
+        )
+
+    @pytest.mark.parametrize("dec", [np.deg2rad(-20.0), PT_DEC_RAD, np.deg2rad(55.0)])
+    def test_transit_analytic_cases(self, dec):
+        length = 1000.0
+        xyz = np.array(
+            [
+                [0.0, length, 0.0],  # East-West
+                [300.0, 0.0, 700.0],  # in the meridian plane
+                [0.0, 0.0, 1.0],  # NCP direction
+            ]
+        )
+        uvw = rotate_xyz_to_uvw_jit(xyz, np.zeros(3), dec)
+        np.testing.assert_allclose(
+            uvw[0], [length, 0.0, 0.0], rtol=0, atol=1e-12 * length
+        )
+        np.testing.assert_allclose(uvw[1, 0], 0.0, rtol=0, atol=1e-12 * length)
+        np.testing.assert_allclose(
+            uvw[2], [0.0, np.cos(dec), np.sin(dec)], rtol=0, atol=1e-12
+        )
+
+    def test_zenith_horizontal_baseline_w_zero(self):
+        length = 1000.0
+        # ENU (e, n, 0) horizontal baseline at latitude phi in XYZ coords:
+        # X = -n sin(phi), Y = e, Z = n cos(phi)
+        e_comp, n_comp = 600.0, 800.0
+        xyz = np.array(
+            [[-n_comp * np.sin(LAT_RAD), e_comp, n_comp * np.cos(LAT_RAD)]]
+        )
+        uvw = rotate_xyz_to_uvw_jit(xyz, np.zeros(1), LAT_RAD)  # zenith: Dec = latitude
+        np.testing.assert_allclose(uvw[0, 2], 0.0, rtol=0, atol=1e-12 * length)
+
+    def test_uvw_basis_matches_finite_difference_of_source_direction(self):
+        def s_hat(ha, dec):
+            return np.array(
+                [np.cos(dec) * np.cos(ha), -np.cos(dec) * np.sin(ha), np.sin(dec)]
+            )
+
+        rng = np.random.default_rng(31)
+        h_step = 1e-5
+        for dec in [np.deg2rad(-30.0), PT_DEC_RAD, np.deg2rad(60.0)]:
+            xyz = rng.uniform(-1500.0, 1500.0, (20, 3))
+            ha_arr = rng.uniform(-np.pi, np.pi, 20)
+            uvw = rotate_xyz_to_uvw_jit(xyz, ha_arr, dec)
+            for i in range(20):
+                ha, b = ha_arr[i], xyz[i]
+                s0 = s_hat(ha, dec)
+                east = (s_hat(ha - h_step, dec) - s_hat(ha + h_step, dec)) / (
+                    2 * h_step * np.cos(dec)
+                )
+                north = (s_hat(ha, dec + h_step) - s_hat(ha, dec - h_step)) / (2 * h_step)
+                np.testing.assert_allclose(
+                    uvw[i], [b @ east, b @ north, b @ s0], rtol=0, atol=1e-6
+                )
+
+    def test_baseline_antisymmetry(self):
+        rng = np.random.default_rng(37)
+        xyz = rng.uniform(-1500.0, 1500.0, (50, 3))
+        ha_arr = rng.uniform(-np.pi, np.pi, 50)
+        fwd = rotate_xyz_to_uvw_jit(xyz, ha_arr, PT_DEC_RAD)
+        rev = rotate_xyz_to_uvw_jit(-xyz, ha_arr, PT_DEC_RAD)
+        np.testing.assert_allclose(rev, -fwd, rtol=0, atol=1e-12 * 1500.0)
+
+
+class TestComputeAndSetUvw:
+    """Production UVW reconstruction against independent astropy geometry.
+
+    The mock UVData carries ECEF-relative antenna positions at the real
+    DSA-110 site with astropy apparent-LST time arrays; compute_and_set_uvw
+    then runs the real pyuvdata phasing chain.
+
+    Criteria
+    --------
+    1. Norm preservation: |uvw| = |antenna_j - antenna_i| for every
+       baseline-time (rotations are isometries; rtol=1e-12, measured 8e-17
+       relative).
+    2. Antenna-pair antisymmetry: swapping ant_1_array/ant_2_array negates
+       every UVW vector (atol=1e-9 m; measured exactly 0).
+    3. w = b . s_hat where s_hat is the ASTROPY ICRS->ITRS unit vector of the
+       phase centre: atol = |b|_max * 5e-6 (~1 arcsec). Basis: w is immune to
+       the sky-frame position angle, so the only cross-implementation
+       difference is apparent-place consistency between astropy and
+       pyuvdata/erfa (sub-arcsec; measured 0.19 arcsec-equivalent).
+    4. Full (u, v, w) vs the astropy finite-difference ICRS sky basis:
+       atol = |b|_max * 1e-4 (~20.6 arcsec). Basis: the two implementations'
+       sky-north (frame position angle) conventions agree only to ~13 arcsec
+       (measured; differential-aberration-level definition differences).
+       This still catches a dropped frame_pa (117 arcsec at the 2018 test
+       epoch, growing ~6.5 arcsec/yr from J2000) and any sign/axis bug
+       (O(|b|)).
+    5. Transit geometry: for a locally East-West baseline the phase centre is
+       on the meridian, so w = 0 analytically at ANY declination (w is
+       frame-PA-immune; the residual measures apparent-HA consistency,
+       measured ~3e-13 m). atol = |b| * 1e-6 (~0.2 arcsec) covers
+       cross-library apparent-place differences. u must equal +|b| to within
+       |b| * 1e-3 (frame-PA rotation reduces it only at second order).
+    6. Fail-loud: a UVData object with no telescope location raises
+       ValueError (guard added during hardening).
+    """
+
+    def test_norm_preserved(self, uvw_case):
+        uv, ant_pos, _ = uvw_case
+        baselines = ant_pos[uv.ant_2_array] - ant_pos[uv.ant_1_array]
+        np.testing.assert_allclose(
+            np.linalg.norm(uv.uvw_array, axis=1),
+            np.linalg.norm(baselines, axis=1),
+            rtol=1e-12,
+        )
+
+    def test_antisymmetry_under_antenna_swap(self, uvw_case):
+        uv, ant_pos, _ = uvw_case
+        swapped = _MockUVData(ant_pos, uv.ant_2_array, uv.ant_1_array, uv.time_array)
+        compute_and_set_uvw(swapped, PT_DEC_RAD * u.rad)
+        np.testing.assert_allclose(swapped.uvw_array, -uv.uvw_array, rtol=0, atol=1e-9)
+
+    def test_w_matches_astropy_projection_onto_phase_centre(self, uvw_case):
+        uv, ant_pos, jd = uvw_case
+        baselines = ant_pos[uv.ant_2_array] - ant_pos[uv.ant_1_array]
+        bl_max = np.linalg.norm(baselines, axis=1).max()
+        for jdi in jd:
+            t = Time(jdi, format="jd")
+            ra, dec = get_meridian_coords(PT_DEC_RAD * u.rad, float(t.mjd))
+            _, _, s = _icrs_sky_basis_in_itrs(ra.to_value(u.rad), dec.to_value(u.rad), t)
+            rows = uv.time_array == jdi
+            np.testing.assert_allclose(
+                uv.uvw_array[rows, 2], baselines[rows] @ s, rtol=0, atol=bl_max * 5e-6
+            )
+
+    def test_uvw_matches_astropy_icrs_sky_basis(self, uvw_case):
+        uv, ant_pos, jd = uvw_case
+        baselines = ant_pos[uv.ant_2_array] - ant_pos[uv.ant_1_array]
+        bl_max = np.linalg.norm(baselines, axis=1).max()
+        for jdi in jd:
+            t = Time(jdi, format="jd")
+            ra, dec = get_meridian_coords(PT_DEC_RAD * u.rad, float(t.mjd))
+            east, north, s = _icrs_sky_basis_in_itrs(
+                ra.to_value(u.rad), dec.to_value(u.rad), t
+            )
+            rows = uv.time_array == jdi
+            b = baselines[rows]
+            expected = np.stack([b @ east, b @ north, b @ s], axis=1)
+            np.testing.assert_allclose(
+                uv.uvw_array[rows], expected, rtol=0, atol=bl_max * 1e-4
+            )
+
+    @pytest.mark.parametrize("dec_deg", [-20.0, 16.1, 55.0])
+    def test_east_west_baseline_at_transit_has_zero_w(self, dec_deg):
+        length = 1000.0
+        ant_pos = np.array([[0.0, 0.0, 0.0], length * EAST_ECEF])
+        jd = Time(MJD0, format="mjd").jd
+        uv = _MockUVData(ant_pos, [0], [1], [jd])
+        compute_and_set_uvw(uv, np.deg2rad(dec_deg) * u.rad)
+        np.testing.assert_allclose(uv.uvw_array[0, 2], 0.0, rtol=0, atol=length * 1e-6)
+        np.testing.assert_allclose(uv.uvw_array[0, 0], length, rtol=0, atol=length * 1e-3)
+
+    def test_missing_telescope_location_raises(self):
+        class _Bare:
+            pass
+
+        bare = _Bare()
+        bare.time_array = np.array([Time(MJD0, format="mjd").jd])
+        with pytest.raises(ValueError, match="telescope location"):
+            compute_and_set_uvw(bare, PT_DEC_RAD * u.rad)
+
+    def test_apparent_coord_failure_raises_instead_of_silent_frame_pa_zero(self, monkeypatch):
+        """A failed apparent-coordinate transform must abort conversion: the old
+        frame_pa=0 fallback silently rotated UVWs by the ICRS<->apparent sky
+        rotation (~2 arcmin at 2026 epochs), which is wrong science with no
+        exception."""
+        pu_calc_uvw, _, calc_frame_pos_angle = (
+            helpers_coordinates._load_pyuvdata_phasing_helpers()
+        )
+
+        def broken_calc_app_coords(*args, **kwargs):
+            raise ValueError("synthetic apparent-coordinate failure")
+
+        monkeypatch.setattr(
+            helpers_coordinates,
+            "_load_pyuvdata_phasing_helpers",
+            lambda: (pu_calc_uvw, broken_calc_app_coords, calc_frame_pos_angle),
+        )
+        ant_pos = np.array([[0.0, 0.0, 0.0], [100.0, 0.0, 0.0]])
+        uv = _MockUVData(ant_pos, [0], [1], [Time(MJD0, format="mjd").jd])
+        with pytest.raises(ValueError, match="apparent-coordinate"):
+            compute_and_set_uvw(uv, PT_DEC_RAD * u.rad)
+
+
+class TestPhaseCorrections:
+    """w-offset phase rotation kernel.
+
+    Criteria
+    --------
+    1. Unit modulus: |exp(i*phi)| = 1 exactly (atol=1e-14; cos^2+sin^2
+       identity holds to ~eps, measured 2.2e-16).
+    2. Reference cross-check: matches an independent numpy
+       exp(-2j*pi*w*f/c) with the SI speed of light — verifies both the
+       PHASE SIGN convention (negative for positive w offset) and the
+       magnitude. atol=1e-9: sin/cos vs exp argument-reduction differences
+       are ~eps*|phi| with |phi| up to 2*pi*2000m*1.53GHz/c ~ 6.4e4 rad,
+       giving ~1.4e-11 (measured); ~70x headroom.
+    3. Zero offset maps to exactly 1+0j; conjugate symmetry
+       corr(-w) = conj(corr(w)) (atol=1e-14, pure parity of cos/sin).
+    """
+
+    FREQS_HZ = np.linspace(1.28e9, 1.53e9, 64)  # DSA-110 band
+
+    def test_unit_modulus_and_matches_numpy_reference(self):
+        rng = np.random.default_rng(41)
+        w_off = rng.uniform(-2000.0, 2000.0, 50)
+        corr = compute_phase_corrections_jit(np.zeros((50, 3)), self.FREQS_HZ, w_off)
+        np.testing.assert_allclose(np.abs(corr), 1.0, rtol=0, atol=1e-14)
+        reference = np.exp(-2j * np.pi * np.outer(w_off, self.FREQS_HZ) / C_LIGHT_M_S)
+        np.testing.assert_allclose(corr, reference, rtol=0, atol=1e-9)
+
+    def test_zero_offset_is_unity_and_conjugate_symmetry(self):
+        w_off = np.array([0.0, 123.456])
+        corr = compute_phase_corrections_jit(np.zeros((2, 3)), self.FREQS_HZ, w_off)
+        np.testing.assert_allclose(corr[0], 1.0 + 0.0j, rtol=0, atol=1e-14)
+        corr_neg = compute_phase_corrections_jit(np.zeros((2, 3)), self.FREQS_HZ, -w_off)
+        np.testing.assert_allclose(corr_neg, np.conj(corr), rtol=0, atol=1e-14)

--- a/tests/test_metrics_canonical.py
+++ b/tests/test_metrics_canonical.py
@@ -1,0 +1,341 @@
+"""Canonical correctness tests for the variability-metric implementations.
+
+Correctness criteria (hardening-research-code):
+
+1. Analytic closed forms — Mooley et al. (2016), ApJ 818, 105, §5. Expected
+   values below are derived by hand; the derivation is stated in each test.
+2. Reference implementation — the VAST pipeline/tools checkout at
+   /data/radio-pipelines/askap-vast (vasttools/utils.py::pipeline_get_eta_metric,
+   vast_pipeline/pipeline/pairs.py::calculate_vs_metric/calculate_m_metric,
+   pipeline/finalise.py V metric with pandas .std(), i.e. ddof=1). Formulas are
+   transcribed into expected values here; the tests do not import VAST.
+3. Algebraic identity — with w = 1/sigma^2 the VAST eta form
+   (N/(N-1)) * [mean(w f^2) - mean(w f)^2 / mean(w)]
+   equals the reduced chi-squared about the weighted mean
+   (1/(N-1)) * sum((f_i - <f>_w)^2 / sigma_i^2)
+   exactly in real arithmetic, so the three repo implementations
+   (photometry/metrics.py, photometry/variability.py, lightcurves/metrics.py)
+   must agree to double-precision rounding.
+4. Statistical calibration — for Gaussian noise with correctly stated errors,
+   eta follows a reduced chi-squared distribution: E[eta] = 1,
+   std(eta) = sqrt(2/(N-1)).
+
+No golden data files: every expected value is derivable from the formulas
+above.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+from dsa110_continuum.lightcurves.metrics import compute_source_metrics
+from dsa110_continuum.photometry import metrics as pmetrics
+from dsa110_continuum.photometry import variability as pvar
+
+
+def _var_df(fluxes, errors):
+    return pd.DataFrame(
+        {
+            "normalized_flux_jy": np.asarray(fluxes, dtype=float),
+            "normalized_flux_err_jy": np.asarray(errors, dtype=float),
+        }
+    )
+
+
+def _eta_three_ways(fluxes, errors):
+    fluxes = np.asarray(fluxes, dtype=float)
+    errors = np.asarray(errors, dtype=float)
+    eta_metrics = pmetrics.calculate_eta_metric(fluxes, 1.0 / errors**2)
+    eta_var = pvar.calculate_eta_metric(_var_df(fluxes, errors))
+    _, _, eta_lc = compute_source_metrics(fluxes, errors)
+    return eta_metrics, eta_var, eta_lc
+
+
+class TestEtaAnalytic:
+    """Criterion 1: closed-form eta values.
+
+    Two points f=[1,3], sigma=[1,1]: weighted mean 2, chi^2 = 1+1 = 2,
+    eta = chi^2/(N-1) = 2.
+    Three points f=[2,4,6], sigma=[1,2,1]: w=[1,1/4,1], <f>_w = 9/2.25 = 4,
+    chi^2 = 4*1 + 0*0.25 + 4*1 = 8, eta = 8/2 = 4.
+    Tolerance rtol=1e-12: the arithmetic is a handful of double ops
+    (eps ~ 2.2e-16), so 1e-12 leaves ~1e3 headroom without admitting any
+    formula error.
+    """
+
+    def test_two_point_equal_errors(self):
+        for eta in _eta_three_ways([1.0, 3.0], [1.0, 1.0]):
+            np.testing.assert_allclose(eta, 2.0, rtol=1e-12)
+
+    def test_three_point_unequal_errors(self):
+        for eta in _eta_three_ways([2.0, 4.0, 6.0], [1.0, 2.0, 1.0]):
+            np.testing.assert_allclose(eta, 4.0, rtol=1e-12)
+
+    def test_constant_flux_eta_zero(self):
+        """Constant flux has chi^2 = 0 analytically. Cancellation floor is
+        eps * mean(w f^2) ~ 2e-16 * 25 ~ 6e-15, so atol=1e-12 sits well above
+        the floor and far below any physical eta."""
+        for eta in _eta_three_ways([5.0, 5.0, 5.0, 5.0], [1.0, 1.0, 1.0, 1.0]):
+            np.testing.assert_allclose(eta, 0.0, atol=1e-12)
+
+
+class TestEtaAlgebraicIdentity:
+    """Criterion 3: the VAST algebraic form and the two-pass reduced
+    chi-squared are the same quantity in real arithmetic, so all three repo
+    implementations must agree with an independent two-pass computation to
+    double rounding. rtol=1e-10: N=50 accumulations at eps ~ 2.2e-16 give
+    ~1e-14 relative error on well-conditioned data; 1e-10 leaves margin for
+    the mild cancellation in the algebraic form."""
+
+    def _dataset(self):
+        rng = np.random.default_rng(42)
+        fluxes = 10.0 + rng.normal(0.0, 2.0, 50)
+        errors = rng.uniform(0.5, 1.5, 50)
+        return fluxes, errors
+
+    def test_all_implementations_match_two_pass_chi2(self):
+        fluxes, errors = self._dataset()
+        w = 1.0 / errors**2
+        mean_w = np.sum(w * fluxes) / np.sum(w)
+        eta_ref = np.sum(((fluxes - mean_w) / errors) ** 2) / (len(fluxes) - 1)
+        for eta in _eta_three_ways(fluxes, errors):
+            np.testing.assert_allclose(eta, eta_ref, rtol=1e-10)
+
+    def test_scale_invariance(self):
+        """eta(c*f, c*sigma) = eta(f, sigma) exactly in real arithmetic:
+        both chi^2 numerator and denominator scale as c^2."""
+        fluxes, errors = self._dataset()
+        base = _eta_three_ways(fluxes, errors)
+        scaled = _eta_three_ways(137.0 * fluxes, 137.0 * errors)
+        np.testing.assert_allclose(scaled, base, rtol=1e-12)
+
+
+class TestEtaStatisticalCalibration:
+    """Criterion 4: for flux = const + N(0, sigma^2) with the true sigma
+    supplied, eta ~ reduced chi-squared with E=1, std=sqrt(2/(N-1)). With a
+    fixed seed the test is deterministic; the 5-sigma acceptance band
+    1 +/- 5*sqrt(2/999) ~ [0.78, 1.22] comes from the chi-squared
+    distribution, not from the observed value."""
+
+    def test_pure_noise_eta_near_one(self):
+        rng = np.random.default_rng(7)
+        n = 1000
+        fluxes = 10.0 + rng.normal(0.0, 1.0, n)
+        errors = np.ones(n)
+        band = 5.0 * np.sqrt(2.0 / (n - 1))
+        for eta in _eta_three_ways(fluxes, errors):
+            assert abs(eta - 1.0) < band
+
+
+class TestEtaFloat32Stability:
+    """Stability check: float32 input must agree with float64 within the
+    conditioning of the algebraic form. The subtraction
+    mean(w f^2) - mean(w f)^2/mean(w) cancels by a factor
+    kappa ~ mean(w f^2)/(eta*(N-1)/N) ~ 100 for this dataset, so the float32
+    error bound is ~eps32 * kappa ~ 1.2e-5; rtol=1e-4 gives ~8x margin."""
+
+    def test_float32_matches_float64(self):
+        rng = np.random.default_rng(3)
+        fluxes = 10.0 + rng.normal(0.0, 1.0, 50)
+        errors = rng.uniform(0.8, 1.2, 50)
+        eta64 = _eta_three_ways(fluxes, errors)
+        eta32 = _eta_three_ways(fluxes.astype(np.float32), errors.astype(np.float32))
+        np.testing.assert_allclose(eta32, eta64, rtol=1e-4)
+
+
+class TestTwoEpochMetrics:
+    """Criterion 1 + 2: Mooley two-epoch metrics, identical formulas in the
+    VAST reference (vast_pipeline/pipeline/pairs.py).
+
+    Vs(3,1,1,1) = 2/sqrt(2) = sqrt(2).
+    m(3,1) = 2*(3-1)/(3+1) = 1.
+    Antisymmetry and the bound |m| <= 2 for positive fluxes hold for all
+    inputs (property checks)."""
+
+    def test_vs_analytic(self):
+        np.testing.assert_allclose(
+            pvar.calculate_vs_metric(3.0, 1.0, 1.0, 1.0), np.sqrt(2.0), rtol=1e-12
+        )
+
+    def test_m_analytic(self):
+        np.testing.assert_allclose(pvar.calculate_m_metric(3.0, 1.0), 1.0, rtol=1e-12)
+
+    def test_antisymmetry(self):
+        rng = np.random.default_rng(11)
+        for _ in range(20):
+            a, b = rng.uniform(0.1, 10.0, 2)
+            ea, eb = rng.uniform(0.05, 1.0, 2)
+            np.testing.assert_allclose(
+                pvar.calculate_vs_metric(a, b, ea, eb),
+                -pvar.calculate_vs_metric(b, a, eb, ea),
+                rtol=1e-12,
+            )
+            np.testing.assert_allclose(
+                pvar.calculate_m_metric(a, b), -pvar.calculate_m_metric(b, a), rtol=1e-12
+            )
+
+    def test_m_bounded_for_positive_fluxes(self):
+        rng = np.random.default_rng(13)
+        for _ in range(50):
+            a, b = rng.uniform(1e-3, 1e3, 2)
+            assert abs(pvar.calculate_m_metric(a, b)) <= 2.0
+
+    def test_vs_rejects_invalid_errors(self):
+        with pytest.raises(ValueError):
+            pvar.calculate_vs_metric(3.0, 1.0, 0.0, 1.0)
+        with pytest.raises(ValueError):
+            pvar.calculate_vs_metric(3.0, 1.0, -1.0, 1.0)
+        with pytest.raises(ValueError):
+            pvar.calculate_vs_metric(3.0, 1.0, np.nan, 1.0)
+
+    def test_m_zero_sum_raises(self):
+        with pytest.raises(ValueError):
+            pvar.calculate_m_metric(1.0, -1.0)
+
+    def test_lightcurves_vs_analytic(self):
+        """Vs from the max/min pair: f=[1,2,5], sigma=[1,1,2] gives
+        (5-1)/sqrt(2^2+1^2) = 4/sqrt(5)."""
+        _, vs, _ = compute_source_metrics(np.array([1.0, 2.0, 5.0]), np.array([1.0, 1.0, 2.0]))
+        np.testing.assert_allclose(vs, 4.0 / np.sqrt(5.0), rtol=1e-12)
+
+
+class TestSourceModuleMetricImports:
+    """photometry/source.py must not silently stub calculate_eta/vs/m_metric to
+    0.0 when its imports fail: a 0.0-returning eta means variability is never
+    flagged, with no exception anywhere. A failed import must abort loudly."""
+
+    def test_import_failure_propagates_instead_of_stubbing(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "dsa110_continuum.catalog.multiwavelength", None)
+        sys.modules.pop("dsa110_continuum.photometry.source", None)
+        try:
+            with pytest.raises(ImportError):
+                importlib.import_module("dsa110_continuum.photometry.source")
+        finally:
+            sys.modules.pop("dsa110_continuum.photometry.source", None)
+
+    def test_source_metrics_are_the_variability_implementations(self):
+        psource = importlib.import_module("dsa110_continuum.photometry.source")
+        assert psource.calculate_eta_metric is pvar.calculate_eta_metric
+        assert psource.calculate_vs_metric is pvar.calculate_vs_metric
+        assert psource.calculate_m_metric is pvar.calculate_m_metric
+
+
+class TestRelativeLightcurveWiring:
+    """Source.calculate_relative_lightcurve builds neighbor_flux_matrix but
+    must actually bind and pass the transposed matrix to
+    calculate_relative_flux; a missing neighbor_fluxes binding is a NameError
+    on every call with >=1 valid neighbor (path previously uncovered).
+
+    Analytic expectation: two identical neighbors at 2.0 Jy give a weighted
+    median ensemble of 2.0 per epoch, so relative flux = target / 2.0."""
+
+    def test_reaches_calculate_relative_flux_with_neighbor_matrix(self, monkeypatch):
+        psource = importlib.import_module("dsa110_continuum.photometry.source")
+        target = psource.Source("T1", ra_deg=10.0, dec_deg=16.0)
+        target.measurements = pd.DataFrame(
+            {
+                "image_path": ["a.fits", "b.fits", "c.fits"],
+                "mjd": [60000.0, 60001.0, 60002.0],
+                "normalized_flux_jy": [1.0, 1.1, 0.9],
+                "normalized_flux_err_jy": [0.1, 0.1, 0.1],
+            }
+        )
+        monkeypatch.setattr(target, "find_stable_neighbors", lambda **kwargs: ["N1", "N2"])
+
+        class _FakeNeighbor:
+            measurements = pd.DataFrame(
+                {
+                    "image_path": ["a.fits", "b.fits", "c.fits"],
+                    "normalized_flux_jy": [2.0, 2.0, 2.0],
+                    "normalized_flux_err_jy": [0.2, 0.2, 0.2],
+                }
+            )
+
+        monkeypatch.setattr(psource, "Source", lambda nid, products_db=None: _FakeNeighbor())
+
+        result = target.calculate_relative_lightcurve()
+
+        assert result["n_neighbors"] == 2
+        np.testing.assert_allclose(result["relative_flux"], [0.5, 0.55, 0.45], rtol=1e-12)
+
+
+class TestVMetricConvention:
+    """Criterion 2: the VAST reference computes V with pandas .std(), i.e.
+    the ddof=1 sample standard deviation. For f=[1,3]: std=sqrt(2), mean=2,
+    V = sqrt(2)/2. photometry/metrics.py follows this convention."""
+
+    def test_metrics_v_matches_vast_ddof1(self):
+        v = pmetrics.calculate_v_metric(np.array([1.0, 3.0]))
+        np.testing.assert_allclose(v, np.sqrt(2.0) / 2.0, rtol=1e-12)
+
+    def test_variability_v_matches_vast_ddof1(self):
+        """photometry/variability.py delegates to the canonical metrics.py
+        implementation, so both copies follow the VAST convention (pandas
+        .std(), ddof=1). Replaces the former UNVERIFIED ddof=0 pin."""
+        v = pvar.calculate_v_metric(np.array([1.0, 3.0]))
+        np.testing.assert_allclose(v, np.sqrt(2.0) / 2.0, rtol=1e-12)
+
+
+class TestWeightedHelpers:
+    """Criterion 1 + invariants for the weighted-statistics helpers in
+    photometry/metrics.py.
+
+    Weighted mean of [1,3] with w=[1,3] is (1+9)/4 = 2.5.
+    Weighted variance (normalized by sum(w)) of [1,3] with w=[1,1]:
+    mean 2, variance = (1+1)/2 = 1.
+    Both are invariant under w -> c*w (weights enter homogeneously)."""
+
+    def test_weighted_mean_analytic(self):
+        m = pmetrics.calculate_weighted_mean(np.array([1.0, 3.0]), np.array([1.0, 3.0]))
+        np.testing.assert_allclose(m, 2.5, rtol=1e-12)
+
+    def test_weighted_variance_analytic(self):
+        v = pmetrics.calculate_weighted_variance(np.array([1.0, 3.0]), np.array([1.0, 1.0]))
+        np.testing.assert_allclose(v, 1.0, rtol=1e-12)
+
+    def test_weight_scale_invariance(self):
+        values = np.array([1.0, 2.0, 4.0, 8.0])
+        weights = np.array([1.0, 0.5, 2.0, 0.25])
+        for func in (pmetrics.calculate_weighted_mean, pmetrics.calculate_weighted_variance):
+            np.testing.assert_allclose(
+                func(values, 137.0 * weights), func(values, weights), rtol=1e-12
+            )
+
+    def test_zero_weights_return_nan(self):
+        assert np.isnan(pmetrics.calculate_weighted_mean(np.array([1.0]), np.array([0.0])))
+        assert np.isnan(pmetrics.calculate_weighted_variance(np.array([1.0]), np.array([0.0])))
+
+    def test_chi_squared_documented_contract(self):
+        """Criterion: the documented formula (module docstring states the
+        chi^2-per-N normalization, NOT the (N-1)-dof reduced chi^2). Perfect
+        model gives 0; f=[1,3], w=[1,1], model=2 gives (1+1)/2 = 1."""
+        chi = pmetrics.calculate_chi_squared(np.array([1.0, 3.0]), np.array([1.0, 1.0]), 2.0)
+        np.testing.assert_allclose(chi, 1.0, rtol=1e-12)
+        chi0 = pmetrics.calculate_chi_squared(np.array([2.0, 2.0]), np.array([1.0, 1.0]), 2.0)
+        np.testing.assert_allclose(chi0, 0.0, atol=1e-12)
+
+
+class TestSigmaDeviation:
+    """Criterion 1: f=[0,0,0,4]: mean 1, sample std (ddof=1)
+    sqrt((1+1+1+9)/3) = 2, max deviation |4-1| = 3, so sigma_dev = 1.5.
+    Applies to both copies (photometry/metrics.py and variability.py);
+    their empty-input contracts differ and are pinned as documented."""
+
+    def test_analytic_value_both_implementations(self):
+        data = np.array([0.0, 0.0, 0.0, 4.0])
+        np.testing.assert_allclose(pmetrics.calculate_sigma_deviation(data), 1.5, rtol=1e-12)
+        np.testing.assert_allclose(pvar.calculate_sigma_deviation(data), 1.5, rtol=1e-12)
+
+    def test_constant_is_zero(self):
+        data = np.array([3.0, 3.0, 3.0])
+        assert pmetrics.calculate_sigma_deviation(data) == 0.0
+        assert pvar.calculate_sigma_deviation(data) == 0.0
+
+    def test_empty_input_contracts(self):
+        assert pmetrics.calculate_sigma_deviation(np.array([])) == 0.0
+        with pytest.raises(ValueError):
+            pvar.calculate_sigma_deviation(np.array([]))


### PR DESCRIPTION
## Summary

Ships the conversion/photometry portion of the 2026-07-15 hardening campaign (`ai-research-workflows:hardening-research-code`) plus the bug fixes that came out of it. Protocol per target: explicit correctness criteria (analytic / VAST-reference / invariant) → tests capturing them → mutation red-green (every correctness test observed failing) → fix → green.

### Source changes

| File | Change |
|---|---|
| `conversion/calibrator_ms_generator.py` | `SIDEREAL_DAY_MINUTES` constant; `select_groups_by_position` rejects tolerances outside `(0, sidereal_day/2)` — beyond that the scoping silently re-admits the wrong-transit-date bug from #72 |
| `conversion/helpers_coordinates.py` | `compute_and_set_uvw` now raises on apparent-coordinate failure instead of silently falling back to `frame_pa=0` (~2′ UVW rotation at 2026 epochs); missing telescope location raises `ValueError` instead of an opaque downstream `TypeError` |
| `photometry/source.py` | Removed `except ImportError` stubs that silently pinned `calculate_eta/vs/m_metric` to 0.0 (variability would never flag); fixed latent `NameError` in `calculate_relative_lightcurve` (`neighbor_fluxes` never bound — crashed on every call with ≥1 valid neighbor) |
| `photometry/variability.py` | `calculate_v_metric` delegates to the canonical `photometry/metrics.py` copy (ddof=1, matching VAST's pandas `.std()`); the divergent ddof=0 copy had no production caller |
| `utils/numba_accel.py` | Doc-only: `angular_separation_jit` implements the spherical law of cosines, not haversine; documents the ~4.3 mas conditioning floor |

### Tests

- `tests/test_metrics_canonical.py` (new, 27): all three eta implementations pinned to Mooley (2016) closed forms, VAST reference formulas (`/data/radio-pipelines/askap-vast`, transcribed — not imported), the reduced-χ² algebraic identity, χ² statistical calibration, float32 stability; import-failure and relative-lightcurve wiring regressions.
- `tests/test_conversion_coordinates_hardening.py` (new, 31): UVW correctness vs independent astropy constructions (norm, antisymmetry, w-projection, ICRS sky-basis), meridian coords, angular separation vs astropy, LST, phase corrections; fail-loud paths.
- `tests/test_calibrator_ms_generator.py` (+13 → 21 here): sidereal-day scoping bounds (analytic), boundary semantics, adjacent-transit rejection, `convert_groups` behavioral invariants.

Mutation red-green from the campaign: calibrator 3/3, metrics 4/4, coordinates 9/9 mutations killed.

### Verification

- Worktree at `main` (2a62963): 146 passed across the six affected suites (casa6 env).
- `make test-cloud`: 200 passed + import gate + mention classifier clean.
- `ruff check` clean on all touched files.

### Notes for review

- **Relationship to #106**: the `convert_groups` string-group fix is deliberately NOT here — it ships in #106 (hunks are byte-identical). Whichever merges second hits a trivial append-conflict at the end of `tests/test_calibrator_ms_generator.py`.
- **Policy promotion**: the `frame_pa=0` fallback → hard failure is a behavior change on conversion error paths; a transient astropy/pyuvdata failure now aborts conversion rather than producing silently mis-rotated UVWs. This matches the repo's fail-loud invariants but flag it if partial-epoch tolerance was relied on.
- The observability-side fixes from the same campaign (hour-glob cross-match, `find_csv` mtime, dashboard test isolation) depend on the not-yet-pushed dashboard stack and ride that lane instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLPHL6EdWZEJTgHp2AdFvC