### PR TITLE
Promote live-observability stack to main (carries b6a303e bug fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Set `PYTHONPATH=/workspace` when running scripts/tests from this workspace conte
 | `scripts/verify_sources.py` | Verify fluxes against expected values |
 | `scripts/validate_date.py` | Run validation on one date's outputs |
 | `scripts/run_canary.sh` | QA smoke test against a reference FITS tile |
+| `scripts/auto_pipeline.py` | Scheduled launcher: runs `batch_pipeline.py` for yesterday UTC via the control registry (systemd timer entrypoint; skips if a launcher-owned run is active) |
 | `PYTHONPATH=/workspace uvicorn scripts.monitor_server:app --host 0.0.0.0 --port 8765` | Start the monitor API (host-ops service) |
 | `scripts/check_import_migration.py` | Legacy-import gate: exits 1 if any `dsa110_contimg` import exists under `dsa110_continuum/` (CI runs this on every push/PR) |
 | `scripts/check_contimg_mentions.py` | Mention classifier: fails on vendored headers, stale API refs, and dead layout probes (ops path defaults are INFO until `--strict-paths`) |
@@ -260,8 +261,8 @@ Save under `/data/dsa110-continuum/outputs/` (organize by topic or date). Do NOT
 Three FastAPI services exist; their statuses differ:
 
 - `dsa110_continuum/mosaic/api.py` — **dormant**. Defines a router but no caller currently mounts it. Do NOT assume users hit this path; verify the mount before changing behavior.
-- `scripts/qa_server.py` — **live**. The QA dashboard users currently rely on. Treat as production: changes need the same care as pipeline code.
-- `scripts/monitor_server.py` — **live, host-ops**. Exposes a `POST /exec` shell hook; any change to that endpoint is a security-relevant edit and must be flagged.
+- `scripts/qa_server.py` — **live**. The QA dashboard users currently rely on. Treat as production: changes need the same care as pipeline code. Includes the token-gated pipeline control API (`/api/runs`, launch/dry-run/terminate via `dsa110_continuum/observability/control.py`); mutating routes fail closed when `DSA110_CONTROL_TOKEN` is unset and are audited to `control/audit.jsonl`. Ops runbook: `docs/operations/dashboard.md`.
+- `scripts/monitor_server.py` — **not currently running** (no launcher in repo; verified 2026-07-15). Exposes a `POST /exec` shell hook; any change to that endpoint is a security-relevant edit and must be flagged. Never mount or proxy it; #62 tracks retirement.
 
 The live-observability-stack work lands across these services; tracking issues #48–#62 (`gh issue list --label needs-triage --state open`).
 

--- a/docs/operations/dashboard.md
+++ b/docs/operations/dashboard.md
@@ -1,0 +1,77 @@
+# Dashboard operations (qa_server + pipeline control)
+
+The dashboard on port 8767 (`scripts/qa_server.py`) is the single operator surface: read-only
+monitoring is open; every mutating route (`POST /api/runs`, `POST /api/runs/{id}/terminate`)
+requires a bearer token and is audited. The Dagster tracer-bullet on :3212 remains a separate
+read-only metadata view (see `outputs/observability-dashboard-2026-07-14/REPRODUCE.md`).
+
+## Control token
+
+Generate once, store in the environment file the systemd unit loads:
+
+```bash
+/opt/miniforge/envs/casa6/bin/python -c "import secrets; print(secrets.token_urlsafe(32))"
+sudo mkdir -p /data/dsa110-proc/products/control
+printf 'DSA110_CONTROL_TOKEN=%s\n' '<token>' | sudo tee /data/dsa110-proc/products/control/dashboard.env
+sudo chown ubuntu:ubuntu /data/dsa110-proc/products/control/dashboard.env
+sudo chmod 600 /data/dsa110-proc/products/control/dashboard.env
+```
+
+Fail-closed: if `DSA110_CONTROL_TOKEN` is unset in the server environment, every mutating
+request returns 403 and the dashboard is effectively read-only. Never commit the env file.
+
+## Service installation (one-time, requires sudo)
+
+```bash
+sudo cp ops/systemd/dsa110-dashboard.service ops/systemd/dsa110-autopipeline.service \
+        ops/systemd/dsa110-autopipeline.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now dsa110-dashboard
+sudo systemctl enable --now dsa110-autopipeline.timer
+```
+
+Health checks: `systemctl status dsa110-dashboard`, `systemctl list-timers 'dsa110-*'`,
+`curl -s http://127.0.0.1:8767/health`.
+
+The timer runs `scripts/auto_pipeline.py` daily at 02:00 UTC, which launches
+`batch_pipeline.py --date <yesterday UTC> --retry-failed --quarantine-after-failures 3
+--photometry-workers 4` through the same registry the dashboard uses. If a launcher-owned run
+is still active the timer tick reports `skipped_running` to the journal and does not queue.
+
+## Manual intervention runbook
+
+1. Open `http://lxd110h17:8767/` → Pipeline control panel.
+2. Fill in date (and hours / flags as needed), paste the control token.
+3. **Dry-run preview** — shows `batch_pipeline.py --dry-run`'s full rebuild/skip/quarantine
+   plan; writes nothing.
+4. **Launch** — the run appears in the runs table; click its ID for live log tail
+   (`/control/runs/{run_id}`, 15 s refresh).
+5. **Terminate** — SIGTERMs the whole process group (batch driver, CASA workers, WSClean),
+   escalating to SIGKILL after 10 s. Verify with `pgrep -g <pid>` if paranoid.
+6. Per-date QA and provenance: `/runs/{date}` (verdict, gate reasons, per-epoch QA).
+7. Light curves: `/sources/lightcurve?ra=<deg>&dec=<deg>` or the dashboard lookup form.
+
+Equivalent curl:
+
+```bash
+curl -s -X POST http://127.0.0.1:8767/api/runs \
+  -H "Authorization: Bearer $DSA110_CONTROL_TOKEN" -H 'Content-Type: application/json' \
+  -d '{"date":"2026-01-25","start_hour":22,"end_hour":23,"force_recal":true,"dry_run":true}'
+```
+
+## Audit and registry
+
+- Run registry: `/data/dsa110-proc/products/control/runs.sqlite3` (`runs` table; each row
+  carries the full request + argv JSON, pid, log path, status, exit code).
+- Per-run logs: `/data/dsa110-proc/products/control/run_<id>.log`.
+- Audit log: `/data/dsa110-proc/products/control/audit.jsonl` — one JSON line per mutating
+  request (timestamp, action, remote address, payload). The token is never written.
+- Env overrides: `DSA110_CONTROL_DIR`, `DSA110_REPO_ROOT`, `DSA110_PIPELINE_PYTHON`.
+
+## Network posture
+
+The Cloudflare tunnel (see `outputs/observability-dashboard-2026-07-14/CLOUDFLARE.md`) points
+at this origin. Mutating routes are safe to expose only because of the token gate; for
+defense in depth, enable Cloudflare Access (SSO) on the tunnel hostname before advertising
+the URL beyond the group. LAN access needs no extra step. `scripts/monitor_server.py` and its
+`POST /exec` remain unmounted and must stay that way (issue #62 tracks retirement).

--- a/docs/operations/dashboard.md
+++ b/docs/operations/dashboard.md
@@ -10,12 +10,14 @@ read-only metadata view (see `outputs/observability-dashboard-2026-07-14/REPRODU
 Generate once, store in the environment file the systemd unit loads:
 
 ```bash
-/opt/miniforge/envs/casa6/bin/python -c "import secrets; print(secrets.token_urlsafe(32))"
-sudo mkdir -p /data/dsa110-proc/products/control
-printf 'DSA110_CONTROL_TOKEN=%s\n' '<token>' | sudo tee /data/dsa110-proc/products/control/dashboard.env
-sudo chown ubuntu:ubuntu /data/dsa110-proc/products/control/dashboard.env
-sudo chmod 600 /data/dsa110-proc/products/control/dashboard.env
+mkdir -p ~/.config/dsa110
+/opt/miniforge/envs/casa6/bin/python -c "import secrets; print(secrets.token_urlsafe(32))" \
+  | xargs -I{} printf 'DSA110_CONTROL_TOKEN=%s\n' '{}' > ~/.config/dsa110/dashboard.env
+chmod 600 ~/.config/dsa110/dashboard.env
 ```
+
+The env file must live on a real POSIX filesystem (`~` is ext4). Do NOT put it under `/data`
+or `/stage` — both are fuseblk there and ignore chmod, leaving the token world-readable.
 
 Fail-closed: if `DSA110_CONTROL_TOKEN` is unset in the server environment, every mutating
 request returns 403 and the dashboard is effectively read-only. Never commit the env file.

--- a/docs/rse/specs/implement-dashboard-production-readiness.md
+++ b/docs/rse/specs/implement-dashboard-production-readiness.md
@@ -1,0 +1,132 @@
+# Implementation Summary: Production-ready pipeline dashboard (monitoring + control)
+
+---
+**Date:** 2026-07-15
+**Author:** AI Assistant (Claude Fable 5)
+**Status:** Complete (code); manual verification + deploy steps pending user
+**Plan Reference:** [plan-dashboard-production-readiness.md](plan-dashboard-production-readiness.md)
+
+---
+
+## Overview
+
+Implemented the full plan on branch `dashboard-production` (7 commits, `7183fe7..136b99c`):
+landed the previously-uncommitted observability baseline, built the token-gated pipeline
+control plane (module + API + UI), added run-provenance and light-curve science views,
+epoch auto-discovery, the scheduled automation entrypoint, systemd units, and operations docs.
+
+**Implementation Duration:** 2026-07-15 (single session)
+
+**Final Status:** ✅ Complete (code + automated verification); deploy/manual steps reserved for user
+
+## Plan Adherence
+
+**Deviations from Plan:**
+
+- **Deviation 1:** Phase 0's `gh issue comment 51` and Phase 6's PR creation were NOT executed.
+  - **Reason:** outward-facing actions reserved for user review per session constraints.
+  - **Impact:** none on code; listed under Remaining Work.
+- **Deviation 2:** Phase 2's "manual smoke on H17" was performed via the control module
+  directly (`run_dry_run` against the real `scripts/batch_pipeline.py`, date 2026-01-25
+  hours 22–23) rather than HTTP against the live :8767 server.
+  - **Reason:** the running qa_server instance (PID 3226242, started 2026-07-14) still serves
+    the pre-branch code; restarting a production service before user review was out of bounds.
+  - **Impact:** end-to-end integration with the real pipeline is verified (179 MS discovered,
+    Dec-strip check passed, dry-run plan rendered); the HTTP hop is exercised by 20+
+    TestClient tests. Live-restart is a deploy step.
+- **Deviation 3:** small test additions beyond plan (failed-run reaping, calendar-date
+  validation, no-points light-curve page, invalid-date auto-launch outcome) and an extra
+  registry-missing 404 guard on `GET /api/runs/{run_id}`.
+  - **Reason:** edge cases surfaced while writing the planned tests.
+  - **Impact:** stricter coverage, no interface change.
+
+## Phases Completed
+
+| Phase | Commit | Summary |
+| --- | --- | --- |
+| 0 — Baseline | `7183fe7` | Routed qa_server + observability package + 4 test suites committed (80 tests green first). |
+| 1 — Control module | `5284d84` | `observability/control.py`: validated RunRequest→argv allowlist, SQLite registry, detached process-group launch, reaper thread, SIGTERM→SIGKILL group terminate, single-flight guard, dry-run. 12 tests. |
+| 2 — Control API | `18d222b` | `/api/runs` list/detail/launch/terminate on qa_server; fail-closed bearer auth (constant-time), JSONL audit (token never written). 7 tests. |
+| 3 — Control UI | `f6e1b9d` | Dashboard control panel (runs table, launch form, dry-run preview, terminate; token field suspends auto-reload), `/control/runs/{id}` detail pages with escaped log tails, `discover_epochs` replacing hardcoded EPOCHS (fallback retained). 6 tests. |
+| 4 — Provenance | `b2f1540` | `/runs/{date}` manifest page: verdict badge, gate reasons, per-epoch QA table linked to mosaic artifacts, run report; partial manifests render placeholders. 3 tests. |
+| 5 — Light curves | `344761a` | `/sources/lightcurve` + `.png`: cos(dec)-scaled nearest-match per epoch, per-point mosaic click-through, η/V from `photometry/metrics.py` canonical formulas; dashboard lookup form. 7 tests. |
+| 6 — Automation/ops | `136b99c` | `scripts/auto_pipeline.py` (single-flight scheduled launcher, 3 tests), `ops/systemd/` units, `docs/operations/dashboard.md`, CLAUDE.md updates (control API note; corrected stale "monitor_server live" claim). |
+
+## Files Modified
+
+**Created:** `dsa110_continuum/observability/control.py`, `tests/test_observability_control.py`,
+`scripts/auto_pipeline.py`, `tests/test_auto_pipeline.py`,
+`ops/systemd/dsa110-dashboard.service`, `ops/systemd/dsa110-autopipeline.service`,
+`ops/systemd/dsa110-autopipeline.timer`, `docs/operations/dashboard.md`
+(plus Phase 0 landing of the previously-untracked observability package and test suites).
+
+**Modified:** `scripts/qa_server.py` (control router + pages + discovery + light curves),
+`tests/test_qa_server.py` (23 new tests), `CLAUDE.md` (two sections).
+
+**Deleted:** none.
+
+## Verification Results
+
+### Automated
+
+- ✅ `make test-cloud PYTHON=/opt/miniforge/envs/casa6/bin/python` — 200 passed.
+- ✅ Targeted suites (`test_qa_server` 63, `test_observability_control` 12,
+  `test_auto_pipeline` 3, hour_state/mosaic_preview/no-dagster 40) — 118 passed.
+- ✅ `ruff check` + `ruff format --check` clean on all touched files.
+- ✅ Dagster-free import: `import dsa110_continuum.observability.control` loads no `dagster`.
+- ✅ `tests/test_mosaic_import_no_dagster.py` still green.
+- ✅ Real-pipeline smoke: `run_dry_run(RunRequest(date='2026-01-25', start_hour=22,
+  end_hour=23))` executed the actual `batch_pipeline.py --dry-run` (179 valid MS, Dec-strip
+  16.1° check passed, plan printed).
+- ✅ `systemd-analyze verify` on shipped units — no unit-specific errors (system-wide legacy
+  warnings only).
+- ⏳ Full `pytest tests/ --ignore=tests/test_mosaic_ra_wrap.py` was launched; result recorded
+  in the completion summary / final report.
+
+### Manual (pending user)
+
+- [ ] Restart qa_server from the branch; browser checks: control panel, discovered epochs,
+  `/runs/2026-07-13` (real DEGRADED manifest), light curve at RA 47.499 Dec 17.0998.
+- [ ] Full intervention loop on a scratch date (dry-run → launch → log tail → terminate;
+  verify `pgrep -g` empty after terminate).
+- [ ] Fail-closed check with token env unset.
+- [ ] Install systemd units + token env file (`docs/operations/dashboard.md`), confirm timer.
+
+## Issues Encountered
+
+Minor only: ruff D102/D103/I001 on first pass (docstrings + import order, fixed); FastAPI
+route needed an explicit registry-missing guard to avoid a 500 on `GET /api/runs/{id}` before
+any run exists.
+
+## Testing Summary
+
+**Tests added:** 31 new (12 control module, 7 control auth, 3 discovery, 3 UI, 3 provenance,
+7 light curve — counting per class; plus 3 auto-pipeline) on top of the 80 landed in Phase 0.
+All criterion-first (injection safety, fail-closed auth, process-group kill incl. grandchild,
+registry state machine, partial-manifest resilience, positional matching).
+
+**All tests passing:** ✅ (cloud gate 200; targeted 118)
+
+## Remaining Work
+
+- [ ] User review of research + plan + this summary; then PR from `dashboard-production`.
+- [ ] Issue-tracker updates (#48/#49 decisions, #51/#53/#59/#60 partial closes) — outward-facing.
+- [ ] ADR in `docs/adr/` recording the #48/#49 decisions (short follow-up commit).
+- [ ] Deploy: restart qa_server from branch, token env file, systemd install (sudo).
+- [ ] Deferred slices per plan: #52, #54–#57, full #53 lifecycle badges, #58/#61 mosaic
+  routes, #62 monitor_server retirement, legacy-stack teardown plan.
+
+## Next Steps
+
+1. User reviews `research-dashboard-production-readiness.md`, the plan, and this summary.
+2. `ai-research-workflows:validating-implementations` after the manual checks.
+3. PR + issue hygiene + deploy per Remaining Work.
+
+## References
+
+- [Plan](plan-dashboard-production-readiness.md) · [Research](research-dashboard-production-readiness.md)
+- Commits: `7183fe7`, `5284d84`, `18d222b`, `f6e1b9d`, `b2f1540`, `344761a`, `136b99c`
+
+---
+
+**Implementation completed by AI Assistant on 2026-07-15**

--- a/docs/rse/specs/plan-dashboard-production-readiness.md
+++ b/docs/rse/specs/plan-dashboard-production-readiness.md
@@ -1,0 +1,1359 @@
+# Implementation Plan: Production-ready pipeline dashboard (monitoring + control)
+
+---
+**Date:** 2026-07-15
+**Author:** AI Assistant (Claude Fable 5)
+**Status:** Implemented on branch `dashboard-production` — awaiting user review (manual verification + deploy pending)
+**Related Documents:**
+- [Research: Production-ready pipeline dashboard](research-dashboard-production-readiness.md)
+- Prior session: `outputs/observability-dashboard-2026-07-14/{DECISION,ARCHITECTURE,STATUS}.md`
+- GitHub issues #48–#62 (dsa110/dsa110-continuum)
+
+---
+
+## Overview
+
+This plan takes the DSA-110 continuum dashboard from an uncommitted read-only tracer-bullet to a
+production dashboard that monitors the full imaging pipeline and lets the operator launch,
+re-run, and terminate pipeline stages when automation fails. It resolves the orchestrator
+question the user delegated ("investigate and determine"): **Dagster is kept only in its
+existing read-only observability lane; it is not the control plane.** The control plane is a
+small, auth-gated run-launcher inside the existing FastAPI dashboard (`scripts/qa_server.py`)
+that drives `scripts/batch_pipeline.py` — the component that already owns checkpoint/resume,
+quarantine, retry, per-hour windows, and dry-run semantics.
+
+**Goal:** One dashboard origin (`:8767`) where the operator can watch every epoch's products,
+QA verdicts, and light curves; preview a re-run with `--dry-run`; launch/terminate real runs
+with structured, validated parameters; and where scheduled automation uses the same launcher
+code path.
+
+**Motivation:** The pipeline is meant to run automated with manual fallback; today there is no
+automation trigger, no control surface, no auth, and the recent observability work is
+uncommitted (research doc, Findings §5).
+
+## Current State Analysis
+
+**Existing Implementation:**
+- `scripts/qa_server.py:1-597` — live routed FastAPI dashboard (uncommitted rewrite): mosaic
+  artifact router (`:526-549`), `/api/status` (`:558-566`), server-rendered HTML with 30 s
+  reload (`:510`), hardcoded `EPOCHS` (`:52-59`), `DashboardConfig` env-driven paths (`:32-49`).
+- `dsa110_continuum/observability/hour_state.py:151-233` — read-only per-hour collector
+  (uncommitted); `dagster_defs.py:80-190` — six assets + 1-min sensor on :3212 (uncommitted).
+- `scripts/batch_pipeline.py:1217-1440` — CLI-only entrypoint; all control knobs are flags
+  (`--date :1228`, `--cal-date :1229`, `--start-hour/--end-hour :1291-1304`,
+  `--tile-timeout :1305`, `--retry-failed :1313`, `--force-recal :1320`, `--lenient-qa :1342`,
+  `--dry-run :1375`, `--quarantine-after-failures :1386`, `--clear-quarantine :1397`,
+  `--photometry-workers :1409`, `--rfi-mode :1273` choices `full|conditional|off :1275`,
+  `--skip-photometry :1257`).
+- Run truth: `{date}_manifest.json` (verified keys: `pipeline_verdict`, `gates[]` with
+  `gate/verdict/reason`, `epochs[]` with `hour/n_tiles/status/mosaic_path/peak/rms/qa_result`,
+  `tiles[]`, `git_sha`, `command_line`, `run_log`), `{date}_run_summary.json`, `run_report.md`
+  under `/data/dsa110-proc/products/mosaics/{date}/` (writers:
+  `dsa110_continuum/qa/provenance.py:248`, `scripts/batch_pipeline.py:2245`,
+  `dsa110_continuum/qa/run_report.py:68`).
+- Forced-photometry CSV schema (verified on disk):
+  `ra_deg,dec_deg,nvss_flux_jy,dsa_peak_jyb,dsa_peak_err_jyb,dsa_nvss_ratio` at
+  `products/mosaics/{date}/{date}T{HH}00_forced_phot.csv`.
+- Variability metrics: `dsa110_continuum/photometry/metrics.py` (`calculate_eta_metric` — the
+  VAST-canonical η at line 112, `calculate_v_metric`).
+- Tests idiom: `tests/test_qa_server.py:15-110` — `DashboardConfig` over `tmp_path`,
+  `TestClient(create_app(config))`, synthetic FITS/CSV, invariant-based classes.
+
+**Current Limitations:** no control surface, no auth, no automation, hardcoded epochs, no
+science-product (light-curve) view, uncommitted baseline (research doc, Findings §5).
+
+## Desired End State
+
+**New Behavior:**
+- `GET /` shows auto-discovered recent epochs, active-run state, and a Pipeline-control panel.
+- `POST /api/runs` (Bearer-token) validates a structured request, previews via `--dry-run`
+  synchronously or launches `batch_pipeline.py` detached in its own process group, registered
+  in a SQLite run registry with a per-run log.
+- `POST /api/runs/{run_id}/terminate` (Bearer-token) kills the whole process group.
+- `GET /runs/{date}` renders manifest gates/verdict/epochs + run report for any date.
+- `GET /sources/lightcurve?ra=…&dec=…` renders a positional light curve across all epochs with
+  η/V metrics.
+- A systemd timer (unit files shipped, installation documented) launches the same code path on
+  schedule; overlap is impossible (single-flight guard).
+
+**Success Looks Like:**
+- Operator can go from "hour 11 mosaic QA-FAIL" to "dry-run preview → re-run hour 11 with
+  `--force-recal` → watch log tail → see new verdict" without leaving the browser.
+- `make test-cloud PYTHON=/opt/miniforge/envs/casa6/bin/python` green; all new tests green.
+- Nothing mutating is reachable without the token; token absent ⇒ control disabled (403).
+
+## What We're NOT Doing
+
+- [ ] Dagster as control plane (partitioned assets wrapping the CLI) — documented fallback
+      only; the tracer-bullet on :3212 stays as-is, unmodified.
+- [ ] Prefect/Airflow migration.
+- [ ] Per-MS/per-tile/per-caltable deep QA views (#54–#56), stage-event contract (#52),
+      full lifecycle-state badge taxonomy (#53 beyond epoch auto-discovery), CARTA/interactive
+      FITS (#50), mosaic-on-demand mutating routes (#61), monitor_server retirement (#62 —
+      blocked by #57). These are follow-up plans per-issue.
+- [ ] Legacy stack teardown (old contimg Dagster host+Docker services, nginx fronts,
+      lightcurve `http.server`) — needs its own inventory + user sign-off; out of scope here.
+- [ ] WebSockets/SSE push; the 30 s reload + on-demand JSON stays (matches #48 provisional
+      baseline "polling, lazy, single-process").
+- [ ] Frontend framework rewrite; server-rendered HTML + minimal vanilla JS only.
+
+**Rationale:** ship the monitoring+control core first; every deferred item layers onto the same
+routed FastAPI substrate without rework.
+
+## Implementation Approach
+
+**Key Architectural Decisions:**
+1. **Decision:** FastAPI unified server is the product; Dagster stays read-only.
+   - **Rationale:** `batch_pipeline.py` already owns re-run semantics (checkpoint, quarantine,
+     manifest-keyed epoch rebuild); wrapping it in Dagster partitions duplicates state and adds
+     daemon ops burden + the grandchild-kill caveat (research doc, Prior Art). Observatory
+     precedent (Simons, Keck) favors lighter control planes.
+   - **Trade-offs:** we own a small run registry + reaper (~200 LOC) instead of getting a
+     partition grid UI for free.
+   - **Alternatives considered:** Dagster-as-control (rejected: two sources of truth, ops
+     burden, retired-bridge history), Prefect (rejected: migration cost, no installed base).
+2. **Decision:** Auth = pre-shared Bearer token (`DSA110_CONTROL_TOKEN`), fail-closed,
+   constant-time compare, JSONL audit log; read-only routes stay open. Resolves #49 for the
+   single-operator case; Cloudflare Access on the tunnel is documented optional hardening.
+   - **Trade-offs:** no per-user identity; acceptable for one operator, revisit if that changes.
+3. **Decision:** Control API accepts only a structured request and builds argv itself — no raw
+   command strings anywhere (kills the `POST /exec` failure mode).
+4. **Decision:** Launcher uses `start_new_session=True` (fresh process group) +
+   `os.killpg` terminate + daemon reaper thread + pid-liveness reconciliation; registry is
+   SQLite created inline (repo pattern: `calibration/jobs.py:50`).
+5. **Decision:** Automation = systemd timer invoking `scripts/auto_pipeline.py`, which calls
+   the same `launch_run()`; single-flight guard refuses overlapping runs.
+
+**Patterns to Follow:**
+- Config dataclass with env-default fields — `scripts/qa_server.py:32-49`,
+  `dsa110_continuum/observability/hour_state.py:14-49`.
+- Inline `CREATE TABLE IF NOT EXISTS` in the owning module — `calibration/jobs.py:50`.
+- Test style — `tests/test_qa_server.py:15-110`.
+- No ThreadPoolExecutor+SIGALRM (CLAUDE.md); the reaper thread only `wait()`s — no signals.
+
+## Implementation Phases
+
+Run all commands from `/data/dsa110-continuum` with
+`PY=/opt/miniforge/envs/casa6/bin/python` and `PYTHONPATH=/data/dsa110-continuum`.
+
+### Phase 0: Land the uncommitted observability baseline
+
+**Objective:** the working-tree tracer-bullet (routed qa_server, observability package, tests)
+becomes committed, lint-clean history — the foundation every later phase edits.
+
+**Tasks:**
+- [x] Run the affected tests, watch them pass (they exist and passed on 2026-07-14):
+  `$PY -m pytest tests/test_qa_server.py tests/test_observability_hour_state.py tests/test_observability_mosaic_preview.py tests/test_mosaic_import_no_dagster.py -q` → 80 passed.
+- [x] `ruff check` + `ruff format --check` on baseline files → clean.
+- [x] Staged only in-scope files (unrelated working-tree modifications left unstaged).
+- [x] Committed on branch `dashboard-production` (7183fe7).
+- [ ] *(deferred to user — outward-facing)* Cross-reference issue #51 via `gh issue comment`.
+
+**Verification:**
+- [x] `git log --oneline -1` shows the commit; unrelated files remain unstaged as intended.
+- [x] `make test-cloud PYTHON=$PY` → 200 passed, exit 0.
+
+### Phase 1: Control module — validated requests, registry, launcher, terminate
+
+**Objective:** `dsa110_continuum/observability/control.py`: a framework-free module that builds
+safe argv from a structured request, launches `batch_pipeline.py` in its own process group,
+tracks it in SQLite, reaps exit status, terminates process groups, and reports liveness.
+
+**Tasks:**
+- [x] **Failing test — request validation + argv building.** File: `tests/test_observability_control.py` (new)
+
+  ```python
+  import sys
+  from pathlib import Path
+
+  import pytest
+
+  from dsa110_continuum.observability.control import ControlConfig, RunRequest
+
+
+  def _config(tmp_path: Path) -> ControlConfig:
+      return ControlConfig(
+          repo_root=tmp_path,
+          python=sys.executable,
+          control_dir=tmp_path / "control",
+      )
+
+
+  class TestRunRequestValidation:
+      def test_rejects_shell_metacharacters_in_date(self):
+          for bad in ("2026-01-25; rm -rf /", "$(reboot)", "2026-01-25x", "..", ""):
+              with pytest.raises(ValueError):
+                  RunRequest(date=bad)
+
+      def test_rejects_out_of_range_hours_and_bad_rfi_mode(self):
+          with pytest.raises(ValueError):
+              RunRequest(date="2026-01-25", start_hour=24)
+          with pytest.raises(ValueError):
+              RunRequest(date="2026-01-25", start_hour=5, end_hour=3)
+          with pytest.raises(ValueError):
+              RunRequest(date="2026-01-25", rfi_mode="sometimes")
+
+      def test_argv_is_allowlisted_flags_only(self, tmp_path):
+          request = RunRequest(
+              date="2026-01-25", cal_date="2026-01-25", start_hour=22, end_hour=23,
+              force_recal=True, retry_failed=True, lenient_qa=True,
+              rfi_mode="conditional", quarantine_after_failures=3,
+          )
+          argv = request.to_argv(_config(tmp_path))
+          assert argv[0] == sys.executable
+          assert argv[1] == "scripts/batch_pipeline.py"
+          assert "--date" in argv and "2026-01-25" in argv
+          assert "--force-recal" in argv and "--retry-failed" in argv
+          assert "--rfi-mode" in argv and "conditional" in argv
+          joined = " ".join(argv)
+          assert ";" not in joined and "$(" not in joined
+  ```
+
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_observability_control.py -q` → FAIL (module missing).
+- [x] **Implement request + config.** File: `dsa110_continuum/observability/control.py` (new)
+
+  ```python
+  """Launch, track, and terminate batch_pipeline.py runs for the dashboard."""
+
+  from __future__ import annotations
+
+  import json
+  import os
+  import re
+  import signal
+  import sqlite3
+  import subprocess
+  import threading
+  import time
+  import uuid
+  from dataclasses import dataclass, field, fields
+  from datetime import datetime, timezone
+  from pathlib import Path
+
+  DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+  RFI_MODES = ("full", "conditional", "off")
+
+
+  class RunConflictError(RuntimeError):
+      """Another launcher-owned pipeline run is still alive."""
+
+
+  @dataclass(frozen=True)
+  class ControlConfig:
+      repo_root: Path = field(
+          default_factory=lambda: Path(
+              os.environ.get("DSA110_REPO_ROOT", "/data/dsa110-continuum")
+          )
+      )
+      python: str = field(
+          default_factory=lambda: os.environ.get(
+              "DSA110_PIPELINE_PYTHON", "/opt/miniforge/envs/casa6/bin/python"
+          )
+      )
+      control_dir: Path = field(
+          default_factory=lambda: Path(
+              os.environ.get("DSA110_CONTROL_DIR", "/data/dsa110-proc/products/control")
+          )
+      )
+
+      @property
+      def db_path(self) -> Path:
+          return self.control_dir / "runs.sqlite3"
+
+
+  @dataclass(frozen=True)
+  class RunRequest:
+      date: str
+      cal_date: str | None = None
+      start_hour: int | None = None
+      end_hour: int | None = None
+      rfi_mode: str | None = None
+      tile_timeout: int | None = None
+      quarantine_after_failures: int | None = None
+      photometry_workers: int | None = None
+      retry_failed: bool = False
+      force_recal: bool = False
+      skip_photometry: bool = False
+      lenient_qa: bool = False
+      clear_quarantine: bool = False
+      dry_run: bool = False
+
+      def __post_init__(self) -> None:
+          for label, value in (("date", self.date), ("cal_date", self.cal_date)):
+              if value is None:
+                  continue
+              if not DATE_RE.fullmatch(value):
+                  raise ValueError(f"{label} must be YYYY-MM-DD, got {value!r}")
+              datetime.strptime(value, "%Y-%m-%d")
+          for label, value in (("start_hour", self.start_hour), ("end_hour", self.end_hour)):
+              if value is not None and not 0 <= value <= 23:
+                  raise ValueError(f"{label} must be 0-23, got {value}")
+          if (
+              self.start_hour is not None
+              and self.end_hour is not None
+              and self.start_hour > self.end_hour
+          ):
+              raise ValueError("start_hour must be <= end_hour")
+          if self.rfi_mode is not None and self.rfi_mode not in RFI_MODES:
+              raise ValueError(f"rfi_mode must be one of {RFI_MODES}, got {self.rfi_mode!r}")
+          if self.tile_timeout is not None and not 60 <= self.tile_timeout <= 86400:
+              raise ValueError("tile_timeout must be 60-86400 seconds")
+          if self.quarantine_after_failures is not None and not (
+              0 <= self.quarantine_after_failures <= 99
+          ):
+              raise ValueError("quarantine_after_failures must be 0-99")
+          if self.photometry_workers is not None and not 1 <= self.photometry_workers <= 32:
+              raise ValueError("photometry_workers must be 1-32")
+
+      def to_argv(self, config: ControlConfig) -> list[str]:
+          argv = [config.python, "scripts/batch_pipeline.py", "--date", self.date]
+          value_flags = (
+              ("--cal-date", self.cal_date),
+              ("--start-hour", self.start_hour),
+              ("--end-hour", self.end_hour),
+              ("--rfi-mode", self.rfi_mode),
+              ("--tile-timeout", self.tile_timeout),
+              ("--quarantine-after-failures", self.quarantine_after_failures),
+              ("--photometry-workers", self.photometry_workers),
+          )
+          for flag, value in value_flags:
+              if value is not None:
+                  argv.extend([flag, str(value)])
+          switch_flags = (
+              ("--retry-failed", self.retry_failed),
+              ("--force-recal", self.force_recal),
+              ("--skip-photometry", self.skip_photometry),
+              ("--lenient-qa", self.lenient_qa),
+              ("--clear-quarantine", self.clear_quarantine),
+              ("--dry-run", self.dry_run),
+          )
+          argv.extend(flag for flag, enabled in switch_flags if enabled)
+          return argv
+
+      def to_json(self) -> str:
+          return json.dumps({f.name: getattr(self, f.name) for f in fields(self)})
+  ```
+
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_observability_control.py -q` → PASS.
+- [x] **Commit:** `git commit -am "Add validated RunRequest and argv builder for pipeline control"`
+- [x] **Failing test — launch, registry, reaper.** Append to `tests/test_observability_control.py`:
+
+  ```python
+  import time
+
+  from dsa110_continuum.observability.control import (
+      RunConflictError, get_run, launch_run, list_runs, run_dry_run, terminate_run,
+  )
+
+  FAKE_OK = "import sys; print('plan ok', ' '.join(sys.argv[1:])); sys.exit(0)\n"
+  FAKE_SLEEPER = (
+      "import subprocess, sys, time, pathlib\n"
+      "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+      "pathlib.Path(sys.argv[sys.argv.index('--date') + 1] + '.childpid').write_text(str(child.pid))\n"
+      "time.sleep(120)\n"
+  )
+
+
+  def _install_fake_pipeline(tmp_path: Path, body: str) -> None:
+      scripts = tmp_path / "scripts"
+      scripts.mkdir(exist_ok=True)
+      (scripts / "batch_pipeline.py").write_text(body)
+
+
+  class TestLaunchAndReap:
+      def test_launch_registers_run_and_reaper_marks_succeeded(self, tmp_path):
+          _install_fake_pipeline(tmp_path, FAKE_OK)
+          config = _config(tmp_path)
+          record = launch_run(RunRequest(date="2026-01-25"), config)
+          assert record["status"] == "running" and record["pid"] > 0
+          deadline = time.monotonic() + 15
+          while time.monotonic() < deadline:
+              row = get_run(record["run_id"], config)
+              if row["status"] != "running":
+                  break
+              time.sleep(0.2)
+          assert row["status"] == "succeeded" and row["exit_code"] == 0
+          assert "plan ok" in Path(row["log_path"]).read_text()
+
+      def test_single_flight_guard_rejects_concurrent_launch(self, tmp_path):
+          _install_fake_pipeline(tmp_path, FAKE_SLEEPER)
+          config = _config(tmp_path)
+          first = launch_run(RunRequest(date="2026-01-25"), config)
+          try:
+              with pytest.raises(RunConflictError):
+                  launch_run(RunRequest(date="2026-01-26"), config)
+          finally:
+              terminate_run(first["run_id"], config, grace_seconds=2.0)
+
+      def test_terminate_kills_whole_process_group(self, tmp_path):
+          _install_fake_pipeline(tmp_path, FAKE_SLEEPER)
+          config = _config(tmp_path)
+          record = launch_run(RunRequest(date="2026-01-25"), config)
+          childpid_file = tmp_path / "2026-01-25.childpid"
+          deadline = time.monotonic() + 10
+          while time.monotonic() < deadline and not childpid_file.exists():
+              time.sleep(0.1)
+          child_pid = int(childpid_file.read_text())
+          terminate_run(record["run_id"], config, grace_seconds=2.0)
+          row = get_run(record["run_id"], config)
+          assert row["status"] == "terminated"
+          time.sleep(0.5)
+          assert not Path(f"/proc/{record['pid']}").exists()
+          assert not Path(f"/proc/{child_pid}").exists()
+
+      def test_dry_run_returns_plan_text_and_registers_nothing(self, tmp_path):
+          _install_fake_pipeline(tmp_path, FAKE_OK)
+          config = _config(tmp_path)
+          output = run_dry_run(RunRequest(date="2026-01-25", dry_run=True), config)
+          assert "plan ok" in output and "--dry-run" in output
+          assert list_runs(config) == []
+  ```
+
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_observability_control.py -q` → FAIL (functions missing).
+- [x] **Implement launcher/registry/reaper/terminate.** Append to `dsa110_continuum/observability/control.py`:
+
+  ```python
+  _SCHEMA = """
+  CREATE TABLE IF NOT EXISTS runs (
+      run_id TEXT PRIMARY KEY,
+      created_at TEXT NOT NULL,
+      finished_at TEXT,
+      request_json TEXT NOT NULL,
+      argv_json TEXT NOT NULL,
+      pid INTEGER NOT NULL,
+      log_path TEXT NOT NULL,
+      status TEXT NOT NULL,
+      exit_code INTEGER
+  )
+  """
+
+
+  def _connect(db_path: Path) -> sqlite3.Connection:
+      connection = sqlite3.connect(db_path, timeout=10)
+      connection.row_factory = sqlite3.Row
+      connection.execute(_SCHEMA)
+      return connection
+
+
+  def _now() -> str:
+      return datetime.now(timezone.utc).isoformat()
+
+
+  def _pid_alive(pid: int) -> bool:
+      return Path(f"/proc/{pid}").exists()
+
+
+  def _reconcile(row: dict) -> dict:
+      if row["status"] == "running" and not _pid_alive(row["pid"]):
+          row["status"] = "orphaned"
+      return row
+
+
+  def _reap(db_path: Path, run_id: str, process: subprocess.Popen) -> None:
+      exit_code = process.wait()
+      status = "succeeded" if exit_code == 0 else "failed"
+      with _connect(db_path) as connection:
+          connection.execute(
+              "UPDATE runs SET status = ?, exit_code = ?, finished_at = ?"
+              " WHERE run_id = ? AND status = 'running'",
+              (status, exit_code, _now(), run_id),
+          )
+
+
+  def launch_run(request: RunRequest, config: ControlConfig) -> dict:
+      config.control_dir.mkdir(parents=True, exist_ok=True)
+      live = [row for row in list_runs(config) if row["status"] == "running"]
+      if live:
+          raise RunConflictError(f"run {live[0]['run_id']} is still running")
+      run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ") + "-" + uuid.uuid4().hex[:6]
+      log_path = config.control_dir / f"run_{run_id}.log"
+      argv = request.to_argv(config)
+      environment = {**os.environ, "PYTHONPATH": str(config.repo_root)}
+      with log_path.open("wb") as stream:
+          process = subprocess.Popen(
+              argv,
+              cwd=config.repo_root,
+              stdout=stream,
+              stderr=subprocess.STDOUT,
+              start_new_session=True,
+              env=environment,
+          )
+      record = {
+          "run_id": run_id,
+          "created_at": _now(),
+          "finished_at": None,
+          "request_json": request.to_json(),
+          "argv_json": json.dumps(argv),
+          "pid": process.pid,
+          "log_path": str(log_path),
+          "status": "running",
+          "exit_code": None,
+      }
+      with _connect(config.db_path) as connection:
+          connection.execute(
+              "INSERT INTO runs VALUES (:run_id, :created_at, :finished_at, :request_json,"
+              " :argv_json, :pid, :log_path, :status, :exit_code)",
+              record,
+          )
+      threading.Thread(
+          target=_reap, args=(config.db_path, run_id, process), daemon=True
+      ).start()
+      return record
+
+
+  def run_dry_run(request: RunRequest, config: ControlConfig, timeout: int = 120) -> str:
+      if not request.dry_run:
+          request = RunRequest(**{**json.loads(request.to_json()), "dry_run": True})
+      result = subprocess.run(
+          request.to_argv(config),
+          cwd=config.repo_root,
+          capture_output=True,
+          text=True,
+          timeout=timeout,
+          env={**os.environ, "PYTHONPATH": str(config.repo_root)},
+      )
+      return result.stdout + result.stderr
+
+
+  def list_runs(config: ControlConfig, limit: int = 50) -> list[dict]:
+      if not config.db_path.is_file():
+          return []
+      with _connect(config.db_path) as connection:
+          rows = connection.execute(
+              "SELECT * FROM runs ORDER BY created_at DESC LIMIT ?", (limit,)
+          ).fetchall()
+      return [_reconcile(dict(row)) for row in rows]
+
+
+  def get_run(run_id: str, config: ControlConfig) -> dict:
+      with _connect(config.db_path) as connection:
+          row = connection.execute(
+              "SELECT * FROM runs WHERE run_id = ?", (run_id,)
+          ).fetchone()
+      if row is None:
+          raise KeyError(run_id)
+      return _reconcile(dict(row))
+
+
+  def terminate_run(run_id: str, config: ControlConfig, grace_seconds: float = 10.0) -> dict:
+      row = get_run(run_id, config)
+      if row["status"] != "running":
+          raise RunConflictError(f"run {run_id} is not running (status={row['status']})")
+      pgid = row["pid"]
+      os.killpg(pgid, signal.SIGTERM)
+      deadline = time.monotonic() + grace_seconds
+      while time.monotonic() < deadline and _pid_alive(pgid):
+          time.sleep(0.25)
+      if _pid_alive(pgid):
+          os.killpg(pgid, signal.SIGKILL)
+      with _connect(config.db_path) as connection:
+          connection.execute(
+              "UPDATE runs SET status = 'terminated', finished_at = ? WHERE run_id = ?",
+              (_now(), run_id),
+          )
+      return get_run(run_id, config)
+  ```
+
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_observability_control.py -q` → PASS (all classes).
+- [x] `ruff check dsa110_continuum/observability/control.py tests/test_observability_control.py` → clean.
+- [x] **Commit:** `git commit -am "Add pipeline run launcher, registry, reaper, and group terminate"`
+
+**Dependencies:** Phase 0.
+
+**Verification:**
+- [x] `$PY -m pytest tests/test_observability_control.py -q` → all pass, < 60 s.
+- [x] `$PY -c "from dsa110_continuum.observability.control import launch_run"` → no import error, no Dagster import triggered (`$PY -c "import sys; import dsa110_continuum.observability.control; assert 'dagster' not in sys.modules"`).
+
+### Phase 2: Auth + `/api/runs` router + audit log in qa_server
+
+**Objective:** the control module becomes an authenticated HTTP surface on the existing
+dashboard app; every mutating request is audited; token absent ⇒ fail closed.
+
+**Tasks:**
+- [x] **Failing test — auth posture.** Append to `tests/test_qa_server.py`:
+
+  ```python
+  class TestControlAuth:
+      """Mutating control routes must fail closed: no token env => 403 always;
+      wrong/missing header => 403; correct bearer => accepted."""
+
+      def _client(self, tmp_path, monkeypatch, token_env):
+          if token_env is None:
+              monkeypatch.delenv("DSA110_CONTROL_TOKEN", raising=False)
+          else:
+              monkeypatch.setenv("DSA110_CONTROL_TOKEN", token_env)
+          monkeypatch.setenv("DSA110_CONTROL_DIR", str(tmp_path / "control"))
+          monkeypatch.setenv("DSA110_REPO_ROOT", str(tmp_path))
+          import sys as _sys
+          monkeypatch.setenv("DSA110_PIPELINE_PYTHON", _sys.executable)
+          scripts = tmp_path / "scripts"
+          scripts.mkdir(exist_ok=True)
+          (scripts / "batch_pipeline.py").write_text("print('plan ok')\n")
+          return TestClient(create_app(_make_config(tmp_path)))
+
+      def test_launch_without_token_env_is_403_even_with_header(self, tmp_path, monkeypatch):
+          with self._client(tmp_path, monkeypatch, token_env=None) as client:
+              response = client.post(
+                  "/api/runs",
+                  json={"date": "2026-01-25", "dry_run": True},
+                  headers={"Authorization": "Bearer anything"},
+              )
+          assert response.status_code == 403
+
+      def test_wrong_token_is_403_and_not_audited_as_launch(self, tmp_path, monkeypatch):
+          with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+              response = client.post(
+                  "/api/runs",
+                  json={"date": "2026-01-25", "dry_run": True},
+                  headers={"Authorization": "Bearer wrong"},
+              )
+          assert response.status_code == 403
+
+      def test_dry_run_with_token_returns_plan_and_audits(self, tmp_path, monkeypatch):
+          with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+              response = client.post(
+                  "/api/runs",
+                  json={"date": "2026-01-25", "dry_run": True},
+                  headers={"Authorization": "Bearer s3cret"},
+              )
+          assert response.status_code == 200
+          assert "plan ok" in response.json()["plan"]
+          audit = (tmp_path / "control" / "audit.jsonl").read_text()
+          assert '"dry_run": true' in audit and "s3cret" not in audit
+
+      def test_injection_shaped_date_is_422(self, tmp_path, monkeypatch):
+          with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+              response = client.post(
+                  "/api/runs",
+                  json={"date": "2026-01-25; rm -rf /", "dry_run": True},
+                  headers={"Authorization": "Bearer s3cret"},
+              )
+          assert response.status_code in (400, 422)
+
+      def test_run_listing_is_readable_without_token(self, tmp_path, monkeypatch):
+          with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+              response = client.get("/api/runs")
+          assert response.status_code == 200
+          assert response.json() == {"runs": []}
+  ```
+
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_qa_server.py::TestControlAuth -q` → FAIL (404 route).
+- [x] **Implement router.** Edit `scripts/qa_server.py`. Add imports near the top (after line 24):
+
+  ```python
+  import secrets
+
+  from pydantic import BaseModel
+
+  from dsa110_continuum.observability import control as pipeline_control
+  ```
+
+  Add after `ops_router` definition (`scripts/qa_server.py:527`):
+
+  ```python
+  control_router = APIRouter(prefix="/api/runs", tags=["pipeline control"])
+  CONTROL_TOKEN_ENV = "DSA110_CONTROL_TOKEN"
+
+
+  class RunRequestBody(BaseModel):
+      date: str
+      cal_date: str | None = None
+      start_hour: int | None = None
+      end_hour: int | None = None
+      rfi_mode: str | None = None
+      tile_timeout: int | None = None
+      quarantine_after_failures: int | None = None
+      photometry_workers: int | None = None
+      retry_failed: bool = False
+      force_recal: bool = False
+      skip_photometry: bool = False
+      lenient_qa: bool = False
+      clear_quarantine: bool = False
+      dry_run: bool = False
+
+
+  def _require_control_token(request: Request) -> None:
+      expected = os.environ.get(CONTROL_TOKEN_ENV, "")
+      provided = request.headers.get("authorization", "").removeprefix("Bearer ").strip()
+      if not expected or not secrets.compare_digest(provided, expected):
+          raise HTTPException(status_code=403, detail="control token missing or invalid")
+
+
+  def _audit(config: pipeline_control.ControlConfig, action: str, request: Request, payload: dict) -> None:
+      config.control_dir.mkdir(parents=True, exist_ok=True)
+      entry = {
+          "time": datetime.now(timezone.utc).isoformat(),
+          "action": action,
+          "remote": request.client.host if request.client else None,
+          "payload": payload,
+      }
+      with (config.control_dir / "audit.jsonl").open("a") as stream:
+          stream.write(json.dumps(entry) + "\n")
+
+
+  @control_router.get("")
+  def control_list_runs():
+      return {"runs": pipeline_control.list_runs(pipeline_control.ControlConfig())}
+
+
+  @control_router.get("/{run_id}")
+  def control_get_run(run_id: str, tail: int = 40):
+      config = pipeline_control.ControlConfig()
+      try:
+          record = pipeline_control.get_run(run_id, config)
+      except KeyError:
+          raise HTTPException(status_code=404, detail="unknown run") from None
+      record["log_tail"] = _tail(Path(record["log_path"]), tail)
+      return record
+
+
+  @control_router.post("")
+  def control_launch(body: RunRequestBody, request: Request):
+      _require_control_token(request)
+      config = pipeline_control.ControlConfig()
+      try:
+          run_request = pipeline_control.RunRequest(**body.model_dump())
+      except ValueError as exc:
+          raise HTTPException(status_code=400, detail=str(exc)) from None
+      _audit(config, "dry_run" if body.dry_run else "launch", request, body.model_dump())
+      if body.dry_run:
+          try:
+              plan = pipeline_control.run_dry_run(run_request, config)
+          except subprocess.TimeoutExpired:
+              raise HTTPException(status_code=504, detail="dry-run timed out") from None
+          return {"plan": plan}
+      try:
+          return pipeline_control.launch_run(run_request, config)
+      except pipeline_control.RunConflictError as exc:
+          raise HTTPException(status_code=409, detail=str(exc)) from None
+
+
+  @control_router.post("/{run_id}/terminate")
+  def control_terminate(run_id: str, request: Request):
+      _require_control_token(request)
+      config = pipeline_control.ControlConfig()
+      _audit(config, "terminate", request, {"run_id": run_id})
+      try:
+          return pipeline_control.terminate_run(run_id, config)
+      except KeyError:
+          raise HTTPException(status_code=404, detail="unknown run") from None
+      except pipeline_control.RunConflictError as exc:
+          raise HTTPException(status_code=409, detail=str(exc)) from None
+  ```
+
+  Add `import json` to the stdlib import block (it is not imported today), and register the
+  router in `create_app` after `application.include_router(ops_router)`
+  (`scripts/qa_server.py:576`):
+
+  ```python
+      application.include_router(control_router)
+  ```
+
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_qa_server.py::TestControlAuth -q` → PASS.
+- [x] Regression: `$PY -m pytest tests/test_qa_server.py -q` → all pass (existing suites unaffected).
+- [x] `ruff check scripts/qa_server.py` → clean for new code.
+- [x] **Commit:** `git commit -am "Add auth-gated pipeline control API with audit log"`
+
+**Dependencies:** Phase 1.
+
+**Verification:**
+- [x] `$PY -m pytest tests/test_qa_server.py tests/test_observability_control.py -q` → pass.
+- [ ] Manual smoke on H17 (token set): `curl -s -X POST -H "Authorization: Bearer $DSA110_CONTROL_TOKEN" -H 'Content-Type: application/json' -d '{"date":"2026-01-25","start_hour":22,"end_hour":23,"dry_run":true}' http://127.0.0.1:8767/api/runs | head` → JSON with the real dry-run plan text.
+
+### Phase 3: Dashboard UI — control panel, run pages, epoch auto-discovery
+
+**Objective:** the operator can see and drive runs from the browser, and the historical QA
+table stops being hardcoded to six epochs.
+
+**Tasks:**
+- [x] **Failing test — auto-discovery.** Append to `tests/test_qa_server.py`:
+
+  ```python
+  class TestEpochDiscovery:
+      def test_discovers_epochs_from_stage_newest_first(self, tmp_path):
+          config = _make_config(tmp_path)
+          old = _write_mosaic(config, "2026-01-25", "T0200", np.ones((4, 4), np.float32))
+          new = _write_mosaic(config, "2026-07-13", "T1100", np.ones((4, 4), np.float32))
+          os.utime(old, (1, 1))
+          discovered = qa_server.discover_epochs(config)
+          assert discovered[0] == ("2026-07-13", "T1100")
+          assert ("2026-01-25", "T0200") in discovered
+
+      def test_falls_back_to_static_epochs_when_stage_empty(self, tmp_path):
+          assert qa_server.discover_epochs(_make_config(tmp_path)) == qa_server.EPOCHS
+
+      def test_ignores_malformed_names(self, tmp_path):
+          config = _make_config(tmp_path)
+          directory = config.stage / "images" / "mosaic_2026-01-25"
+          directory.mkdir(parents=True)
+          (directory / "junk_mosaic.fits").write_bytes(b"x")
+          assert qa_server.discover_epochs(config) == qa_server.EPOCHS
+  ```
+
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_qa_server.py::TestEpochDiscovery -q` → FAIL.
+- [x] **Implement discovery.** Add to `scripts/qa_server.py` after `find_csv` (`:88`):
+
+  ```python
+  MOSAIC_NAME_RE = re.compile(r"(\d{4}-\d{2}-\d{2})(T\d{4})_mosaic\.fits")
+
+
+  def discover_epochs(config: DashboardConfig, limit: int = 24) -> list[tuple[str, str]]:
+      """List (date, epoch) for every hourly-epoch mosaic on stage, newest first."""
+      root = config.stage / "images"
+      found = []
+      if root.is_dir():
+          for path in root.glob("mosaic_*/*_mosaic.fits"):
+              match = MOSAIC_NAME_RE.fullmatch(path.name)
+              if match:
+                  found.append((path.stat().st_mtime, match.group(1), match.group(2)))
+      found.sort(reverse=True)
+      discovered = [(date, epoch) for _, date, epoch in found[:limit]]
+      return discovered or EPOCHS
+  ```
+
+  In `render_dashboard` replace `for date, epoch in EPOCHS` (`:409`) with
+  `for date, epoch in discover_epochs(config)` and the `len(EPOCHS)` total (`:521`) with the
+  discovered count.
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_qa_server.py::TestEpochDiscovery -q` → PASS.
+- [x] **Failing test — control panel + run page rendering.** Append to `tests/test_qa_server.py`:
+
+  ```python
+  class TestControlUi:
+      def test_dashboard_shows_pipeline_control_panel(self, tmp_path):
+          with TestClient(create_app(_make_config(tmp_path))) as client:
+              page = client.get("/").text
+          assert "Pipeline control" in page
+          assert 'id="run-form"' in page and "/api/runs" in page
+
+      def test_run_detail_page_renders_log_tail(self, tmp_path, monkeypatch):
+          monkeypatch.setenv("DSA110_CONTROL_DIR", str(tmp_path / "control"))
+          import sys as _sys
+          monkeypatch.setenv("DSA110_PIPELINE_PYTHON", _sys.executable)
+          monkeypatch.setenv("DSA110_REPO_ROOT", str(tmp_path))
+          (tmp_path / "scripts").mkdir()
+          (tmp_path / "scripts" / "batch_pipeline.py").write_text("print('hello from run')\n")
+          from dsa110_continuum.observability.control import ControlConfig, RunRequest, launch_run
+          record = launch_run(RunRequest(date="2026-01-25"), ControlConfig(
+              repo_root=tmp_path, python=_sys.executable, control_dir=tmp_path / "control"))
+          import time as _time
+          _time.sleep(1.0)
+          with TestClient(create_app(_make_config(tmp_path))) as client:
+              page = client.get(f"/control/runs/{record['run_id']}")
+          assert page.status_code == 200
+          assert "hello from run" in page.text
+  ```
+
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_qa_server.py::TestControlUi -q` → FAIL.
+- [x] **Implement UI.** In `scripts/qa_server.py`:
+  1. Add a `control_page_router = APIRouter(include_in_schema=False)` with
+     `GET /control/runs/{run_id}` returning an HTML page: run metadata table (status badge via
+     `_badge`, argv, created/finished, exit code) + `<pre>` log tail via
+     `_tail(Path(record["log_path"]), 200)`, HTML-escaped, with the same 30 s reload script.
+     Register it in `create_app`.
+  2. In `render_dashboard`, insert a `Pipeline control` section between the campaign section
+     and `Historical hourly-epoch QA` containing:
+     - a runs table from `pipeline_control.list_runs(pipeline_control.ControlConfig(), limit=10)`
+       (run id linked to `/control/runs/{run_id}`, status badge, created_at, exit code, and a
+       Terminate button for `running` rows);
+     - a `<form id="run-form">` with inputs: date (required, `pattern="\d{4}-\d{2}-\d{2}"`),
+       cal-date, start/end hour (`type=number min=0 max=23`), selects for rfi-mode
+       (blank/full/conditional/off), checkboxes (force-recal, retry-failed, skip-photometry,
+       lenient-qa, clear-quarantine), a password-type token field, and two buttons:
+       **Dry-run preview** and **Launch**;
+     - an empty `<pre id="run-output"></pre>`;
+     - an inline `<script>` that serializes the form to the `/api/runs` JSON body, sends
+       `fetch("/api/runs", {method:"POST", headers:{"Content-Type":"application/json",
+       "Authorization":"Bearer "+token}, body})` with `dry_run` true/false per button,
+       writes the response (plan text or run record or error detail) into `#run-output`,
+       and wires each Terminate button to `POST /api/runs/{id}/terminate` with the same
+       token header. Suspend the 30 s auto-reload while the token field is non-empty
+       (`if(!document.getElementById("control-token").value) location.reload()`), so form
+       state is not lost mid-entry.
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_qa_server.py::TestControlUi -q` → PASS.
+- [x] Full-file regression + lint: `$PY -m pytest tests/test_qa_server.py -q && ruff check scripts/qa_server.py` → pass/clean.
+- [x] **Commit:** `git commit -am "Add pipeline control panel, run pages, and epoch auto-discovery"`
+
+**Dependencies:** Phase 2.
+
+**Verification:**
+- [x] `$PY -m pytest tests/test_qa_server.py -q` → pass.
+- [ ] Manual: open `http://lxd110h17:8767/`, confirm discovered epochs (2026-07-13T1100 present), control panel renders, dry-run preview round-trips.
+
+### Phase 4: Run provenance page `/runs/{date}` (#60 minimal)
+
+**Objective:** surface manifest verdict, gates, epochs, and the run report for any date —
+the "why did QA fail" page.
+
+**Tasks:**
+- [x] **Failing test.** Append to `tests/test_qa_server.py`:
+
+  ```python
+  class TestRunProvenancePage:
+      def _write_manifest(self, config, date="2026-01-25"):
+          directory = config.products / date
+          directory.mkdir(parents=True, exist_ok=True)
+          manifest = {
+              "date": date, "cal_date": date, "git_sha": "abc1234",
+              "command_line": "batch_pipeline.py --date " + date,
+              "pipeline_verdict": "DEGRADED",
+              "gates": [{"gate": "epoch_qa:22", "verdict": "FAIL",
+                         "reason": "catalog completeness 0.42 < 0.5"}],
+              "epochs": [{"hour": 22, "n_tiles": 11, "status": "ok", "qa_result": "FAIL",
+                          "peak": 12.5, "rms": 0.008, "mosaic_path": "/x.fits",
+                          "gaincal_status": "ok", "n_sources": 40, "median_ratio": 0.9,
+                          "weight_path": "/x.w.fits"}],
+              "tiles": [], "run_log": "run_x.log",
+          }
+          (directory / f"{date}_manifest.json").write_text(json.dumps(manifest))
+          (directory / "run_report.md").write_text("# Run report\nverdict DEGRADED\n")
+
+      def test_renders_verdict_gates_and_epochs(self, tmp_path):
+          config = _make_config(tmp_path)
+          self._write_manifest(config)
+          with TestClient(create_app(config)) as client:
+              page = client.get("/runs/2026-01-25")
+          assert page.status_code == 200
+          assert "DEGRADED" in page.text
+          assert "catalog completeness" in page.text
+          assert "T2200" in page.text or ">22<" in page.text
+
+      def test_missing_manifest_is_404_and_traversal_rejected(self, tmp_path):
+          with TestClient(create_app(_make_config(tmp_path))) as client:
+              assert client.get("/runs/2026-01-26").status_code == 404
+              assert 400 <= client.get("/runs/..%2f..%2fetc").status_code < 500
+  ```
+
+  (add `import json` to the test-file imports if not already present)
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_qa_server.py::TestRunProvenancePage -q` → FAIL.
+- [x] **Implement.** In `scripts/qa_server.py` add `GET /runs/{date}` to a `runs_page_router`
+  (registered in `create_app`): `_validate_date_epoch(date)`; load
+  `config.products / date / f"{date}_manifest.json"` (404 if absent); render an HTML page with
+  the same stylesheet: header (verdict badge — `pass`-green for CLEAN, `fail`-red otherwise —
+  date, cal_date, git_sha, command line), a gates table (`gate/verdict/reason`), an epochs
+  table (hour, n_tiles, status, qa_result badge, peak, rms, n_sources, median_ratio, link to
+  `/artifacts/mosaic/{date}/T{hour:02d}00/status`), and the run report `run_report.md`
+  rendered inside `<pre>` (HTML-escaped). Missing keys render as `—` via `_format_number` /
+  `dict.get` — the page must never 500 on a partial manifest (guard every field access).
+  Link each dashboard historical-table row's date cell to `/runs/{date}`.
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_qa_server.py::TestRunProvenancePage -q` → PASS.
+- [x] **Commit:** `git commit -am "Add per-date run provenance page with gates and verdicts"`
+
+**Dependencies:** Phase 3 (stylesheet/section helpers), but functionally independent of control.
+
+**Verification:**
+- [ ] Manual on H17: `http://lxd110h17:8767/runs/2026-07-13` shows the real DEGRADED manifest
+      (gates + hour-11 epoch row) — the validated 2026-01-25 hour-22 case in CLAUDE.md also renders.
+
+### Phase 5: Positional light-curve view (#59 minimal)
+
+**Objective:** the primary science surface — a light curve for any sky position across all
+epochs with per-point provenance and η/V variability metrics.
+
+**Tasks:**
+- [x] **Failing test.** Append to `tests/test_qa_server.py`:
+
+  ```python
+  class TestLightcurveView:
+      HEADER = "ra_deg,dec_deg,nvss_flux_jy,dsa_peak_jyb,dsa_peak_err_jyb,dsa_nvss_ratio\n"
+
+      def _write_epoch_csv(self, config, date, epoch, flux):
+          directory = config.products / date
+          directory.mkdir(parents=True, exist_ok=True)
+          (directory / f"{date}{epoch}_forced_phot.csv").write_text(
+              self.HEADER + f"47.499,17.099833,4.87,{flux},0.02,0.95\n"
+              + f"120.0,-5.0,1.0,1.1,0.05,1.1\n"
+          )
+
+      def test_matches_position_across_epochs_and_computes_metrics(self, tmp_path):
+          config = _make_config(tmp_path)
+          self._write_epoch_csv(config, "2026-01-25", "T0200", 3.9)
+          self._write_epoch_csv(config, "2026-02-12", "T0000", 4.1)
+          points = qa_server.lightcurve_points(config, ra_deg=47.499, dec_deg=17.0998,
+                                               radius_arcsec=30.0)
+          assert len(points) == 2
+          assert {point["epoch"] for point in points} == {"2026-01-25T0200", "2026-02-12T0000"}
+          assert all(abs(point["flux_jy"] - 4.0) < 0.2 for point in points)
+
+      def test_no_match_outside_radius(self, tmp_path):
+          config = _make_config(tmp_path)
+          self._write_epoch_csv(config, "2026-01-25", "T0200", 3.9)
+          assert qa_server.lightcurve_points(config, 47.499, 18.5, 30.0) == []
+
+      def test_lightcurve_page_and_png(self, tmp_path):
+          config = _make_config(tmp_path)
+          self._write_epoch_csv(config, "2026-01-25", "T0200", 3.9)
+          self._write_epoch_csv(config, "2026-02-12", "T0000", 4.1)
+          with TestClient(create_app(config)) as client:
+              page = client.get("/sources/lightcurve?ra=47.499&dec=17.0998")
+              png = client.get("/sources/lightcurve.png?ra=47.499&dec=17.0998")
+          assert page.status_code == 200 and "2026-01-25" in page.text
+          assert "η" in page.text or "eta" in page.text.lower()
+          assert png.status_code == 200 and png.content.startswith(b"\x89PNG")
+
+      def test_bad_coords_rejected(self, tmp_path):
+          with TestClient(create_app(_make_config(tmp_path))) as client:
+              assert 400 <= client.get("/sources/lightcurve?ra=999&dec=0").status_code < 500
+  ```
+
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_qa_server.py::TestLightcurveView -q` → FAIL.
+- [x] **Implement.** In `scripts/qa_server.py`:
+
+  ```python
+  PHOT_NAME_RE = re.compile(r"(\d{4}-\d{2}-\d{2})(T\d{4})_forced_phot\.csv")
+
+
+  def lightcurve_points(
+      config: DashboardConfig, ra_deg: float, dec_deg: float, radius_arcsec: float = 30.0
+  ) -> list[dict]:
+      """Nearest forced-photometry match per epoch within the match radius."""
+      points = []
+      if not config.products.is_dir():
+          return points
+      radius_deg = radius_arcsec / 3600.0
+      cos_dec = max(np.cos(np.radians(dec_deg)), 1e-6)
+      for csv_path in sorted(config.products.glob("*/*_forced_phot.csv")):
+          match = PHOT_NAME_RE.fullmatch(csv_path.name)
+          if not match:
+              continue
+          try:
+              frame = pd.read_csv(csv_path)
+          except Exception as exc:
+              logger.warning("Lightcurve CSV error %s: %s", csv_path, exc)
+              continue
+          if not {"ra_deg", "dec_deg", "dsa_peak_jyb"}.issubset(frame.columns):
+              continue
+          separation = np.hypot(
+              (frame["ra_deg"] - ra_deg) * cos_dec, frame["dec_deg"] - dec_deg
+          )
+          index = separation.idxmin() if len(separation) else None
+          if index is None or separation[index] > radius_deg:
+              continue
+          row = frame.loc[index]
+          points.append(
+              {
+                  "epoch": match.group(1) + match.group(2),
+                  "date": match.group(1),
+                  "epoch_token": match.group(2),
+                  "flux_jy": float(row["dsa_peak_jyb"]),
+                  "flux_err_jy": float(row.get("dsa_peak_err_jyb", np.nan)),
+                  "separation_arcsec": float(separation[index] * 3600.0),
+                  "csv": str(csv_path),
+              }
+          )
+      points.sort(key=lambda point: point["epoch"])
+      return points
+  ```
+
+  Routes on a `sources_router = APIRouter(prefix="/sources", tags=["science sources"])`:
+  - `GET /sources/lightcurve?ra=&dec=&radius_arcsec=30` — validate `0 <= ra < 360`,
+    `-90 <= dec <= 90`, `1 <= radius_arcsec <= 300` (else 400); render HTML: points table
+    (epoch linked to `/artifacts/mosaic/{date}/{epoch_token}/status` — per-point click-through
+    to the contributing mosaic), `<img>` of the PNG route, and a metrics block computing
+    η and V from the points via
+    `from dsa110_continuum.photometry.metrics import calculate_eta_metric, calculate_v_metric`
+    (function-scope import; guard `len(points) >= 2`, else show "insufficient epochs").
+  - `GET /sources/lightcurve.png?...` — matplotlib errorbar plot of flux vs epoch label
+    (Agg, same dark style as `make_thumbnail`), 404 when no points.
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_qa_server.py::TestLightcurveView -q` → PASS.
+- [x] Add a dashboard entry point: a small "Light curve lookup" form (ra/dec inputs, GET) in
+  the dashboard HTML linking to `/sources/lightcurve`. Assert in the existing
+  `test_dashboard_shows_pipeline_control_panel`-style test:
+  `assert "/sources/lightcurve" in page`.
+- [x] Full regression + lint; **Commit:** `git commit -am "Add positional light-curve science view with variability metrics"`
+
+**Dependencies:** Phase 3 (HTML helpers); independent of control routes.
+
+**Verification:**
+- [ ] Manual on H17: `http://lxd110h17:8767/sources/lightcurve?ra=47.499&dec=17.0998` shows the
+      3C48-field source across the 2026-01/02 epochs with sensible fluxes and η/V values.
+
+### Phase 6: Automation trigger + service hardening
+
+**Objective:** the pipeline runs unattended through the same launcher path; both services are
+supervised; operational posture documented.
+
+**Tasks:**
+- [x] **Failing test — auto-launch decision logic.** File: `tests/test_auto_pipeline.py` (new)
+
+  ```python
+  import sys
+  from pathlib import Path
+
+  from dsa110_continuum.observability.control import ControlConfig
+  from scripts.auto_pipeline import decide_and_launch
+
+
+  def _config(tmp_path: Path) -> ControlConfig:
+      scripts = tmp_path / "scripts"
+      scripts.mkdir()
+      (scripts / "batch_pipeline.py").write_text("print('auto ok')\n")
+      return ControlConfig(repo_root=tmp_path, python=sys.executable,
+                           control_dir=tmp_path / "control")
+
+
+  def test_launches_for_given_date_and_reports_run_id(self, tmp_path=None):
+      pass  # replaced below — pytest functions take tmp_path fixture directly
+
+
+  def test_launch_and_conflict(tmp_path):
+      config = _config(tmp_path)
+      outcome = decide_and_launch(date="2026-01-25", config=config)
+      assert outcome["action"] == "launched" and outcome["run_id"]
+      import time
+      time.sleep(1.0)
+      second = decide_and_launch(date="2026-01-25", config=config)
+      assert second["action"] in ("launched", "skipped_running")
+  ```
+
+- [x] **Run it, watch it fail:** `$PY -m pytest tests/test_auto_pipeline.py -q` → FAIL.
+- [x] **Implement.** File: `scripts/auto_pipeline.py` (new)
+
+  ```python
+  """Scheduled entrypoint: launch today's batch pipeline via the control registry."""
+
+  from __future__ import annotations
+
+  import argparse
+  import json
+  import sys
+  from datetime import datetime, timedelta, timezone
+  from pathlib import Path
+
+  sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+  from dsa110_continuum.observability.control import (
+      ControlConfig, RunConflictError, RunRequest, launch_run,
+  )
+
+
+  def decide_and_launch(date: str, config: ControlConfig | None = None) -> dict:
+      config = config or ControlConfig()
+      request = RunRequest(
+          date=date, retry_failed=True, quarantine_after_failures=3, photometry_workers=4
+      )
+      try:
+          record = launch_run(request, config)
+      except RunConflictError as exc:
+          return {"action": "skipped_running", "detail": str(exc)}
+      return {"action": "launched", "run_id": record["run_id"], "pid": record["pid"]}
+
+
+  def main() -> int:
+      parser = argparse.ArgumentParser(description=__doc__)
+      parser.add_argument(
+          "--date",
+          default=(datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d"),
+          help="Observation date to process (default: yesterday UTC).",
+      )
+      arguments = parser.parse_args()
+      outcome = decide_and_launch(arguments.date)
+      print(json.dumps(outcome))
+      return 0
+
+
+  if __name__ == "__main__":
+      raise SystemExit(main())
+  ```
+
+- [x] **Run it, watch it pass:** `$PY -m pytest tests/test_auto_pipeline.py -q` → PASS.
+- [x] **Ship service units.** Files: `ops/systemd/dsa110-dashboard.service`,
+  `ops/systemd/dsa110-autopipeline.service`, `ops/systemd/dsa110-autopipeline.timer` (new):
+
+  ```ini
+  # ops/systemd/dsa110-dashboard.service
+  [Unit]
+  Description=DSA-110 continuum QA dashboard (qa_server, port 8767)
+  After=network.target
+
+  [Service]
+  User=ubuntu
+  WorkingDirectory=/data/dsa110-continuum
+  Environment=PYTHONPATH=/data/dsa110-continuum
+  EnvironmentFile=-/data/dsa110-proc/products/control/dashboard.env
+  ExecStart=/opt/miniforge/envs/casa6/bin/python -m uvicorn scripts.qa_server:app --host 0.0.0.0 --port 8767 --log-level warning
+  Restart=on-failure
+  RestartSec=10
+
+  [Install]
+  WantedBy=multi-user.target
+  ```
+
+  ```ini
+  # ops/systemd/dsa110-autopipeline.service
+  [Unit]
+  Description=DSA-110 continuum daily batch pipeline launcher
+
+  [Service]
+  Type=oneshot
+  User=ubuntu
+  WorkingDirectory=/data/dsa110-continuum
+  Environment=PYTHONPATH=/data/dsa110-continuum
+  ExecStart=/opt/miniforge/envs/casa6/bin/python scripts/auto_pipeline.py
+  ```
+
+  ```ini
+  # ops/systemd/dsa110-autopipeline.timer
+  [Unit]
+  Description=Launch the DSA-110 batch pipeline daily at 02:00 UTC
+
+  [Timer]
+  OnCalendar=*-*-* 02:00:00 UTC
+  Persistent=true
+
+  [Install]
+  WantedBy=timers.target
+  ```
+
+  `dashboard.env` holds `DSA110_CONTROL_TOKEN=…` (mode 600, owned by ubuntu; NOT committed).
+- [x] **Document.** File: `docs/operations/dashboard.md` (new): token generation
+  (`python -c "import secrets; print(secrets.token_urlsafe(32))"`), env file creation, unit
+  install (`sudo cp ops/systemd/*.{service,timer} /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now dsa110-dashboard dsa110-autopipeline.timer`),
+  Cloudflare posture (tunnel stays read-only-safe because mutating routes are token-gated;
+  enabling Cloudflare Access is the documented hardening step), audit-log location, and the
+  manual-intervention runbook (dry-run → launch → watch → terminate). Update the CLAUDE.md
+  FastAPI section sentence for `scripts/qa_server.py` to mention the token-gated control API,
+  and add `scripts/auto_pipeline.py` to the CLAUDE.md command table.
+- [x] Full gate: `make test-cloud PYTHON=$PY && $PY -m pytest tests/test_qa_server.py tests/test_observability_control.py tests/test_auto_pipeline.py -q && ruff check scripts/ dsa110_continuum/observability/ tests/` → all green.
+- [x] **Commit:** `git commit -am "Add scheduled pipeline launcher, systemd units, and operations docs"`
+- [ ] Open a PR from `dashboard-production` to `main` referencing #51, #53 (partial), #59
+  (minimal), #60 (minimal), and the #49 decision; request user review. Installing/enabling the
+  systemd units on H17 is a user-approved step performed after merge (sudo, shared state).
+
+**Dependencies:** Phases 1–5.
+
+**Verification:**
+- [ ] `systemd-analyze verify ops/systemd/dsa110-dashboard.service` (on H17) → no errors.
+- [ ] After user installs units: `systemctl status dsa110-dashboard` active;
+      `systemctl list-timers dsa110-autopipeline*` shows next trigger;
+      one timer-driven run appears in `/api/runs` the next morning.
+
+## Success Criteria
+
+### Automated Verification
+
+- [x] `make test-cloud PYTHON=/opt/miniforge/envs/casa6/bin/python` → exit 0.
+- [x] `$PY -m pytest tests/test_qa_server.py tests/test_observability_control.py tests/test_auto_pipeline.py tests/test_observability_hour_state.py tests/test_observability_mosaic_preview.py -q` → all pass.
+- [x] `ruff check scripts/qa_server.py scripts/auto_pipeline.py dsa110_continuum/observability/` → clean.
+- [x] `$PY -c "import sys, dsa110_continuum.observability.control; assert 'dagster' not in sys.modules"` → exit 0.
+- [x] Files exist: `dsa110_continuum/observability/control.py`, `scripts/auto_pipeline.py`, `ops/systemd/dsa110-autopipeline.timer`, `docs/operations/dashboard.md`.
+- [x] `$PY -m pytest tests/test_mosaic_import_no_dagster.py -q` → still green (no new Dagster coupling).
+
+### Manual Verification
+
+- [ ] Browser at `http://lxd110h17:8767/`: discovered epochs include 2026-07-13T1100; control
+      panel renders; `/runs/2026-07-13` shows the real DEGRADED verdict with its gate reason.
+- [ ] Full intervention loop on a scratch date: dry-run preview shows the real plan; Launch
+      starts a run visible in `ps` and the runs table; log tail updates; Terminate kills
+      `batch_pipeline.py` AND its WSClean/CASA children (verify `pgrep -g <pid>` empty).
+- [ ] With `DSA110_CONTROL_TOKEN` unset in the service env, the Launch button yields 403 —
+      control is provably disabled by default.
+- [ ] Light-curve page for the 3C48-field position returns plausible fluxes and metrics.
+- [ ] Audit log `/data/dsa110-proc/products/control/audit.jsonl` records every launch/terminate
+      with timestamp and remote address, never the token.
+
+### Reproducibility & Correctness
+
+- [x] Light-curve η/V computed by `photometry/metrics.py` canonical formulas (already
+      test-covered in `tests/test_metrics_canonical.py`); the view itself is checked against
+      hand-written two-epoch CSVs with known fluxes (Phase 5 tests).
+- [x] Run registry rows carry the full argv + request JSON — any launched run is reproducible
+      from its registry row alone.
+
+## Testing Strategy
+
+**Unit (in-phase, test-first):** RunRequest validation/argv (injection-shaped inputs),
+launch/reap/terminate/single-flight against a fake `batch_pipeline.py`, auth fail-closed
+matrix, epoch discovery, provenance page on synthetic manifests (incl. partial manifests),
+light-curve matching on synthetic CSVs, auto-launch decision.
+
+**Integration:** Phase 2/6 manual smoke on H17 with the real `batch_pipeline.py --dry-run`
+(read-only, safe); full intervention loop on a scratch date (Manual Verification).
+
+**Test data:** all unit tests use `tmp_path` + synthetic FITS/CSV/JSON per existing
+`tests/test_qa_server.py` idiom; no telescope data needed; cloud-safe (no casa6-only imports
+in the new modules).
+
+## Migration Strategy
+
+No breaking changes: all existing routes keep their URLs; `EPOCHS` remains the fallback when
+stage is empty; the Dagster tracer-bullet and its launcher scripts are untouched.
+
+**Rollback:** revert the branch; the control registry directory is additive and ignorable;
+disable units with `systemctl disable --now dsa110-autopipeline.timer dsa110-dashboard`.
+
+## Risk Assessment
+
+1. **Risk:** Terminate leaves WSClean/CASA grandchildren alive (the Dagster failure mode we
+   avoided). **Likelihood:** Low **Impact:** High.
+   **Mitigation:** `start_new_session=True` + `os.killpg`; `batch_pipeline.py` workers run in
+   the same session; explicit grandchild-kill test in Phase 1; manual `pgrep -g` check.
+2. **Risk:** Token leaks via audit/logs/HTML. **Likelihood:** Low **Impact:** High.
+   **Mitigation:** audit writes payload only (no headers); token field is `type=password`,
+   never persisted server-side; test asserts token absent from audit.
+3. **Risk:** Dashboard (uvicorn) restart orphans running-status rows. **Likelihood:** Medium
+   **Impact:** Low. **Mitigation:** `_reconcile` marks pid-dead rows `orphaned` on read; the
+   underlying pipeline run continues unharmed (it is session-detached) and its manifest still
+   lands.
+4. **Risk:** Concurrent dashboard + hand-launched CLI runs collide on stage files.
+   **Likelihood:** Medium **Impact:** Medium. **Mitigation:** single-flight guard covers
+   launcher-owned runs; `process_status()` already surfaces any external `batch_pipeline.py`
+   in the UI heartbeat so the operator can see hand-launched runs before launching.
+5. **Risk:** `run_dry_run` blocks a uvicorn worker up to 120 s. **Likelihood:** Medium
+   **Impact:** Low. **Mitigation:** explicit timeout → 504; dry-run of batch_pipeline is
+   read-only and typically seconds.
+
+## Edge Cases and Error Handling
+
+1. **Token env unset** → every mutating route 403s (fail-closed); read-only dashboard fully
+   functional. Tested.
+2. **Injection-shaped fields** (`date="2026-01-25; rm -rf /"`) → `RunRequest` ValueError → 400;
+   argv is a list (no shell) so even a missed case cannot become a shell string. Tested.
+3. **Terminate on finished/unknown run** → 409/404, no signal sent. Tested via status guard.
+4. **Partial/corrupt manifest** → provenance page renders `—` fields, never 500. Tested.
+5. **Photometry CSV with missing columns** → epoch skipped in light curve with a log warning.
+   Tested (header subset check).
+6. **Timer fires while yesterday's run still active** → `skipped_running` outcome, JSON on
+   stdout into the journal; no queueing (deliberate: next timer tick retries).
+
+## Documentation Updates
+
+- [ ] `docs/operations/dashboard.md` (new — Phase 6).
+- [ ] CLAUDE.md: qa_server sentence (token-gated control API), command table row for
+      `scripts/auto_pipeline.py` (Phase 6).
+- [ ] Issue hygiene: comment on #51/#53/#59/#60 with what landed and what remains; note the
+      #49 auth decision on #49 and propose ADR follow-up in `docs/adr/` (the ADR itself can be
+      a short follow-up commit).
+
+## Open Questions
+
+*(none — decisions 1–5 in Implementation Approach resolve the research doc's open items;
+deferred work is listed in What We're NOT Doing)*
+
+---
+
+## References
+
+**Research Documents:**
+- [Research: Production-ready pipeline dashboard](research-dashboard-production-readiness.md)
+
+**Files Analyzed:**
+- `scripts/qa_server.py` (fully), `scripts/batch_pipeline.py:1217-1440`,
+  `dsa110_continuum/observability/hour_state.py` (fully), `tests/test_qa_server.py:1-110`,
+  `scripts/stack_lightcurves.py`, real manifest/summary/CSV schemas on
+  `/data/dsa110-proc/products/mosaics/`.
+
+**External Documentation:**
+- Cited in the research doc (Dagster/Prefect/Airflow docs and issues, observatory prior art).
+
+---
+
+## Review History
+
+### Version 1.0 — 2026-07-15
+- Initial plan created (Direct mode; orchestrator determination delegated by user).
+
+### Version 1.1 — 2026-07-15
+- All phases implemented (commits `7183fe7..136b99c`); checkboxes updated. Deviations and
+  results in [implement-dashboard-production-readiness.md](implement-dashboard-production-readiness.md).
+- Manual-verification items and outward-facing steps (issue comments, PR, systemd install)
+  left unchecked for the user.

--- a/docs/rse/specs/research-dashboard-production-readiness.md
+++ b/docs/rse/specs/research-dashboard-production-readiness.md
@@ -1,0 +1,290 @@
+# Research: Production-ready pipeline dashboard (orchestrator choice + UI substrate)
+
+**Date:** 2026-07-15
+**Scope:** both (internal codebase + external prior art)
+**Codebase state:** commit `2a62963`, 2026-07-15 (plus significant *uncommitted* working-tree state — see Findings §1)
+**Related Documents:** `outputs/observability-dashboard-2026-07-14/{DECISION,ARCHITECTURE,STATUS,HUMAN_VALIDATION,THIRD_OPTION_CODEX,THIRD_OPTION_FABLE5}.md`; GitHub issues #48–#62
+
+## Question / Scope
+
+The target product is a dashboard UI that (a) monitors the fully-automated hourly imaging
+pipeline end-to-end (diagnostics + science data products), (b) lets an operator manually run or
+re-run the pipeline and individual stages when automation fails, and (c) is production-ready.
+The open architectural question: is Dagster the right substrate, given "we currently use
+Dagster"? In scope: every existing UI/observability surface, the pipeline's actual
+execution/control model, the state of issues #48–#62, live H17 infrastructure, and external
+evidence on Dagster-as-control-plane vs alternatives. Out of scope: implementing anything (this
+doc feeds planning).
+
+## Codebase Findings
+
+### 1. "Currently using Dagster" is three different things — none of them is the target product
+
+1. **Legacy `dsa110_contimg` Dagster** (running since 2026-03-01, *outside this repo*):
+   `/data/dsa110-contimg/backend/workspace.yaml` loads
+   `dsa110_contimg.workflow.dagster.definitions` with 14+ job modules (science_mosaic,
+   on_demand_mosaic, calibrate_ms, bandpass_calibration, manual_conversion, imaging_advanced,
+   file_management, database_maintenance, health_monitoring, assets, asset_checks). It is served
+   by host processes (PIDs 2900–2902: legacy uvicorn API, `scripts.dagster_mux_app`,
+   dagster-webserver on 127.0.0.1:3000) and a Docker stack (`dsa110-dagster-{adapter,webserver,
+   code-server,daemon}` on :3211, `dsa110-graphql` :7001, `dsa110-carta` :9002,
+   apollo-router), fronted by nginx on :80 (proxies `carta/`, `api/`, `dagster`) and :3210.
+   These orchestrate the **old retired package**, not `dsa110_continuum`. Old systemd units
+   (`dsa110-api`, `dsa110-dagster-webserver`, `dsa110-webui`, `dsa110-dagster-mux`,
+   `dsa110-frontend`) all belong to the old package
+   (`docs/archive/contimg-retirement/validation-contimg-import-retirement.md:150-190`).
+2. **New read-only Dagster tracer-bullet** (2026-07-14, this repo, **uncommitted**):
+   `dsa110_continuum/observability/dagster_defs.py` — six external-state assets in group
+   `hour_11_observability` produced by one `@multi_asset` (`dagster_defs.py:80-172`), a
+   1-minute always-running sensor (`dagster_defs.py:182-190`), webserver on 127.0.0.1:3212.
+   Materializations are metadata-only; no science code runs (`dagster_defs.py:97`).
+   `hour_state.py:151-233` is the package-local read-only collector (MS/cal/tile/mosaic/HDF5
+   counts, disk, processes, run products, campaign state machine running>finished>absent at
+   `hour_state.py:215-222`). Generic over date/hour via `HourStateConfig` (env
+   `DSA110_OBSERVE_DATE`/`_HOUR`, defaults 2026-07-13/11 at `hour_state.py:18-19`); hour-11
+   naming and a couple of alias paths are the only hardcoding
+   (`mosaic_preview.py:61,193-202`).
+3. **The retired Dagster science bridge** (this repo): `ScienceMosaicBridgeJob.execute()`
+   raises `RuntimeError` (`dsa110_continuum/mosaic/science_jobs.py:133-138`). Production
+   science mosaicking deliberately does **not** go through Dagster.
+
+Yesterday's `DECISION.md` chose Dagster **only** for the read-only observability surface and
+explicitly not for routing science mosaicking; `POST /exec` and all mutating surfaces were kept
+out by design. The new requirement (run/re-run the pipeline from the UI) goes beyond that
+decision's scope, so the orchestrator question must be re-opened for the *control* dimension —
+that is the external research question below.
+
+### 2. Live UI surfaces (and their status)
+
+| Surface | Port | Status | Notes |
+| --- | --- | --- | --- |
+| `scripts/qa_server.py` (FastAPI) | 8767 | **live, public** via Cloudflare tunnel; **no auth** | 596 lines, uncommitted rewrite (+559/−173 vs HEAD). Routes: `/` HTML dashboard (30 s full-page reload, `qa_server.py:510`), `/artifacts/mosaic/{date}/{epoch}/status|thumb.png` router (`:526-549`), `/api/status` ops snapshot (`:558-566`), `/health`. Read-only; path-traversal- and XSS-hardened; 562-line test file. Hardcoded 6-epoch `EPOCHS` list (`:52-59`). |
+| Dagster tracer-bullet | 3212 | live, localhost-only | See §1.2. Human-validated 2026-07-14 (`HUMAN_VALIDATION.md`: all checks PASS). |
+| `scripts/monitor_server.py` (FastAPI) | — | not running (verified via `pgrep`, 2026-07-15; CLAUDE.md's "live, host-ops" note is stale), no launcher in repo, not tunneled | 78 lines. Read-only probes plus **`POST /exec` running `subprocess.run(shell=True)`** gated only by shared-secret env (`monitor_server.py:63-73`). Untested. Issue #62 plans its retirement. |
+| `dsa110_continuum/mosaic/api.py` | — | **dormant** | 535-line `/mosaics` router incl. mutating `POST /mosaics/create` (spawns `execute_mosaic_pipeline_task`, `api.py:224-227`) and `DELETE /mosaics/{name}`. Never mounted anywhere; `configure_mosaic_api` never called (repo-wide grep). Issues #58/#61 plan mounting read-only/mutating subsets. |
+| `python -m http.server 8765` | 8765 | live | Bare directory listing of `/data/dsa110-proc/products/lightcurves`. |
+
+Frontend stack facts: FastAPI ≥0.115 / uvicorn / dagster ≥1.12.10 in `pyproject.toml:46-77`;
+**no** Panel/Plotly/Streamlit anywhere; bokeh pinned only for a CVE and never imported; a
+`django>=4.2` dependency exists ("Phase 1: Add VAST-style monitoring UI") with zero Django code —
+aspirational leftover.
+
+### 3. Pipeline execution/control model (what a control dashboard must drive)
+
+`scripts/batch_pipeline.py` (2343 lines) is **CLI-only** — `main()` at `:1217`, no importable
+entrypoint. Stages: per-epoch gaincal → RFI flagging → per-tile calibrate+image (subprocess pool,
+SIGKILL timeout `:81,:1071-1142`) → hourly-epoch mosaics (`:846-897`) → forced photometry →
+manifest/summary/report emission (`:2226-2319`).
+
+Manual-intervention primitives **already exist as CLI knobs**:
+
+- per-tile re-run: `--force-recal` (`:1320`), checkpoint resume via `.tile_checkpoint.json`
+  (atomic writer `:424,479-482`), quarantine with `--quarantine-after-failures` /
+  `--clear-quarantine` (`:549-574`), `--retry-failed` one-retry-with-cooldown (`:1137-1142`);
+- per-hour re-run: `--start-hour`/`--end-hour` (`:1291-1298`) +
+  `_epoch_should_rebuild` (`:519`) keyed on prior-manifest verdict;
+- photometry-only: `--skip-photometry`, `scripts/regenerate_photometry.py`,
+  `scripts/forced_photometry.py`;
+- read-only planning: `--dry-run` → `_dry_run_main` (`:709`) prints the full rebuild/skip/
+  quarantine plan and exits without writing.
+
+Run state is **file-based JSON, not a service**: `.tile_checkpoint.json` (stage dir),
+`{date}_manifest.json` (`dsa110_continuum/qa/provenance.py:42,248` — tiles, epochs, gates,
+verdict CLEAN/DEGRADED/FAILED), `{date}_run_summary.json` (`batch_pipeline.py:2245-2269`, also
+symlinked to `/tmp/pipeline_last_run.json` and optionally POSTed to `DSA_NOTIFY_URL`
+`:2294-2310`), `run_report.md` (`qa/run_report.py:34-68`), `qa_summary.csv` (`:85-89,976`),
+promotion sidecar (`:2319`). Fifteen-plus SQLite stores exist (unified
+`/data/dsa110-contimg/state/db/pipeline.sqlite3` with `ms_index`, `images`, `photometry`,
+`ese_candidates`, calibration tables, etc. — `dsa110_continuum/database/schema.sql:3-159`), but
+the run/checkpoint state a dashboard needs is in the JSON artifacts.
+
+**There is no automation today.** No cron/systemd runs `dsa110_continuum`'s pipeline; campaigns
+are hand-launched per hour (e.g. `outputs/slowvis-mosaic-campaign-2026-07-14/batch_run_h11.log`).
+"Fully automated with manual fallback" is therefore an unbuilt requirement, not a current
+property — the dashboard plan must include the automation trigger itself.
+
+The in-repo `workflow/` Job/Pipeline/Executor abstraction is largely vestigial for production:
+`batch_pipeline.py` never touches it; only the dormant on-demand-mosaic path and
+`calibration/pipeline.py` use `PipelineExecutor` (read-only legacy DB,
+`workflow/executor.py:298-327`).
+
+### 4. Issues #48–#62 already spec the product
+
+All fifteen are open, `needs-triage`, zero comments, no linked PRs. Shape: three ADRs (#48
+architecture: cadence/render-time/consolidation/navigation; #49 auth posture — today the public
+tunnel has **no auth**; #50 interactive FITS vs pre-rendered), one tracer-bullet (#51: routed
+FastAPI scaffold at :8767 — **effectively already implemented** by the uncommitted qa_server
+rewrite, which has exactly the routed-artifact architecture #51 asks for, but the issue is open
+and the code uncommitted), then vertical slices: stage-event→diagnostic contract (#52),
+auto-discovered artifact browser with 7 lifecycle states (#53), per-MS/per-tile/per-caltable QA
+views (#54–#56) wiring the existing 19 `qa/` + 40+ `visualization/` modules, per-artifact
+in-flight job state (#57, prereq for retiring monitor_server #62), mounting `mosaic/api.py`
+read-only (#58) then mutating routes auth-gated (#61), the forced-photometry/light-curve
+science surface (#59 — "the primary science surface"), and QA-gate/provenance run view (#60).
+Adjacent: #82 campaign tracker; #95/#96 green-workspace umbrellas that explicitly defer to
+#48–#62 as source of truth.
+
+Sequencing encoded in the issues: #51 blocks nearly everything; #61 blocked by #49+#58;
+#62 blocked by #49+#51+#57.
+
+### 5. Gaps between current state and the user's target
+
+1. **Nothing is committed**: qa_server rewrite, `dsa110_continuum/observability/` (3 modules),
+   4 test files — all working-tree only. First production-readiness step is landing this.
+2. **No control surface at all**: nothing in the new stack can launch `batch_pipeline.py`; the
+   only mutating endpoints are the unmounted `mosaic/api.py` routes and the deliberately
+   unmounted `POST /exec`.
+3. **No auth** on a publicly-tunneled origin (#49 undecided) — blocking for any mutating route.
+4. **No automation trigger** (cron/systemd/sensor) for the new pipeline.
+5. **Science-product depth missing**: no light-curve/variability view (#59), no per-artifact QA
+   views (#54–#56), no lifecycle browser (#53); the historical `EPOCHS` list is hardcoded.
+6. **Three parallel legacy surfaces still run** (old Dagster host+Docker stacks, nginx fronts,
+   lightcurve http.server) — operator-confusing and unowned; retirement is unplanned except
+   #62 (monitor_server).
+7. **Dashboard state fragmentation**: run truth lives in per-date JSON artifacts + 15 SQLite
+   stores + filesystem globs; every UI so far re-derives it by scanning.
+
+## Prior Art
+
+### Dagster OSS as a control plane — feature fit is real
+
+Everything the manual-intervention role needs is in OSS, none of it Dagster+-gated: Launchpad
+runs with editable config ([webserver docs](https://docs.dagster.io/guides/operate/webserver),
+[run configuration](https://docs.dagster.io/guides/operate/configuration/run-configuration)),
+daily/hourly partitioned assets ([partitioning](https://docs.dagster.io/guides/build/partitions-and-backfills/partitioning-assets)),
+UI backfills over partition ranges ([backfilling](https://docs.dagster.io/guides/build/partitions-and-backfills/backfilling-data)),
+re-execution from failure / arbitrary step subsets ([run retries](https://docs.dagster.io/deployment/execution/run-retries)),
+and blocking asset checks as QA gates ([asset checks](https://docs.dagster.io/guides/test/asset-checks)).
+Dagster+-only features (alerting, RBAC/audit, Insights) are not needed for this role
+([Dagster+ scope](https://docs.dagster.io/deployment/dagster-plus)).
+
+### Disconfirming findings on self-hosted Dagster (mandatory adversarial pass)
+
+- **Event-log growth is unbounded by default** — no built-in retention; users report the
+  `event_logs` table at ~99% of DB size, one at 250 GB
+  ([discuss thread](https://discuss.dagster.io/t/5115138/hi-team-our-dagster-event-logs-table-is-like-250g-now-see-no));
+  cleanup is DIY ([discussion #12985](https://github.com/dagster-io/dagster/discussions/12985),
+  [issue #15526](https://github.com/dagster-io/dagster/issues/15526));
+  DB tuning is a documented operator chore
+  ([database tuning](https://docs.dagster.io/deployment/troubleshooting/database-tuning)).
+- **Daemon/webserver memory leaks and crashes recur**:
+  [#32070](https://github.com/dagster-io/dagster/issues/32070),
+  [#21307](https://github.com/dagster-io/dagster/issues/21307),
+  [#26287](https://github.com/dagster-io/dagster/issues/26287) (daemon to 20 GB),
+  [#18997](https://github.com/dagster-io/dagster/issues/18997),
+  [#19893](https://github.com/dagster-io/dagster/issues/19893) (crashes, no stack trace).
+- **UI Terminate does not reliably kill grandchild subprocesses** — exactly the WSClean/CASA
+  shape: steps surviving run termination is a filed bug
+  ([issue #21476](https://github.com/dagster-io/dagster/issues/21476)); in-op code must catch
+  `DagsterExecutionInterruptedError` and kill its own process group
+  ([discussion #13986](https://github.com/dagster-io/dagster/discussions/13986)). No mid-step
+  checkpointing — a killed step restarts at the step boundary (acceptable at per-tile
+  granularity). Run monitoring / `dagster/max_runtime` enforcement exists but needs the daemon
+  ([run monitoring](https://docs.dagster.io/deployment/execution/run-monitoring)).
+- Net operational footprint on one host: webserver + daemon + code-server (3 services), Postgres
+  strongly advised over SQLite
+  ([OSS deployment architecture](https://docs.dagster.io/deployment/oss/oss-deployment-architecture)),
+  plus a retention cron and planned restarts. Comparisons rate this moderate — lighter than
+  Airflow, heavier than Prefect or a bare FastAPI service
+  ([DZone](https://dzone.com/articles/airflow-vs-dagster-vs-prefect-which-scheduler-fits),
+  [Bruin 2026](https://getbruin.com/blog/best-data-pipeline-tools-2026/)).
+
+### Alternatives
+
+- **Prefect 3 self-hosted** — deployments give UI-triggered runs with a parameter form,
+  cancel/pause, retries ([deployments](https://docs.prefect.io/v3/concepts/deployments),
+  [self-host](https://docs-3.prefect.io/3.0/manage/self-host)); lightest self-host of the three
+  ([ZenML comparison](https://www.zenml.io/blog/orchestration-showdown-dagster-vs-prefect-vs-airflow)).
+  Weaker partition story: date/hour become flow parameters; per-partition status grids are
+  hand-built. Not installed in casa6 today.
+- **Airflow** — mature trigger-with-conf and clear-to-rerun
+  ([DAG runs](https://airflow.apache.org/docs/apache-airflow/stable/dag-run.html)), but the
+  heaviest self-host ("0.5–1 FTE of platform engineering at scale",
+  [Bruin 2026](https://getbruin.com/blog/best-data-pipeline-tools-2026/)). Overkill for one host,
+  one operator.
+- **Custom FastAPI driving the CLI** — zero new infrastructure (it is what `qa_server.py`
+  already is) and total control of domain UI; the cost is re-implementing run-state, queueing,
+  retry, and termination machinery. The build-vs-buy consensus is that orchestrators earn their
+  keep when *re-run semantics over partitions* matter
+  ([ZenML](https://www.zenml.io/blog/orchestration-showdown-dagster-vs-prefect-vs-airflow),
+  [CodeX](https://medium.com/codex/airflow-vs-prefect-vs-dagster-which-workflow-tool-actually-fits-your-stack-d581e622cd27)) —
+  but see Synthesis: in this repo the CLI already owns most of those semantics.
+
+### Observatory prior art
+
+- **Simons Observatory** (production, on-site): Prefect orchestrates daily packaging + reduction
+  on a site compute node; chosen for Python-native flows, the monitoring UI, and
+  concurrency limits ([arXiv:2406.10905](https://arxiv.org/abs/2406.10905)).
+- **Keck LRIS-2** (Caltech/WMKO, in development): "workflow orchestration using Prefect"
+  ([SPIE AS26 program](https://spie.org/AS26/conferencedetails/astronomy-control-software)).
+- **No production observatory using Dagster surfaced** across four query variants (absence of
+  evidence from these backends, not proof — but the asymmetry vs Prefect is a data point).
+  Locally, this codebase already retired one Dagster science bridge.
+- **Steward risk/wildcard:** Prefect acquired Dagster Labs, announced 2026-07-13, with stated
+  commitments to keep both OSS lines maintained
+  ([prefect.io](https://www.prefect.io/prefect-acquires-dagster),
+  [dagster.io](https://dagster.io/blog/prefect-is-acquiring-dagster)). Long-horizon investment
+  in two overlapping OSS orchestrators under one company is an open risk.
+
+## Synthesis
+
+1. **Two halves, one decision.** The *monitoring/science-visualization* half (per-artifact QA
+   views, lifecycle browser, light curves, provenance) cannot be rendered by any orchestrator UI
+   — it is domain UI, already spec'd as the unified FastAPI server in #48–#62 and partially
+   built (uncommitted routed `qa_server.py`). That half is needed under every orchestrator
+   choice. The genuinely open question is only the *control* half: what launches, re-runs, and
+   terminates `batch_pipeline.py`.
+2. **The control half is thinner than it looks.** `batch_pipeline.py` already implements the
+   hard re-run semantics internally — idempotent per-tile skip/rebuild from checkpoint +
+   manifest verdict, quarantine, retry, per-hour windows, photometry-only, dry-run
+   (Findings §3). An external orchestrator wrapping the CLI would *duplicate* partition/state
+   bookkeeping the CLI already owns (Dagster partition status vs manifest verdicts = two
+   sources of truth), while the standard build-vs-buy argument for orchestrators assumes that
+   machinery is absent.
+3. **Dagster evidence cuts both ways.** Feature fit for control is 1:1 and already installed;
+   but the operational burden is real (event-log retention, daemon leaks), the
+   grandchild-kill caveat lands exactly on WSClean/CASA-shaped work, this repo already walked
+   back one Dagster science path, the legacy Dagster stack on H17 is a live example of the
+   unmaintained end-state, and observatory precedent (Simons, Keck) went Prefect.
+4. **Light recommendation (design deferred to planning):** keep Dagster where yesterday's
+   decision put it — read-only observability, optionally with an eventual sunset — and build
+   the production dashboard as the #48–#62 unified FastAPI server, adding the control plane as
+   a *small, auth-gated run-launcher* in that same service: spawn `batch_pipeline.py` in its
+   own process group with chosen flags (date/hours/`--force-recal`/`--retry-failed`/…), persist
+   a run registry, stream/serve logs, and expose terminate as process-group kill. Automation
+   then becomes a scheduler (systemd timer, or the existing Dagster sensor if retained) calling
+   the same launcher — one code path for automated and manual runs. Dagster-as-control
+   (partitioned assets wrapping the CLI) remains the documented fallback if a partition-grid UI
+   proves indispensable; Prefect only becomes attractive if the ops burden of Dagster is being
+   paid anyway and a migration window opens.
+5. **Gaps that block "production-ready" regardless of the orchestrator decision** (Findings §5):
+   uncommitted work must land; auth (#49) gates every mutating route; no automation trigger
+   exists; the science surfaces (#53–#60, esp. #59) are unbuilt; legacy stacks need a
+   retirement plan; run-state fragmentation needs a single read model.
+
+Open questions for planning: auth mechanism choice (#49 options: VPN-only / basic auth /
+pre-shared token / Caltech OAuth vs the current Cloudflare tunnel posture); whether the
+run-launcher lives in `qa_server.py` or a separate auth-boundary service; lifecycle-state read
+model (derive on scan vs persist); fate of the Dagster tracer-bullet (keep as-is vs fold its
+collector into the FastAPI status API — the collector `hour_state.py` is already
+Dagster-free); legacy-stack retirement sequencing.
+
+## References / Sources
+
+- Code: anchors inline above (`scripts/qa_server.py`, `scripts/batch_pipeline.py`,
+  `dsa110_continuum/observability/*`, `dsa110_continuum/mosaic/{api,science_jobs,pipeline}.py`,
+  `dsa110_continuum/qa/{provenance,run_report}.py`, `dsa110_continuum/workflow/executor.py`,
+  `docs/archive/contimg-retirement/validation-contimg-import-retirement.md`).
+- Prior session: `outputs/observability-dashboard-2026-07-14/` (DECISION, ARCHITECTURE, STATUS,
+  HUMAN_VALIDATION, THIRD_OPTION_CODEX, THIRD_OPTION_FABLE5, REPRODUCE).
+- Issues: dsa110/dsa110-continuum #48–#62, #82, #95, #96.
+- External: Dagster docs (webserver, run-configuration, partitioning-assets, backfilling-data,
+  run-retries, asset-checks, run-monitoring, oss-deployment-architecture, database-tuning,
+  dagster-plus) at docs.dagster.io; Dagster GitHub issues/discussions #32070, #21307, #26287,
+  #18997, #19893, #21476, #23125, #15526, discussions #12985, #13986, #24232, #28182;
+  discuss.dagster.io event-log-250GB thread; Prefect docs (deployments, self-host) at
+  docs.prefect.io; Airflow dag-run docs; comparisons: DZone "Airflow vs Dagster vs Prefect",
+  ZenML orchestration showdown, Bruin best-data-pipeline-tools-2026, FreeAgent 2025,
+  Medium/CodeX 2025; observatory prior art: arXiv:2406.10905 (Simons Observatory), SPIE AS26
+  astronomy-control-software program (Keck LRIS-2); acquisition: prefect.io/prefect-acquires-dagster,
+  dagster.io/blog/prefect-is-acquiring-dagster (2026-07-13).

--- a/dsa110_continuum/observability/__init__.py
+++ b/dsa110_continuum/observability/__init__.py
@@ -1,0 +1,5 @@
+"""Read-only continuum pipeline observability."""
+
+from dsa110_continuum.observability.hour_state import HourStateConfig, collect_hour_state
+
+__all__ = ["HourStateConfig", "collect_hour_state"]

--- a/dsa110_continuum/observability/control.py
+++ b/dsa110_continuum/observability/control.py
@@ -1,0 +1,266 @@
+"""Launch, track, and terminate batch_pipeline.py runs for the dashboard."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import sqlite3
+import subprocess
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field, fields
+from datetime import datetime, timezone
+from pathlib import Path
+
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+RFI_MODES = ("full", "conditional", "off")
+
+
+class RunConflictError(RuntimeError):
+    """Another launcher-owned pipeline run is still alive."""
+
+
+@dataclass(frozen=True)
+class ControlConfig:
+    """Locations and interpreter for launcher-owned pipeline runs."""
+
+    repo_root: Path = field(
+        default_factory=lambda: Path(os.environ.get("DSA110_REPO_ROOT", "/data/dsa110-continuum"))
+    )
+    python: str = field(
+        default_factory=lambda: os.environ.get(
+            "DSA110_PIPELINE_PYTHON", "/opt/miniforge/envs/casa6/bin/python"
+        )
+    )
+    control_dir: Path = field(
+        default_factory=lambda: Path(
+            os.environ.get("DSA110_CONTROL_DIR", "/data/dsa110-proc/products/control")
+        )
+    )
+
+    @property
+    def db_path(self) -> Path:
+        """Path of the SQLite run registry."""
+        return self.control_dir / "runs.sqlite3"
+
+
+@dataclass(frozen=True)
+class RunRequest:
+    """Validated, allowlisted parameters for one batch_pipeline.py invocation."""
+
+    date: str
+    cal_date: str | None = None
+    start_hour: int | None = None
+    end_hour: int | None = None
+    rfi_mode: str | None = None
+    tile_timeout: int | None = None
+    quarantine_after_failures: int | None = None
+    photometry_workers: int | None = None
+    retry_failed: bool = False
+    force_recal: bool = False
+    skip_photometry: bool = False
+    lenient_qa: bool = False
+    clear_quarantine: bool = False
+    dry_run: bool = False
+
+    def __post_init__(self) -> None:
+        for label, value in (("date", self.date), ("cal_date", self.cal_date)):
+            if value is None:
+                continue
+            if not DATE_RE.fullmatch(value):
+                raise ValueError(f"{label} must be YYYY-MM-DD, got {value!r}")
+            datetime.strptime(value, "%Y-%m-%d")
+        for label, value in (("start_hour", self.start_hour), ("end_hour", self.end_hour)):
+            if value is not None and not 0 <= value <= 23:
+                raise ValueError(f"{label} must be 0-23, got {value}")
+        if (
+            self.start_hour is not None
+            and self.end_hour is not None
+            and self.start_hour > self.end_hour
+        ):
+            raise ValueError("start_hour must be <= end_hour")
+        if self.rfi_mode is not None and self.rfi_mode not in RFI_MODES:
+            raise ValueError(f"rfi_mode must be one of {RFI_MODES}, got {self.rfi_mode!r}")
+        if self.tile_timeout is not None and not 60 <= self.tile_timeout <= 86400:
+            raise ValueError("tile_timeout must be 60-86400 seconds")
+        if self.quarantine_after_failures is not None and not (
+            0 <= self.quarantine_after_failures <= 99
+        ):
+            raise ValueError("quarantine_after_failures must be 0-99")
+        if self.photometry_workers is not None and not 1 <= self.photometry_workers <= 32:
+            raise ValueError("photometry_workers must be 1-32")
+
+    def to_argv(self, config: ControlConfig) -> list[str]:
+        """Build the exact argv list; only allowlisted flags, never a shell string."""
+        argv = [config.python, "scripts/batch_pipeline.py", "--date", self.date]
+        value_flags = (
+            ("--cal-date", self.cal_date),
+            ("--start-hour", self.start_hour),
+            ("--end-hour", self.end_hour),
+            ("--rfi-mode", self.rfi_mode),
+            ("--tile-timeout", self.tile_timeout),
+            ("--quarantine-after-failures", self.quarantine_after_failures),
+            ("--photometry-workers", self.photometry_workers),
+        )
+        for flag, value in value_flags:
+            if value is not None:
+                argv.extend([flag, str(value)])
+        switch_flags = (
+            ("--retry-failed", self.retry_failed),
+            ("--force-recal", self.force_recal),
+            ("--skip-photometry", self.skip_photometry),
+            ("--lenient-qa", self.lenient_qa),
+            ("--clear-quarantine", self.clear_quarantine),
+            ("--dry-run", self.dry_run),
+        )
+        argv.extend(flag for flag, enabled in switch_flags if enabled)
+        return argv
+
+    def to_json(self) -> str:
+        """Serialize every request field for the registry and reproducibility."""
+        return json.dumps({f.name: getattr(self, f.name) for f in fields(self)})
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS runs (
+    run_id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    finished_at TEXT,
+    request_json TEXT NOT NULL,
+    argv_json TEXT NOT NULL,
+    pid INTEGER NOT NULL,
+    log_path TEXT NOT NULL,
+    status TEXT NOT NULL,
+    exit_code INTEGER
+)
+"""
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(db_path, timeout=10)
+    connection.row_factory = sqlite3.Row
+    connection.execute(_SCHEMA)
+    return connection
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _pid_alive(pid: int) -> bool:
+    return Path(f"/proc/{pid}").exists()
+
+
+def _reconcile(row: dict) -> dict:
+    if row["status"] == "running" and not _pid_alive(row["pid"]):
+        row["status"] = "orphaned"
+    return row
+
+
+def _reap(db_path: Path, run_id: str, process: subprocess.Popen) -> None:
+    exit_code = process.wait()
+    status = "succeeded" if exit_code == 0 else "failed"
+    with _connect(db_path) as connection:
+        connection.execute(
+            "UPDATE runs SET status = ?, exit_code = ?, finished_at = ?"
+            " WHERE run_id = ? AND status = 'running'",
+            (status, exit_code, _now(), run_id),
+        )
+
+
+def launch_run(request: RunRequest, config: ControlConfig) -> dict:
+    """Start batch_pipeline.py detached in its own process group and register it."""
+    config.control_dir.mkdir(parents=True, exist_ok=True)
+    live = [row for row in list_runs(config) if row["status"] == "running"]
+    if live:
+        raise RunConflictError(f"run {live[0]['run_id']} is still running")
+    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ") + "-" + uuid.uuid4().hex[:6]
+    log_path = config.control_dir / f"run_{run_id}.log"
+    argv = request.to_argv(config)
+    environment = {**os.environ, "PYTHONPATH": str(config.repo_root)}
+    with log_path.open("wb") as stream:
+        process = subprocess.Popen(
+            argv,
+            cwd=config.repo_root,
+            stdout=stream,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env=environment,
+        )
+    record = {
+        "run_id": run_id,
+        "created_at": _now(),
+        "finished_at": None,
+        "request_json": request.to_json(),
+        "argv_json": json.dumps(argv),
+        "pid": process.pid,
+        "log_path": str(log_path),
+        "status": "running",
+        "exit_code": None,
+    }
+    with _connect(config.db_path) as connection:
+        connection.execute(
+            "INSERT INTO runs VALUES (:run_id, :created_at, :finished_at, :request_json,"
+            " :argv_json, :pid, :log_path, :status, :exit_code)",
+            record,
+        )
+    threading.Thread(target=_reap, args=(config.db_path, run_id, process), daemon=True).start()
+    return record
+
+
+def run_dry_run(request: RunRequest, config: ControlConfig, timeout: int = 120) -> str:
+    """Run batch_pipeline.py --dry-run synchronously and return its output."""
+    if not request.dry_run:
+        request = RunRequest(**{**json.loads(request.to_json()), "dry_run": True})
+    result = subprocess.run(
+        request.to_argv(config),
+        cwd=config.repo_root,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env={**os.environ, "PYTHONPATH": str(config.repo_root)},
+    )
+    return result.stdout + result.stderr
+
+
+def list_runs(config: ControlConfig, limit: int = 50) -> list[dict]:
+    """Return the newest registry rows, reconciling stale running statuses."""
+    if not config.db_path.is_file():
+        return []
+    with _connect(config.db_path) as connection:
+        rows = connection.execute(
+            "SELECT * FROM runs ORDER BY created_at DESC LIMIT ?", (limit,)
+        ).fetchall()
+    return [_reconcile(dict(row)) for row in rows]
+
+
+def get_run(run_id: str, config: ControlConfig) -> dict:
+    """Return one registry row by run_id; raise KeyError when unknown."""
+    with _connect(config.db_path) as connection:
+        row = connection.execute("SELECT * FROM runs WHERE run_id = ?", (run_id,)).fetchone()
+    if row is None:
+        raise KeyError(run_id)
+    return _reconcile(dict(row))
+
+
+def terminate_run(run_id: str, config: ControlConfig, grace_seconds: float = 10.0) -> dict:
+    """SIGTERM the run's process group, escalate to SIGKILL after the grace period."""
+    row = get_run(run_id, config)
+    if row["status"] != "running":
+        raise RunConflictError(f"run {run_id} is not running (status={row['status']})")
+    pgid = row["pid"]
+    os.killpg(pgid, signal.SIGTERM)
+    deadline = time.monotonic() + grace_seconds
+    while time.monotonic() < deadline and _pid_alive(pgid):
+        time.sleep(0.25)
+    if _pid_alive(pgid):
+        os.killpg(pgid, signal.SIGKILL)
+    with _connect(config.db_path) as connection:
+        connection.execute(
+            "UPDATE runs SET status = 'terminated', finished_at = ? WHERE run_id = ?",
+            (_now(), run_id),
+        )
+    return get_run(run_id, config)

--- a/dsa110_continuum/observability/control.py
+++ b/dsa110_continuum/observability/control.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import re
@@ -17,6 +18,7 @@ from pathlib import Path
 
 DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 RFI_MODES = ("full", "conditional", "off")
+CONTROL_TOKEN_ENV = "DSA110_CONTROL_TOKEN"
 
 
 class RunConflictError(RuntimeError):
@@ -134,7 +136,8 @@ CREATE TABLE IF NOT EXISTS runs (
     pid INTEGER NOT NULL,
     log_path TEXT NOT NULL,
     status TEXT NOT NULL,
-    exit_code INTEGER
+    exit_code INTEGER,
+    proc_start INTEGER
 )
 """
 
@@ -143,6 +146,9 @@ def _connect(db_path: Path) -> sqlite3.Connection:
     connection = sqlite3.connect(db_path, timeout=10)
     connection.row_factory = sqlite3.Row
     connection.execute(_SCHEMA)
+    columns = {row[1] for row in connection.execute("PRAGMA table_info(runs)")}
+    if "proc_start" not in columns:
+        connection.execute("ALTER TABLE runs ADD COLUMN proc_start INTEGER")
     return connection
 
 
@@ -150,12 +156,40 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _pid_alive(pid: int) -> bool:
-    return Path(f"/proc/{pid}").exists()
+def _proc_start_ticks(pid: int) -> int | None:
+    """Start time (clock ticks since boot) of the current occupant of pid.
+
+    Returns None when the pid is free or its stat is unreadable. A zombie is
+    reported as None: it can no longer be signaled meaningfully and its group
+    is gone or dying.
+    """
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+    except OSError:
+        return None
+    tail = stat.rpartition(")")[2].split()
+    try:
+        if tail[0] == "Z":
+            return None
+        return int(tail[19])
+    except (IndexError, ValueError):
+        return None
+
+
+def _run_process_alive(pid: int, expected_start: int | None) -> bool:
+    """Report whether pid is still occupied by the same process this row launched.
+
+    Rows without a recorded identity (legacy schema, or stat unreadable at
+    launch) can never be verified, so they are never treated as alive — they
+    reconcile to 'orphaned' and terminate refuses to signal them.
+    """
+    if expected_start is None:
+        return False
+    return _proc_start_ticks(pid) == expected_start
 
 
 def _reconcile(row: dict) -> dict:
-    if row["status"] == "running" and not _pid_alive(row["pid"]):
+    if row["status"] == "running" and not _run_process_alive(row["pid"], row.get("proc_start")):
         row["status"] = "orphaned"
     return row
 
@@ -171,42 +205,58 @@ def _reap(db_path: Path, run_id: str, process: subprocess.Popen) -> None:
         )
 
 
-def launch_run(request: RunRequest, config: ControlConfig) -> dict:
-    """Start batch_pipeline.py detached in its own process group and register it."""
-    config.control_dir.mkdir(parents=True, exist_ok=True)
-    live = [row for row in list_runs(config) if row["status"] == "running"]
-    if live:
-        raise RunConflictError(f"run {live[0]['run_id']} is still running")
-    run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ") + "-" + uuid.uuid4().hex[:6]
-    log_path = config.control_dir / f"run_{run_id}.log"
-    argv = request.to_argv(config)
+def _launch_env(config: ControlConfig) -> dict[str, str]:
+    """Pipeline child env: repo on PYTHONPATH, control token never inherited."""
     environment = {**os.environ, "PYTHONPATH": str(config.repo_root)}
-    with log_path.open("wb") as stream:
-        process = subprocess.Popen(
-            argv,
-            cwd=config.repo_root,
-            stdout=stream,
-            stderr=subprocess.STDOUT,
-            start_new_session=True,
-            env=environment,
-        )
-    record = {
-        "run_id": run_id,
-        "created_at": _now(),
-        "finished_at": None,
-        "request_json": request.to_json(),
-        "argv_json": json.dumps(argv),
-        "pid": process.pid,
-        "log_path": str(log_path),
-        "status": "running",
-        "exit_code": None,
-    }
-    with _connect(config.db_path) as connection:
-        connection.execute(
-            "INSERT INTO runs VALUES (:run_id, :created_at, :finished_at, :request_json,"
-            " :argv_json, :pid, :log_path, :status, :exit_code)",
-            record,
-        )
+    environment.pop(CONTROL_TOKEN_ENV, None)
+    return environment
+
+
+def launch_run(request: RunRequest, config: ControlConfig) -> dict:
+    """Start batch_pipeline.py detached in its own process group and register it.
+
+    The single-flight guard, spawn, and registry insert run under an exclusive
+    file lock so a concurrent launcher (dashboard click vs systemd timer)
+    cannot both pass the guard.
+    """
+    config.control_dir.mkdir(parents=True, exist_ok=True)
+    with (config.control_dir / "launch.lock").open("w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        live = [row for row in list_runs(config) if row["status"] == "running"]
+        if live:
+            raise RunConflictError(f"run {live[0]['run_id']} is still running")
+        run_id = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ") + "-" + uuid.uuid4().hex[:6]
+        log_path = config.control_dir / f"run_{run_id}.log"
+        argv = request.to_argv(config)
+        with log_path.open("wb") as stream:
+            process = subprocess.Popen(
+                argv,
+                cwd=config.repo_root,
+                stdout=stream,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+                env=_launch_env(config),
+            )
+        record = {
+            "run_id": run_id,
+            "created_at": _now(),
+            "finished_at": None,
+            "request_json": request.to_json(),
+            "argv_json": json.dumps(argv),
+            "pid": process.pid,
+            "log_path": str(log_path),
+            "status": "running",
+            "exit_code": None,
+            "proc_start": _proc_start_ticks(process.pid),
+        }
+        with _connect(config.db_path) as connection:
+            connection.execute(
+                "INSERT INTO runs (run_id, created_at, finished_at, request_json, argv_json,"
+                " pid, log_path, status, exit_code, proc_start)"
+                " VALUES (:run_id, :created_at, :finished_at, :request_json, :argv_json,"
+                " :pid, :log_path, :status, :exit_code, :proc_start)",
+                record,
+            )
     threading.Thread(target=_reap, args=(config.db_path, run_id, process), daemon=True).start()
     return record
 
@@ -221,7 +271,7 @@ def run_dry_run(request: RunRequest, config: ControlConfig, timeout: int = 120) 
         capture_output=True,
         text=True,
         timeout=timeout,
-        env={**os.environ, "PYTHONPATH": str(config.repo_root)},
+        env=_launch_env(config),
     )
     return result.stdout + result.stderr
 
@@ -247,17 +297,31 @@ def get_run(run_id: str, config: ControlConfig) -> dict:
 
 
 def terminate_run(run_id: str, config: ControlConfig, grace_seconds: float = 10.0) -> dict:
-    """SIGTERM the run's process group, escalate to SIGKILL after the grace period."""
+    """SIGTERM the run's process group, escalate to SIGKILL after the grace period.
+
+    Signals only after the pid's current occupant is verified to be the
+    launched process (get_run reconciles identity mismatches to 'orphaned').
+    A run that exits between the check and the signal is not an error.
+    """
     row = get_run(run_id, config)
     if row["status"] != "running":
         raise RunConflictError(f"run {run_id} is not running (status={row['status']})")
     pgid = row["pid"]
-    os.killpg(pgid, signal.SIGTERM)
+    expected_start = row.get("proc_start")
+    if not _run_process_alive(pgid, expected_start):
+        raise RunConflictError(f"run {run_id} process identity unverified; refusing to signal")
+    try:
+        os.killpg(pgid, signal.SIGTERM)
+    except ProcessLookupError:
+        return get_run(run_id, config)
     deadline = time.monotonic() + grace_seconds
-    while time.monotonic() < deadline and _pid_alive(pgid):
+    while time.monotonic() < deadline and _run_process_alive(pgid, expected_start):
         time.sleep(0.25)
-    if _pid_alive(pgid):
-        os.killpg(pgid, signal.SIGKILL)
+    if _run_process_alive(pgid, expected_start):
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
     with _connect(config.db_path) as connection:
         connection.execute(
             "UPDATE runs SET status = 'terminated', finished_at = ? WHERE run_id = ?",

--- a/dsa110_continuum/observability/dagster_defs.py
+++ b/dsa110_continuum/observability/dagster_defs.py
@@ -1,0 +1,197 @@
+"""Dagster definitions for read-only H17 continuum observability."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from dagster import (
+    AssetSelection,
+    AssetSpec,
+    DefaultSensorStatus,
+    Definitions,
+    MaterializeResult,
+    MetadataValue,
+    RunRequest,
+    define_asset_job,
+    multi_asset,
+    sensor,
+)
+from dsa110_continuum.observability.hour_state import HourStateConfig, collect_hour_state
+from dsa110_continuum.observability.mosaic_preview import (
+    mosaic_preview_markdown,
+    sync_mosaic_thumb,
+)
+
+GROUP = "hour_11_observability"
+ASSET_NAMES = (
+    "campaign_runtime",
+    "measurement_sets_tiles_mosaic",
+    "calibration_tables",
+    "incoming_hdf5",
+    "storage_capacity",
+    "hour_11_continuum_summary",
+)
+
+
+def _spec(name: str, description: str) -> AssetSpec:
+    return AssetSpec(
+        name,
+        group_name=GROUP,
+        description=description,
+        tags={"dsa110/view": "read-only", "dsa110/product": "hourly-epoch"},
+    )
+
+
+def _readiness_markdown(state: dict) -> str:
+    labels = {
+        "measurement_sets_present": "Measurement Sets",
+        "calibration_present": "bandpass and gain calibration",
+        "tiles_present": "tile images",
+        "mosaic_present": "hourly-epoch mosaic",
+        "incoming_hdf5_present": "incoming HDF5",
+        "campaign_process_visible": "campaign process",
+        "campaign_pid_visible": "recorded campaign PID",
+    }
+    rows = [
+        f"# {state['date']} UTC hour {state['hour']:02d}",
+        "",
+        f"**Campaign state:** `{state['summary']['campaign_state']}`",
+        "",
+        "| Check | State |",
+        "| --- | --- |",
+    ]
+    rows.extend(
+        f"| {label} | {'present' if state['summary'][key] else 'not visible'} |"
+        for key, label in labels.items()
+    )
+    rows.extend(
+        [
+            "",
+            "This snapshot is read-only; `not visible` does not launch or retry pipeline work.",
+        ]
+    )
+    preview = state.get("mosaic_preview")
+    if preview:
+        mosaic_path = (state.get("mosaic") or {}).get("path")
+        rows.extend(["", mosaic_preview_markdown(preview, mosaic_path=mosaic_path)])
+    return "\n".join(rows)
+
+
+@multi_asset(
+    specs=[
+        _spec("campaign_runtime", "Campaign processes, recorded PIDs, latest log, and log tail."),
+        _spec(
+            "measurement_sets_tiles_mosaic",
+            "Selected-hour Measurement Sets, tile images, hourly-epoch mosaic, and run records.",
+        ),
+        _spec("calibration_tables", "Selected-hour bandpass and gain table inventory."),
+        _spec("incoming_hdf5", "Selected-hour slow-vis HDF5 inventory under the incoming root."),
+        _spec("storage_capacity", "Capacity, use, and free space on configured H17 volumes."),
+        _spec(
+            "hour_11_continuum_summary",
+            "Operator checklist for data, calibration, products, and campaign visibility.",
+        ),
+    ]
+)
+def observe_hour_11_continuum():
+    """Record external state as Dagster asset metadata without running science code."""
+    config = HourStateConfig()
+    state = collect_hour_state(config)
+    mosaic_path = (state.get("mosaic") or {}).get("path")
+    preview = sync_mosaic_thumb(config, fits_path=mosaic_path)
+    state["mosaic_preview"] = preview
+    campaign = state["campaign"]
+    log = campaign["log"]
+    mosaic_meta = {
+        "mosaic": MetadataValue.json(state["mosaic"]),
+        "mosaic_preview": MetadataValue.md(
+            mosaic_preview_markdown(preview, mosaic_path=mosaic_path)
+        ),
+        "qa_thumbnail": MetadataValue.url(preview["qa_thumb_url"]),
+        "dagster_mosaic_page": MetadataValue.url(preview["dagster_page_url"]),
+    }
+    if mosaic_path:
+        mosaic_meta["mosaic_fits"] = MetadataValue.path(mosaic_path)
+    yield MaterializeResult(
+        asset_key="campaign_runtime",
+        metadata={
+            "date": state["date"],
+            "hour": state["hour"],
+            "campaign_state": campaign["state"],
+            "processes": MetadataValue.json(campaign["processes"]),
+            "pid_hints": MetadataValue.json(campaign["pid_hints"]),
+            "latest_log": log["path"] if log else "not found",
+            "log_tail": MetadataValue.md("```text\n" + "\n".join(campaign["log_tail"]) + "\n```"),
+        },
+    )
+    yield MaterializeResult(
+        asset_key="measurement_sets_tiles_mosaic",
+        metadata={
+            "measurement_set_count": state["measurement_sets"]["count"],
+            "measurement_sets": MetadataValue.json(state["measurement_sets"]["paths"]),
+            "tile_count": state["tiles"]["count"],
+            "latest_tile": MetadataValue.json(state["tiles"]["latest"]),
+            "run_products": MetadataValue.json(state["run_products"]),
+            **mosaic_meta,
+        },
+    )
+    yield MaterializeResult(
+        asset_key="calibration_tables",
+        metadata={
+            "bandpass_count": state["calibration"]["bandpass_count"],
+            "gain_count": state["calibration"]["gain_count"],
+            "tables": MetadataValue.json(state["calibration"]),
+        },
+    )
+    yield MaterializeResult(
+        asset_key="incoming_hdf5",
+        metadata={
+            "hdf5_count": state["incoming"]["count"],
+            "directory": state["incoming"]["directory"],
+            "latest": MetadataValue.json(state["incoming"]["latest"]),
+        },
+    )
+    yield MaterializeResult(
+        asset_key="storage_capacity",
+        metadata={"volumes": MetadataValue.json(state["disks"])},
+    )
+    yield MaterializeResult(
+        asset_key="hour_11_continuum_summary",
+        metadata={
+            "observing_date": state["date"],
+            "utc_hour": state["hour"],
+            "generated_at": state["generated_at"],
+            "operator_checklist": MetadataValue.md(_readiness_markdown(state)),
+            "readiness": MetadataValue.json(state["summary"]),
+            "mosaic_preview": MetadataValue.md(
+                mosaic_preview_markdown(preview, mosaic_path=mosaic_path)
+            ),
+            "qa_thumbnail": MetadataValue.url(preview["qa_thumb_url"]),
+            "dagster_mosaic_page": MetadataValue.url(preview["dagster_page_url"]),
+        },
+    )
+
+
+refresh_hour_11_observability = define_asset_job(
+    "refresh_hour_11_observability",
+    selection=AssetSelection.groups(GROUP),
+    description="Refresh read-only H17 campaign and product metadata.",
+)
+
+
+@sensor(
+    job=refresh_hour_11_observability,
+    minimum_interval_seconds=60,
+    default_status=DefaultSensorStatus.RUNNING,
+)
+def refresh_hour_11_observability_sensor():
+    """Refresh the operator snapshot once per UTC minute."""
+    minute = datetime.now(timezone.utc).replace(second=0, microsecond=0)
+    return RunRequest(run_key=minute.isoformat())
+
+
+defs = Definitions(
+    assets=[observe_hour_11_continuum],
+    jobs=[refresh_hour_11_observability],
+    sensors=[refresh_hour_11_observability_sensor],
+)

--- a/dsa110_continuum/observability/hour_state.py
+++ b/dsa110_continuum/observability/hour_state.py
@@ -1,0 +1,233 @@
+"""Read-only filesystem and process probes for one continuum observing hour."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class HourStateConfig:
+    """Locations and epoch selected for an observability snapshot."""
+
+    date: str = field(default_factory=lambda: os.environ.get("DSA110_OBSERVE_DATE", "2026-07-13"))
+    hour: int = field(default_factory=lambda: int(os.environ.get("DSA110_OBSERVE_HOUR", "11")))
+    stage: Path = field(
+        default_factory=lambda: Path(os.environ.get("DSA110_STAGE", "/stage/dsa110-contimg"))
+    )
+    products: Path = field(
+        default_factory=lambda: Path(
+            os.environ.get("DSA110_PRODUCTS_BASE", "/data/dsa110-proc/products/mosaics")
+        )
+    )
+    incoming: Path = field(
+        default_factory=lambda: Path(os.environ.get("DSA110_INCOMING", "/data/incoming"))
+    )
+    campaign_outputs: Path = field(
+        default_factory=lambda: Path(
+            os.environ.get(
+                "DSA110_CAMPAIGN_OUTPUTS",
+                "/data/dsa110-continuum/outputs/slowvis-mosaic-campaign-2026-07-14",
+            )
+        )
+    )
+    disk_roots: tuple[Path, ...] = (Path("/stage"), Path("/data"))
+
+    def __post_init__(self) -> None:
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", self.date):
+            raise ValueError(f"Invalid observing date: {self.date}")
+        try:
+            datetime.strptime(self.date, "%Y-%m-%d")
+        except ValueError as exc:
+            raise ValueError(f"Invalid observing date: {self.date}") from exc
+        if not 0 <= self.hour <= 23:
+            raise ValueError(f"Invalid observing hour: {self.hour}")
+
+
+def _file_record(path: Path | None) -> dict | None:
+    if path is None or not path.is_file():
+        return None
+    stat = path.stat()
+    return {
+        "path": str(path),
+        "size_bytes": stat.st_size,
+        "modified_utc": datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+    }
+
+
+def _latest(paths: list[Path]) -> Path | None:
+    files = [path for path in paths if path.is_file()]
+    return max(files, key=lambda path: path.stat().st_mtime) if files else None
+
+
+def _tail(path: Path | None, lines: int = 24) -> list[str]:
+    if path is None:
+        return []
+    try:
+        with path.open(errors="replace") as stream:
+            return [line.rstrip() for line in stream.readlines()[-lines:]]
+    except OSError as exc:
+        return [f"Unable to read {path}: {exc}"]
+
+
+def _process_status() -> list[dict]:
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid=,etimes=,stat=,args="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [{"error": str(exc)}]
+    matches = []
+    for line in result.stdout.splitlines():
+        lower = line.lower()
+        if not any(
+            marker in lower for marker in ("scripts/batch_pipeline", " wsclean ", " aoflagger ")
+        ):
+            continue
+        fields = line.strip().split(maxsplit=3)
+        if len(fields) == 4:
+            matches.append(
+                {
+                    "pid": int(fields[0]),
+                    "elapsed_seconds": int(fields[1]),
+                    "state": fields[2],
+                    "command": fields[3],
+                }
+            )
+    return matches
+
+
+def _pid_hints(directory: Path) -> list[dict]:
+    hints = []
+    if not directory.is_dir():
+        return hints
+    for path in sorted(directory.glob("*.pid")):
+        try:
+            content = path.read_text(errors="replace").strip()
+        except OSError:
+            continue
+        labelled = re.findall(r"([A-Z_]*PID)=(\d+)", content)
+        values = labelled or [
+            (path.stem.upper(), value) for value in re.findall(r"\b\d+\b", content)
+        ]
+        for label, raw_pid in values:
+            pid = int(raw_pid)
+            hints.append(
+                {
+                    "label": label,
+                    "pid": pid,
+                    "visible": Path(f"/proc/{pid}").exists(),
+                    "source": str(path),
+                }
+            )
+    return hints
+
+
+def _disk_status(paths: tuple[Path, ...]) -> dict:
+    disks = {}
+    for path in paths:
+        try:
+            usage = shutil.disk_usage(path)
+            disks[str(path)] = {
+                "total_bytes": usage.total,
+                "used_bytes": usage.used,
+                "free_bytes": usage.free,
+                "pct_used": round(usage.used / usage.total * 100, 1),
+            }
+        except OSError as exc:
+            disks[str(path)] = {"error": str(exc)}
+    return disks
+
+
+def collect_hour_state(config: HourStateConfig | None = None) -> dict:
+    """Return a bounded, read-only snapshot of one hourly-epoch campaign."""
+    config = config or HourStateConfig()
+    prefix = f"{config.date}T{config.hour:02d}"
+    ms_dir = config.stage / "ms"
+    image_dir = config.stage / f"images/mosaic_{config.date}"
+    product_dir = config.products / config.date
+
+    measurement_sets = sorted(ms_dir.glob(f"{prefix}:*.ms")) if ms_dir.is_dir() else []
+    bandpass = sorted(ms_dir.glob(f"{prefix}:*.b")) if ms_dir.is_dir() else []
+    gains = sorted(ms_dir.glob(f"{prefix}:*.g")) if ms_dir.is_dir() else []
+    tiles = sorted(image_dir.glob(f"{prefix}:*-image.fits")) if image_dir.is_dir() else []
+    mosaic = image_dir / f"{config.date}T{config.hour:02d}00_mosaic.fits"
+    incoming = (
+        sorted(config.incoming.glob(f"{prefix}:*_sb*.hdf5")) if config.incoming.is_dir() else []
+    )
+    logs = list(product_dir.glob("run_*.log")) if product_dir.is_dir() else []
+    if config.campaign_outputs.is_dir():
+        logs.extend(config.campaign_outputs.glob(f"batch_run_h{config.hour:02d}*.log"))
+        logs.extend(config.campaign_outputs.glob(f"batch_run_h{config.hour}*.log"))
+    latest_log = _latest(list(dict.fromkeys(logs)))
+
+    state = {
+        "date": config.date,
+        "hour": config.hour,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "campaign": {
+            "processes": _process_status(),
+            "pid_hints": _pid_hints(config.campaign_outputs),
+            "log": _file_record(latest_log),
+            "log_tail": _tail(latest_log),
+        },
+        "measurement_sets": {
+            "count": len(measurement_sets),
+            "paths": [str(path) for path in measurement_sets],
+        },
+        "calibration": {
+            "bandpass_count": len(bandpass),
+            "bandpass_paths": [str(path) for path in bandpass],
+            "gain_count": len(gains),
+            "gain_paths": [str(path) for path in gains],
+        },
+        "tiles": {
+            "count": len(tiles),
+            "latest": _file_record(_latest(tiles)),
+        },
+        "mosaic": _file_record(mosaic),
+        "incoming": {
+            "count": len(incoming),
+            "directory": str(config.incoming),
+            "latest": _file_record(_latest(incoming)),
+        },
+        "run_products": {
+            "manifest": _file_record(product_dir / f"{config.date}_manifest.json"),
+            "summary": _file_record(product_dir / f"{config.date}_run_summary.json"),
+            "report": _file_record(product_dir / "run_report.md"),
+        },
+        "disks": _disk_status(config.disk_roots),
+    }
+    process_visible = any("pid" in item for item in state["campaign"]["processes"])
+    pid_visible = any(item["visible"] for item in state["campaign"]["pid_hints"])
+    campaign_artifacts_present = state["campaign"]["log"] is not None or any(
+        state["run_products"].values()
+    )
+    campaign_state = (
+        "running"
+        if process_visible or pid_visible
+        else "finished"
+        if campaign_artifacts_present
+        else "absent"
+    )
+    state["campaign"]["state"] = campaign_state
+    state["summary"] = {
+        "campaign_state": campaign_state,
+        "campaign_process_visible": process_visible,
+        "campaign_pid_visible": pid_visible,
+        "measurement_sets_present": bool(measurement_sets),
+        "calibration_present": bool(bandpass and gains),
+        "tiles_present": bool(tiles),
+        "mosaic_present": state["mosaic"] is not None,
+        "incoming_hdf5_present": bool(incoming),
+    }
+    return state

--- a/dsa110_continuum/observability/hour_state.py
+++ b/dsa110_continuum/observability/hour_state.py
@@ -148,6 +148,12 @@ def _disk_status(paths: tuple[Path, ...]) -> dict:
     return disks
 
 
+def campaign_hour_logs(directory: Path, hour: int) -> list[Path]:
+    """Campaign logs whose filename hour equals `hour` (padded or unpadded form)."""
+    pattern = re.compile(rf"batch_run_h0?{hour}(?!\d)")
+    return sorted(path for path in directory.glob("batch_run_h*.log") if pattern.match(path.name))
+
+
 def collect_hour_state(config: HourStateConfig | None = None) -> dict:
     """Return a bounded, read-only snapshot of one hourly-epoch campaign."""
     config = config or HourStateConfig()
@@ -166,8 +172,7 @@ def collect_hour_state(config: HourStateConfig | None = None) -> dict:
     )
     logs = list(product_dir.glob("run_*.log")) if product_dir.is_dir() else []
     if config.campaign_outputs.is_dir():
-        logs.extend(config.campaign_outputs.glob(f"batch_run_h{config.hour:02d}*.log"))
-        logs.extend(config.campaign_outputs.glob(f"batch_run_h{config.hour}*.log"))
+        logs.extend(campaign_hour_logs(config.campaign_outputs, config.hour))
     latest_log = _latest(list(dict.fromkeys(logs)))
 
     state = {

--- a/dsa110_continuum/observability/mosaic_preview.py
+++ b/dsa110_continuum/observability/mosaic_preview.py
@@ -1,0 +1,240 @@
+"""Mosaic thumbnail URLs and same-origin Dagster static sync (read-only)."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+from dsa110_continuum.observability.hour_state import HourStateConfig
+
+# Durable copy under the observability output tree; start_dagster.sh also rsyncs here.
+DEFAULT_STATIC_ROOT = Path(
+    os.environ.get(
+        "DSA110_DAGSTER_STATIC",
+        "/data/dsa110-continuum/outputs/observability-dashboard-2026-07-14/dagster-static",
+    )
+)
+
+
+def epoch_label(hour: int) -> str:
+    """Return qa_server epoch token for an observing hour (e.g. 11 → T1100)."""
+    return f"T{hour:02d}00"
+
+
+def qa_base_url() -> str:
+    """Public base URL for qa_server thumbnails (localhost until Cloudflare QA is live)."""
+    return os.environ.get("DSA110_QA_BASE_URL", "http://127.0.0.1:8767").rstrip("/")
+
+
+def dagster_public_url() -> str:
+    """Browser-facing Dagster origin for same-origin preview links."""
+    host = os.environ.get("DSA110_DAGSTER_HOST", "127.0.0.1")
+    if host in ("0.0.0.0", "::"):
+        host = "127.0.0.1"
+    port = os.environ.get("DSA110_DAGSTER_PORT", "3212")
+    return os.environ.get("DSA110_DAGSTER_PUBLIC_URL", f"http://{host}:{port}").rstrip("/")
+
+
+def qa_thumb_url(date: str, hour: int, base: str | None = None) -> str:
+    """Return the qa_server PNG thumbnail URL for one hourly-epoch mosaic."""
+    root = (base or qa_base_url()).rstrip("/")
+    return f"{root}/artifacts/mosaic/{date}/{epoch_label(hour)}/thumb.png"
+
+
+def dagster_static_thumb_path(date: str, hour: int) -> str:
+    """Relative web path served from the Dagster webapp build."""
+    return f"/dsa110/{date}_{epoch_label(hour)}_mosaic_thumb.png"
+
+
+def dagster_static_page_path(date: str, hour: int) -> str:
+    """Relative web path for the lightweight mosaic preview HTML page."""
+    return f"/dsa110/{date}_{epoch_label(hour)}_mosaic.html"
+
+
+def resolve_thumb_source(config: HourStateConfig) -> Path | None:
+    """Pick an on-disk PNG for the selected hour without calling science code."""
+    epoch = epoch_label(config.hour)
+    mosaic_stem = f"{config.date}T{config.hour:02d}00_mosaic"
+    candidates = [
+        config.campaign_outputs / "previews" / f"{mosaic_stem}_qa_thumb.png",
+        Path("/data/dsa110-continuum/outputs/mosaic-thumb-2026-07-13") / f"{epoch}_thumb.png",
+        config.stage / f"images/mosaic_{config.date}" / f"{mosaic_stem}_qa_diag.png",
+    ]
+    for candidate in candidates:
+        if candidate.is_file() and candidate.stat().st_size > 0:
+            return candidate
+    thumb_dir = Path(os.environ.get("DSA110_QA_THUMBS", "/tmp/qa_thumbs"))
+    if thumb_dir.is_dir():
+        matches = sorted(
+            thumb_dir.glob(f"{config.date}_{epoch}_*.png"),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+        for match in matches:
+            if match.is_file() and match.stat().st_size > 0:
+                return match
+    return None
+
+
+def webapp_build_dir() -> Path | None:
+    """Locate the active dagster_webserver webapp/build directory."""
+    try:
+        import dagster_webserver
+    except ImportError:
+        return None
+    build = Path(dagster_webserver.__file__).resolve().parent / "webapp" / "build"
+    return build if build.is_dir() else None
+
+
+def _write_preview_html(
+    dest: Path,
+    *,
+    date: str,
+    hour: int,
+    thumb_href: str,
+    fits_path: str | None,
+    qa_url: str,
+) -> None:
+    epoch = epoch_label(hour)
+    fits_line = (
+        f"<p>FITS: <code>{fits_path}</code></p>" if fits_path else "<p>FITS: not visible</p>"
+    )
+    dest.write_text(
+        f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>{date} {epoch} mosaic — Dagster preview</title>
+  <style>
+    body {{ margin: 0; background: #111; color: #eee; font-family: system-ui, sans-serif; }}
+    header {{ padding: 12px 16px; border-bottom: 1px solid #333; }}
+    h1 {{ font-size: 16px; font-weight: 600; margin: 0 0 6px; }}
+    a {{ color: #79b8ff; }}
+    img {{ max-width: 100%; height: auto; display: block; margin: 16px auto; }}
+    main {{ padding: 0 16px 24px; }}
+    code {{ font-size: 12px; word-break: break-all; }}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Hourly-epoch mosaic preview — {date} {epoch}</h1>
+    <p>
+      <a href="/">Dagster home</a> ·
+      <a href="/asset-groups/hour_11_observability">hour_11_observability</a> ·
+      <a href="/assets/measurement_sets_tiles_mosaic">measurement_sets_tiles_mosaic</a> ·
+      <a href="./hour11_mosaic_cutout.html">Cutout benchmark</a> ·
+      <a href="{qa_url}">QA thumb (qa_server)</a>
+    </p>
+  </header>
+  <main>
+    {fits_line}
+    <img src="{thumb_href}" alt="{date} {epoch} mosaic thumbnail"/>
+    <p>Thumbnail source remains qa_server / on-disk PNG caches; this page is a Dagster-static mirror.</p>
+  </main>
+</body>
+</html>
+""",
+        encoding="utf-8",
+    )
+
+
+def sync_mosaic_thumb(
+    config: HourStateConfig,
+    *,
+    fits_path: str | None = None,
+    static_root: Path | None = None,
+) -> dict:
+    """Copy the hour mosaic PNG into Dagster-static paths and return URL metadata."""
+    date = config.date
+    hour = config.hour
+    epoch = epoch_label(hour)
+    qa_url = qa_thumb_url(date, hour)
+    rel_thumb = dagster_static_thumb_path(date, hour)
+    rel_page = dagster_static_page_path(date, hour)
+    public = dagster_public_url()
+    result = {
+        "epoch": epoch,
+        "qa_thumb_url": qa_url,
+        "dagster_thumb_url": f"{public}{rel_thumb}",
+        "dagster_page_url": f"{public}{rel_page}",
+        "dagster_thumb_path": rel_thumb,
+        "dagster_page_path": rel_page,
+        "source_path": None,
+        "synced": False,
+    }
+    source = resolve_thumb_source(config)
+    if source is None:
+        return result
+    result["source_path"] = str(source)
+
+    roots: list[Path] = []
+    durable = static_root or DEFAULT_STATIC_ROOT
+    roots.append(durable / "dsa110")
+    build = webapp_build_dir()
+    if build is not None:
+        roots.append(build / "dsa110")
+
+    thumb_name = Path(rel_thumb).name
+    page_name = Path(rel_page).name
+    for root in roots:
+        root.mkdir(parents=True, exist_ok=True)
+        dest_thumb = root / thumb_name
+        shutil.copy2(source, dest_thumb)
+        _write_preview_html(
+            root / page_name,
+            date=date,
+            hour=hour,
+            thumb_href=f"./{thumb_name}",
+            fits_path=fits_path,
+            qa_url=qa_url,
+        )
+        # Stable aliases for the default hour-11 campaign.
+        if date == "2026-07-13" and hour == 11:
+            shutil.copy2(dest_thumb, root / "hour11_mosaic_thumb.png")
+            _write_preview_html(
+                root / "hour11_mosaic.html",
+                date=date,
+                hour=hour,
+                thumb_href="./hour11_mosaic_thumb.png",
+                fits_path=fits_path,
+                qa_url=qa_url,
+            )
+    result["synced"] = True
+    return result
+
+
+def mosaic_preview_markdown(preview: dict, *, mosaic_path: str | None) -> str:
+    """Markdown block shown in Dagster asset metadata (inline thumb when synced)."""
+    lines = [
+        f"### Hourly-epoch mosaic — `{preview['epoch']}`",
+        "",
+    ]
+    if mosaic_path:
+        lines.append(f"- FITS: `{mosaic_path}`")
+    lines.append(f"- [QA thumbnail (qa_server)]({preview['qa_thumb_url']})")
+    lines.append(f"- [Dagster preview page]({preview['dagster_page_url']})")
+    if preview.get("synced"):
+        lines.extend(
+            [
+                "",
+                f"![mosaic thumbnail]({preview['dagster_thumb_url']})",
+                "",
+                "_Same-origin Dagster-static PNG. Remote browsers: use qa_server / Tailscale; "
+                "`dsa110-continuum.jakobtfaber.com` is not assumed live._",
+            ]
+        )
+    elif preview.get("qa_thumb_url"):
+        lines.extend(
+            [
+                "",
+                f"![mosaic thumbnail]({preview['qa_thumb_url']})",
+                "",
+                "_Inline image from qa_server (`DSA110_QA_BASE_URL`). Requires :8767 reachable "
+                "from the browser viewing Dagster._",
+            ]
+        )
+    else:
+        lines.append("")
+        lines.append("_No mosaic thumbnail source found on disk._")
+    return "\n".join(lines)

--- a/ops/systemd/dsa110-autopipeline.service
+++ b/ops/systemd/dsa110-autopipeline.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=DSA-110 continuum daily batch pipeline launcher
+
+[Service]
+Type=oneshot
+User=ubuntu
+WorkingDirectory=/data/dsa110-continuum
+Environment=PYTHONPATH=/data/dsa110-continuum
+ExecStart=/opt/miniforge/envs/casa6/bin/python scripts/auto_pipeline.py

--- a/ops/systemd/dsa110-autopipeline.timer
+++ b/ops/systemd/dsa110-autopipeline.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Launch the DSA-110 batch pipeline daily at 02:00 UTC
+
+[Timer]
+OnCalendar=*-*-* 02:00:00 UTC
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/ops/systemd/dsa110-dashboard.service
+++ b/ops/systemd/dsa110-dashboard.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=DSA-110 continuum QA dashboard (qa_server, port 8767)
+After=network.target
+
+[Service]
+User=ubuntu
+WorkingDirectory=/data/dsa110-continuum
+Environment=PYTHONPATH=/data/dsa110-continuum
+EnvironmentFile=-/data/dsa110-proc/products/control/dashboard.env
+ExecStart=/opt/miniforge/envs/casa6/bin/python -m uvicorn scripts.qa_server:app --host 0.0.0.0 --port 8767 --log-level warning
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/dsa110-dashboard.service
+++ b/ops/systemd/dsa110-dashboard.service
@@ -6,7 +6,7 @@ After=network.target
 User=ubuntu
 WorkingDirectory=/data/dsa110-continuum
 Environment=PYTHONPATH=/data/dsa110-continuum
-EnvironmentFile=-/data/dsa110-proc/products/control/dashboard.env
+EnvironmentFile=-/home/ubuntu/.config/dsa110/dashboard.env
 ExecStart=/opt/miniforge/envs/casa6/bin/python -m uvicorn scripts.qa_server:app --host 0.0.0.0 --port 8767 --log-level warning
 Restart=on-failure
 RestartSec=10

--- a/scripts/auto_pipeline.py
+++ b/scripts/auto_pipeline.py
@@ -1,0 +1,52 @@
+"""Scheduled entrypoint: launch a date's batch pipeline via the control registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from dsa110_continuum.observability.control import (  # noqa: E402
+    ControlConfig,
+    RunConflictError,
+    RunRequest,
+    launch_run,
+)
+
+
+def decide_and_launch(date: str, config: ControlConfig | None = None) -> dict:
+    """Launch the batch pipeline for one date unless a run is already active."""
+    config = config or ControlConfig()
+    try:
+        request = RunRequest(
+            date=date, retry_failed=True, quarantine_after_failures=3, photometry_workers=4
+        )
+    except ValueError as exc:
+        return {"action": "invalid_request", "detail": str(exc)}
+    try:
+        record = launch_run(request, config)
+    except RunConflictError as exc:
+        return {"action": "skipped_running", "detail": str(exc)}
+    return {"action": "launched", "run_id": record["run_id"], "pid": record["pid"]}
+
+
+def main() -> int:
+    """CLI entrypoint for cron/systemd."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--date",
+        default=(datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d"),
+        help="Observation date to process (default: yesterday UTC).",
+    )
+    arguments = parser.parse_args()
+    outcome = decide_and_launch(arguments.date)
+    print(json.dumps(outcome))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -24,6 +24,7 @@ import numpy as np
 import pandas as pd
 from astropy.io import fits
 from dsa110_continuum.observability import control as pipeline_control
+from dsa110_continuum.observability.hour_state import campaign_hour_logs
 from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 from matplotlib.colors import PowerNorm
@@ -121,7 +122,10 @@ def lightcurve_points(
         except Exception as exc:
             logger.warning("Lightcurve CSV error %s: %s", csv_path, exc)
             continue
-        if not {"ra_deg", "dec_deg", "dsa_peak_jyb"}.issubset(frame.columns) or not len(frame):
+        if not {"ra_deg", "dec_deg", "dsa_peak_jyb"}.issubset(frame.columns):
+            continue
+        frame = frame[np.isfinite(frame["dsa_peak_jyb"])]
+        if not len(frame):
             continue
         separation = np.hypot((frame["ra_deg"] - ra_deg) * cos_dec, frame["dec_deg"] - dec_deg)
         index = separation.idxmin()
@@ -400,8 +404,7 @@ def campaign_status(config: DashboardConfig, date: str, hour: int) -> dict:
     )
     logs = list(product_dir.glob("run_*.log")) if product_dir.is_dir() else []
     if config.campaign_outputs.is_dir():
-        logs.extend(config.campaign_outputs.glob(f"batch_run_h{hour:02d}*.log"))
-        logs.extend(config.campaign_outputs.glob(f"batch_run_h{hour}*.log"))
+        logs.extend(campaign_hour_logs(config.campaign_outputs, hour))
     latest_log = _latest(list(dict.fromkeys(logs)))
     manifest = product_dir / f"{date}_manifest.json"
     summary = product_dir / f"{date}_run_summary.json"

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -99,6 +99,23 @@ def cal_tables(config: DashboardConfig) -> set[str]:
     return {path.stem.split("_")[0] for path in directory.glob("*.b")}
 
 
+MOSAIC_NAME_RE = re.compile(r"(\d{4}-\d{2}-\d{2})(T\d{4})_mosaic\.fits")
+
+
+def discover_epochs(config: DashboardConfig, limit: int = 24) -> list[tuple[str, str]]:
+    """List (date, epoch) for every hourly-epoch mosaic on stage, newest first."""
+    root = config.stage / "images"
+    found = []
+    if root.is_dir():
+        for path in root.glob("mosaic_*/*_mosaic.fits"):
+            match = MOSAIC_NAME_RE.fullmatch(path.name)
+            if match:
+                found.append((path.stat().st_mtime, match.group(1), match.group(2)))
+    found.sort(reverse=True)
+    discovered = [(date, epoch) for _, date, epoch in found[:limit]]
+    return discovered or EPOCHS
+
+
 def get_metrics(config: DashboardConfig, date: str, epoch: str) -> dict:
     """Measure the legacy QA fields for one hourly-epoch mosaic."""
     fits_path = find_mosaic(config, date, epoch)
@@ -408,9 +425,118 @@ def _ratio_cell(ratio) -> str:
     return f'<span style="color:{color};font-weight:700">{ratio:.3f}</span>'
 
 
+_CONTROL_SCRIPT = """<script>
+function controlToken(){return document.getElementById("control-token").value.trim();}
+function showOutput(text){document.getElementById("run-output").textContent=text;}
+async function postRuns(dryRun){
+  const form=document.getElementById("run-form");
+  const body={date:form.date.value,dry_run:dryRun};
+  if(form.cal_date.value)body.cal_date=form.cal_date.value;
+  if(form.start_hour.value)body.start_hour=parseInt(form.start_hour.value,10);
+  if(form.end_hour.value)body.end_hour=parseInt(form.end_hour.value,10);
+  if(form.rfi_mode.value)body.rfi_mode=form.rfi_mode.value;
+  for(const name of["retry_failed","force_recal","skip_photometry","lenient_qa","clear_quarantine"]){
+    if(form[name].checked)body[name]=true;
+  }
+  showOutput("Submitting...");
+  try{
+    const response=await fetch("/api/runs",{method:"POST",
+      headers:{"Content-Type":"application/json","Authorization":"Bearer "+controlToken()},
+      body:JSON.stringify(body)});
+    const payload=await response.json();
+    if(!response.ok){showOutput("Error "+response.status+": "+JSON.stringify(payload.detail));return;}
+    showOutput(payload.plan?payload.plan:JSON.stringify(payload,null,2));
+    if(!dryRun)setTimeout(()=>location.reload(),1500);
+  }catch(error){showOutput("Request failed: "+error);}
+}
+async function terminateRun(runId){
+  if(!confirm("Terminate run "+runId+"?"))return;
+  try{
+    const response=await fetch("/api/runs/"+runId+"/terminate",{method:"POST",
+      headers:{"Authorization":"Bearer "+controlToken()}});
+    const payload=await response.json();
+    if(!response.ok){showOutput("Error "+response.status+": "+JSON.stringify(payload.detail));return;}
+    showOutput(JSON.stringify(payload,null,2));
+    setTimeout(()=>location.reload(),1500);
+  }catch(error){showOutput("Request failed: "+error);}
+}
+</script>"""
+
+
+def _render_control_section() -> str:
+    """Render the pipeline-control panel: recent runs table + launch form."""
+    try:
+        runs = pipeline_control.list_runs(pipeline_control.ControlConfig(), limit=10)
+    except Exception as exc:
+        logger.warning("Run registry unavailable: %s", exc)
+        runs = []
+    if runs:
+        run_rows = []
+        for run in runs:
+            state_key = {
+                "running": "active",
+                "succeeded": "pass",
+                "failed": "fail",
+                "terminated": "not_yet",
+                "orphaned": "missing",
+            }.get(run["status"], "missing")
+            exit_code = run["exit_code"] if run["exit_code"] is not None else "—"
+            action = (
+                f"<button onclick=\"terminateRun('{html.escape(run['run_id'])}')\">"
+                "Terminate</button>"
+                if run["status"] == "running"
+                else ""
+            )
+            run_rows.append(
+                f'<tr><td><a href="/control/runs/{html.escape(run["run_id"])}">'
+                f"{html.escape(run['run_id'])}</a></td>"
+                f"<td>{_badge(state_key, run['status'])}</td>"
+                f"<td>{html.escape(run['created_at'][:19])}</td>"
+                f"<td>{exit_code}</td><td>{action}</td></tr>"
+            )
+        runs_table = (
+            '<div class="table-wrap"><table><thead><tr><th>Run</th><th>Status</th>'
+            "<th>Started (UTC)</th><th>Exit</th><th></th></tr></thead>"
+            f"<tbody>{''.join(run_rows)}</tbody></table></div>"
+        )
+    else:
+        runs_table = '<p class="empty-row">No launcher-owned runs recorded yet.</p>'
+    form = """
+<form id="run-form" onsubmit="return false" style="margin-top:14px">
+<div class="info-grid">
+<div class="info-card"><span>Date</span><input name="date" required pattern="\\d{4}-\\d{2}-\\d{2}" placeholder="YYYY-MM-DD"></div>
+<div class="info-card"><span>Cal date</span><input name="cal_date" pattern="\\d{4}-\\d{2}-\\d{2}" placeholder="optional"></div>
+<div class="info-card"><span>Hours</span><input name="start_hour" type="number" min="0" max="23" placeholder="start" style="width:45%">
+<input name="end_hour" type="number" min="0" max="23" placeholder="end" style="width:45%"></div>
+<div class="info-card"><span>RFI mode</span><select name="rfi_mode"><option value="">default</option><option>full</option><option>conditional</option><option>off</option></select></div>
+</div>
+<div style="margin:10px 0;display:flex;gap:16px;flex-wrap:wrap;font-size:.8rem">
+<label><input type="checkbox" name="retry_failed"> retry failed</label>
+<label><input type="checkbox" name="force_recal"> force recal</label>
+<label><input type="checkbox" name="skip_photometry"> skip photometry</label>
+<label><input type="checkbox" name="lenient_qa"> lenient QA</label>
+<label><input type="checkbox" name="clear_quarantine"> clear quarantine</label>
+</div>
+<div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap">
+<input id="control-token" type="password" placeholder="control token" autocomplete="off">
+<button onclick="postRuns(true)">Dry-run preview</button>
+<button onclick="postRuns(false)" style="background:#274b63">Launch</button>
+</div>
+</form>
+<pre id="run-output" style="margin-top:12px;min-height:40px"></pre>"""
+    return (
+        '<section class="campaign"><div class="campaign-head"><div>'
+        "<h2>Pipeline control</h2>"
+        "<p>Launch or re-run batch_pipeline.py — token required for mutating actions; "
+        "dry-run preview shows the execution plan without writing anything</p></div></div>"
+        f"{runs_table}{form}{_CONTROL_SCRIPT}</section>"
+    )
+
+
 def render_dashboard(config: DashboardConfig) -> str:
     """Render the consolidated QA and operations dashboard."""
-    all_metrics = [get_metrics(config, date, epoch) for date, epoch in EPOCHS]
+    epochs = discover_epochs(config)
+    all_metrics = [get_metrics(config, date, epoch) for date, epoch in epochs]
     cals = cal_tables(config)
     campaign = campaign_status(config, config.campaign_date, config.campaign_hour)
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -488,6 +614,7 @@ def render_dashboard(config: DashboardConfig) -> str:
     run_summary = campaign["run_products"]["summary"]
     run_summary_path = run_summary["path"] if run_summary else "Not yet produced"
     incoming = campaign["incoming"]
+    control_section = _render_control_section()
 
     return f"""<!DOCTYPE html>
 <html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -511,7 +638,7 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;margin:0;ma
 .table-wrap{{overflow:auto;border:1px solid var(--line);border-radius:9px}} table{{width:100%;border-collapse:collapse;font-size:.82rem}} th,td{{padding:10px 12px;text-align:center;border-bottom:1px solid var(--line);white-space:nowrap}} th{{background:#171b20;color:#9da8b4;font-weight:600}} td:first-child{{text-align:left}} td small{{display:block;color:var(--muted);margin-top:2px}} tr:last-child td{{border:0}} tr:hover{{background:#14191f}}
 .grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px}} .mosaic-card{{background:var(--panel);border:1px solid var(--line);border-radius:9px;overflow:hidden}} .mosaic-card header,.mosaic-card footer{{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 12px}} .mosaic-card img{{display:block;width:100%;min-height:140px;object-fit:cover;background:#090b0e}} .mosaic-card footer{{font-size:.75rem;color:#aeb7c0;flex-wrap:wrap}} .empty{{display:grid;place-items:center;min-height:140px;background:#101318;color:#5d6670}} .empty-row{{color:var(--muted)}}
 @media(max-width:850px){{.stage-grid,.info-grid{{grid-template-columns:repeat(2,1fr)}}.ops-grid{{grid-template-columns:1fr}}}} @media(max-width:560px){{.shell{{padding:16px}}.summary,.stage-grid,.info-grid{{grid-template-columns:1fr 1fr}}.grid{{grid-template-columns:1fr}}}}
-</style><script>setTimeout(()=>location.reload(),30000)</script></head>
+</style><script>setTimeout(()=>{{const token=document.getElementById("control-token");if(!token||!token.value)location.reload();}},30000)</script></head>
 <body><main class="shell"><h1>DSA-110 Continuum Observatory</h1><div class="subtitle">Updated {now} · auto-refresh 30s · read-only</div>
 <section class="campaign"><div class="campaign-head"><div><h2>Active campaign · {campaign["date"]} hour {campaign["hour"]:02d}</h2><p>Hourly-epoch mosaic progress from incoming HDF5 through science products</p></div>{_badge("active" if processes else "not_yet", "process visible" if processes else ("PID recorded" if campaign["pid_hints"] else "process not visible"))}</div>
 <div class="stage-grid">{"".join(stage_cards)}</div><div class="info-grid">{"".join(disk_cards)}
@@ -522,7 +649,8 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;margin:0;ma
 <div class="info-card"><span>Run summary</span><strong>{"available" if run_summary else "not yet"}</strong><small class="path">{html.escape(run_summary_path)}</small></div></div>
 <div class="ops-grid"><div class="panel"><h3>Pipeline heartbeat</h3><ul class="process-list">{process_rows}</ul></div>
 <div class="panel"><h3>Latest batch log</h3><div class="log-path">{log_title}</div><pre>{log_tail}</pre></div></div></section>
-<section><h2>Historical hourly-epoch QA</h2><div class="summary"><div class="stat"><strong style="color:#41c97a">{n_pass}</strong><span>Pass</span></div><div class="stat"><strong style="color:#ff6470">{n_fail}</strong><span>Fail</span></div><div class="stat"><strong style="color:#d99b35">{n_missing}</strong><span>Missing / pending photometry</span></div><div class="stat"><strong>{len(EPOCHS)}</strong><span>Total</span></div></div>
+{control_section}
+<section><h2>Historical hourly-epoch QA</h2><div class="summary"><div class="stat"><strong style="color:#41c97a">{n_pass}</strong><span>Pass</span></div><div class="stat"><strong style="color:#ff6470">{n_fail}</strong><span>Fail</span></div><div class="stat"><strong style="color:#d99b35">{n_missing}</strong><span>Missing / pending photometry</span></div><div class="stat"><strong>{len(epochs)}</strong><span>Total</span></div></div>
 <div class="table-wrap"><table><thead><tr><th>Date</th><th>Status</th><th>Cal tables</th><th>Peak (Jy)</th><th>RMS (mJy)</th><th>Dyn range</th><th>DSA/NVSS</th><th>Bright sources</th></tr></thead><tbody>{"".join(rows)}</tbody></table></div></section>
 <section><h2>Mosaic thumbnails</h2><div class="grid">{"".join(cards)}</div></section></main></body></html>"""
 
@@ -585,6 +713,8 @@ def control_list_runs():
 def control_get_run(run_id: str, tail: int = 40):
     """Return one run's registry record plus a bounded log tail (read-only)."""
     config = pipeline_control.ControlConfig()
+    if not config.db_path.is_file():
+        raise HTTPException(status_code=404, detail="unknown run")
     try:
         record = pipeline_control.get_run(run_id, config)
     except KeyError:
@@ -613,6 +743,54 @@ def control_launch(body: RunRequestBody, request: Request):
         return pipeline_control.launch_run(run_request, config)
     except pipeline_control.RunConflictError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from None
+
+
+control_page_router = APIRouter(include_in_schema=False)
+
+
+@control_page_router.get("/control/runs/{run_id}", response_class=HTMLResponse)
+def control_run_page(run_id: str):
+    """Render one launcher-owned run: registry record plus escaped log tail."""
+    config = pipeline_control.ControlConfig()
+    if not config.db_path.is_file():
+        raise HTTPException(status_code=404, detail="run registry unavailable")
+    try:
+        record = pipeline_control.get_run(run_id, config)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="unknown run") from None
+    state_key = {
+        "running": "active",
+        "succeeded": "pass",
+        "failed": "fail",
+        "terminated": "not_yet",
+        "orphaned": "missing",
+    }.get(record["status"], "missing")
+    log_tail = html.escape("".join(_tail(Path(record["log_path"]), 200)) or "No log output yet")
+    argv = html.escape(" ".join(json.loads(record["argv_json"])))
+    finished = record["finished_at"] or "—"
+    exit_code = record["exit_code"] if record["exit_code"] is not None else "—"
+    return HTMLResponse(
+        f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Run {html.escape(run_id)}</title>
+<style>body{{background:#0d1014;color:#e8edf2;font-family:Inter,-apple-system,sans-serif;margin:0}}
+.shell{{max-width:1100px;margin:auto;padding:22px}} a{{color:#4eb8ff}}
+table{{border-collapse:collapse;font-size:.85rem;margin:14px 0}} td,th{{padding:7px 14px;border-bottom:1px solid #2a3038;text-align:left}}
+.badge{{display:inline-block;background:var(--badge);color:#081014;padding:3px 8px;border-radius:999px;font-size:.68rem;font-weight:800}}
+pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;max-height:560px;overflow:auto;font-size:.74rem;line-height:1.45;white-space:pre-wrap}}</style>
+<script>setTimeout(()=>location.reload(),15000)</script></head>
+<body><main class="shell"><p><a href="/">← Dashboard</a></p>
+<h1>Run {html.escape(run_id)}</h1>
+<table>
+<tr><th>Status</th><td>{_badge(state_key, record["status"])}</td></tr>
+<tr><th>Started (UTC)</th><td>{html.escape(record["created_at"])}</td></tr>
+<tr><th>Finished (UTC)</th><td>{html.escape(str(finished))}</td></tr>
+<tr><th>Exit code</th><td>{exit_code}</td></tr>
+<tr><th>Command</th><td><code>{argv}</code></td></tr>
+<tr><th>Log file</th><td><code>{html.escape(record["log_path"])}</code></td></tr>
+</table>
+<h2>Log tail</h2><pre>{log_tail}</pre></main></body></html>"""
+    )
 
 
 @control_router.post("/{run_id}/terminate")
@@ -676,6 +854,7 @@ def create_app(config: DashboardConfig | None = None) -> FastAPI:
     application.include_router(mosaic_router)
     application.include_router(ops_router)
     application.include_router(control_router)
+    application.include_router(control_page_router)
     application.include_router(legacy_router)
 
     @application.get("/", response_class=HTMLResponse)

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -767,7 +767,12 @@ class RunRequestBody(BaseModel):
 def _require_control_token(request: Request) -> None:
     expected = os.environ.get(CONTROL_TOKEN_ENV, "")
     provided = request.headers.get("authorization", "").removeprefix("Bearer ").strip()
-    if not expected or not secrets.compare_digest(provided, expected):
+    try:
+        authorized = bool(expected) and secrets.compare_digest(provided, expected)
+    except TypeError:
+        # compare_digest rejects non-ASCII str (headers decode as latin-1)
+        authorized = False
+    if not authorized:
         raise HTTPException(status_code=403, detail="control token missing or invalid")
 
 

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import html
+import json
 import logging
 import os
 import re
+import secrets
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -21,9 +23,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from astropy.io import fits
+from dsa110_continuum.observability import control as pipeline_control
 from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 from matplotlib.colors import PowerNorm
+from pydantic import BaseModel
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -526,6 +530,103 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;margin:0;ma
 mosaic_router = APIRouter(prefix="/artifacts/mosaic", tags=["mosaic artifacts"])
 ops_router = APIRouter(prefix="/api", tags=["read-only operations"])
 legacy_router = APIRouter(include_in_schema=False)
+control_router = APIRouter(prefix="/api/runs", tags=["pipeline control"])
+
+CONTROL_TOKEN_ENV = "DSA110_CONTROL_TOKEN"
+
+
+class RunRequestBody(BaseModel):
+    """JSON body for launching or previewing a batch_pipeline run."""
+
+    date: str
+    cal_date: str | None = None
+    start_hour: int | None = None
+    end_hour: int | None = None
+    rfi_mode: str | None = None
+    tile_timeout: int | None = None
+    quarantine_after_failures: int | None = None
+    photometry_workers: int | None = None
+    retry_failed: bool = False
+    force_recal: bool = False
+    skip_photometry: bool = False
+    lenient_qa: bool = False
+    clear_quarantine: bool = False
+    dry_run: bool = False
+
+
+def _require_control_token(request: Request) -> None:
+    expected = os.environ.get(CONTROL_TOKEN_ENV, "")
+    provided = request.headers.get("authorization", "").removeprefix("Bearer ").strip()
+    if not expected or not secrets.compare_digest(provided, expected):
+        raise HTTPException(status_code=403, detail="control token missing or invalid")
+
+
+def _audit(
+    config: pipeline_control.ControlConfig, action: str, request: Request, payload: dict
+) -> None:
+    config.control_dir.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "time": datetime.now(timezone.utc).isoformat(),
+        "action": action,
+        "remote": request.client.host if request.client else None,
+        "payload": payload,
+    }
+    with (config.control_dir / "audit.jsonl").open("a") as stream:
+        stream.write(json.dumps(entry) + "\n")
+
+
+@control_router.get("")
+def control_list_runs():
+    """List the newest launcher-owned pipeline runs (read-only)."""
+    return {"runs": pipeline_control.list_runs(pipeline_control.ControlConfig())}
+
+
+@control_router.get("/{run_id}")
+def control_get_run(run_id: str, tail: int = 40):
+    """Return one run's registry record plus a bounded log tail (read-only)."""
+    config = pipeline_control.ControlConfig()
+    try:
+        record = pipeline_control.get_run(run_id, config)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="unknown run") from None
+    record["log_tail"] = _tail(Path(record["log_path"]), max(1, min(tail, 500)))
+    return record
+
+
+@control_router.post("")
+def control_launch(body: RunRequestBody, request: Request):
+    """Launch batch_pipeline.py (or preview with dry_run) — token required."""
+    _require_control_token(request)
+    config = pipeline_control.ControlConfig()
+    try:
+        run_request = pipeline_control.RunRequest(**body.model_dump())
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    _audit(config, "dry_run" if body.dry_run else "launch", request, body.model_dump())
+    if body.dry_run:
+        try:
+            plan = pipeline_control.run_dry_run(run_request, config)
+        except subprocess.TimeoutExpired:
+            raise HTTPException(status_code=504, detail="dry-run timed out") from None
+        return {"plan": plan}
+    try:
+        return pipeline_control.launch_run(run_request, config)
+    except pipeline_control.RunConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
+
+
+@control_router.post("/{run_id}/terminate")
+def control_terminate(run_id: str, request: Request):
+    """Terminate a running pipeline run's whole process group — token required."""
+    _require_control_token(request)
+    config = pipeline_control.ControlConfig()
+    _audit(config, "terminate", request, {"run_id": run_id})
+    try:
+        return pipeline_control.terminate_run(run_id, config)
+    except KeyError:
+        raise HTTPException(status_code=404, detail="unknown run") from None
+    except pipeline_control.RunConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from None
 
 
 @mosaic_router.get("/{date}/{epoch}/status")
@@ -574,6 +675,7 @@ def create_app(config: DashboardConfig | None = None) -> FastAPI:
     application.state.dashboard_config = dashboard_config
     application.include_router(mosaic_router)
     application.include_router(ops_router)
+    application.include_router(control_router)
     application.include_router(legacy_router)
 
     @application.get("/", response_class=HTMLResponse)

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -1,34 +1,53 @@
-"""
-DSA-110 Continuum Pipeline QA Server
-Serves a live dashboard at http://lxd110h17:8767
-"""
-import glob, os, hashlib, logging
-from pathlib import Path
-from datetime import datetime
-from typing import Optional
+"""DSA-110 continuum QA and operations dashboard."""
 
+from __future__ import annotations
+
+import hashlib
+import html
+import logging
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-from matplotlib.colors import PowerNorm
 from astropy.io import fits
-
-from fastapi import FastAPI, Response
+from fastapi import APIRouter, FastAPI, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
-import uvicorn
+from matplotlib.colors import PowerNorm
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="DSA-110 QA Dashboard")
 
-# Paths
-STAGE       = Path("/stage/dsa110-contimg")
-PRODUCTS    = Path(os.environ.get("DSA110_PRODUCTS_BASE", "/data/dsa110-proc/products/mosaics"))
-THUMB_DIR   = Path("/tmp/qa_thumbs")
-THUMB_DIR.mkdir(exist_ok=True)
+@dataclass(frozen=True)
+class DashboardConfig:
+    """Filesystem and campaign settings for one dashboard instance."""
+
+    stage: Path = Path(os.environ.get("DSA110_STAGE", "/stage/dsa110-contimg"))
+    products: Path = Path(
+        os.environ.get("DSA110_PRODUCTS_BASE", "/data/dsa110-proc/products/mosaics")
+    )
+    incoming: Path = Path(os.environ.get("DSA110_INCOMING", "/data/incoming"))
+    thumb_dir: Path = Path(os.environ.get("DSA110_QA_THUMBS", "/tmp/qa_thumbs"))
+    campaign_outputs: Path = Path(
+        os.environ.get(
+            "DSA110_CAMPAIGN_OUTPUTS",
+            "/data/dsa110-continuum/outputs/slowvis-mosaic-campaign-2026-07-14",
+        )
+    )
+    campaign_date: str = os.environ.get("DSA110_CAMPAIGN_DATE", "2026-07-13")
+    campaign_hour: int = int(os.environ.get("DSA110_CAMPAIGN_HOUR", "11"))
+
 
 EPOCHS = [
     ("2026-01-25", "T0200"),
@@ -39,172 +58,539 @@ EPOCHS = [
     ("2026-02-26", "T0000"),
 ]
 
-def find_mosaic(date, epoch):
-    p = STAGE / f"images/mosaic_{date}" / f"{date}{epoch}_mosaic.fits"
-    return p if p.exists() else None
+DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+EPOCH_RE = re.compile(r"T\d{4}")
+PROCESS_NAMES = ("batch_pipeline.py", "wsclean", "aoflagger")
 
-def find_csv(date, epoch):
-    d = PRODUCTS / date
-    if not d.exists(): return None
-    matches = sorted(d.glob(f"*{epoch}*phot.csv"))
+
+def _config(request: Request) -> DashboardConfig:
+    return request.app.state.dashboard_config
+
+
+def _validate_date_epoch(date: str, epoch: str | None = None) -> None:
+    if not DATE_RE.fullmatch(date) or (epoch is not None and not EPOCH_RE.fullmatch(epoch)):
+        raise HTTPException(status_code=400, detail="Invalid date or epoch")
+
+
+def find_mosaic(config: DashboardConfig, date: str, epoch: str) -> Path | None:
+    """Return the canonical hourly-epoch mosaic path when it exists."""
+    path = config.stage / f"images/mosaic_{date}" / f"{date}{epoch}_mosaic.fits"
+    return path if path.is_file() else None
+
+
+def find_csv(config: DashboardConfig, date: str, epoch: str) -> Path | None:
+    """Return the newest matching forced-photometry table when present."""
+    directory = config.products / date
+    if not directory.is_dir():
+        return None
+    matches = sorted(directory.glob(f"*{epoch}*phot.csv"))
     return matches[-1] if matches else None
 
-def cal_tables():
-    bs = {Path(p).stem.split("_")[0] for p in glob.glob(str(STAGE/"ms/*.b"))}
-    return bs  # set of date strings like "2026-02-12T22:26:05"
 
-def get_metrics(date, epoch):
-    fits_p = find_mosaic(date, epoch)
-    csv_p  = find_csv(date, epoch)
-    m = dict(date=date, epoch=epoch, fits=fits_p is not None, csv=csv_p is not None,
-             peak=None, rms=None, dr=None, ratio=None, n_bright=0, status="missing")
-    if not fits_p: return m
+def cal_tables(config: DashboardConfig) -> set[str]:
+    """Return the observation prefixes with bandpass tables."""
+    directory = config.stage / "ms"
+    if not directory.is_dir():
+        return set()
+    return {path.stem.split("_")[0] for path in directory.glob("*.b")}
+
+
+def get_metrics(config: DashboardConfig, date: str, epoch: str) -> dict:
+    """Measure the legacy QA fields for one hourly-epoch mosaic."""
+    fits_path = find_mosaic(config, date, epoch)
+    csv_path = find_csv(config, date, epoch)
+    metrics = {
+        "date": date,
+        "epoch": epoch,
+        "fits": fits_path is not None,
+        "csv": csv_path is not None,
+        "mosaic_path": str(fits_path) if fits_path else None,
+        "photometry_path": str(csv_path) if csv_path else None,
+        "thumbnail_url": f"/artifacts/mosaic/{date}/{epoch}/thumb.png",
+        "peak": None,
+        "rms": None,
+        "dr": None,
+        "ratio": None,
+        "n_bright": 0,
+        "status": "missing",
+    }
+    if not fits_path:
+        return metrics
     try:
-        d = fits.open(fits_p)[0].data.squeeze().astype(np.float32)
-        m["peak"] = float(np.nanmax(d))
-        m["rms"]  = float(np.nanstd(d[np.abs(d) < 0.05])) * 1000
-        m["dr"]   = m["peak"] / (m["rms"] / 1000) if m["rms"] else None
-    except Exception as e:
-        logger.warning(f"FITS error {date}: {e}")
-    if csv_p:
+        with fits.open(fits_path, memmap=True) as hdus:
+            data = hdus[0].data.squeeze().astype(np.float32)
+        finite = data[np.isfinite(data)]
+        metrics["peak"] = float(np.nanmax(finite)) if finite.size else None
+        background = data[np.isfinite(data) & (np.abs(data) < 0.05)]
+        metrics["rms"] = float(np.nanstd(background)) * 1000 if background.size else None
+        if metrics["peak"] is not None and metrics["rms"]:
+            metrics["dr"] = metrics["peak"] / (metrics["rms"] / 1000)
+    except Exception as exc:
+        logger.warning("FITS error %s %s: %s", date, epoch, exc)
+    if csv_path:
         try:
-            df = pd.read_csv(csv_p)
-            bright = df[df.get("nvss_flux_jy", pd.Series(dtype=float)) > 0.06]
-            m["n_bright"] = len(bright)
-            if len(bright):
-                m["ratio"] = float(bright["dsa_nvss_ratio"].median())
-        except Exception as e:
-            logger.warning(f"CSV error {date}: {e}")
-    r = m["ratio"]
-    if r is not None and not np.isnan(r):
-        m["status"] = "pass" if 0.8 <= r <= 1.2 else "fail"
-    elif m["fits"]:
-        m["status"] = "no_phot"
-    return m
+            frame = pd.read_csv(csv_path)
+            flux = frame.get("nvss_flux_jy", pd.Series(index=frame.index, dtype=float))
+            bright = frame[flux > 0.06]
+            metrics["n_bright"] = len(bright)
+            if len(bright) and "dsa_nvss_ratio" in bright:
+                metrics["ratio"] = float(bright["dsa_nvss_ratio"].median())
+        except Exception as exc:
+            logger.warning("CSV error %s %s: %s", date, epoch, exc)
+    ratio = metrics["ratio"]
+    if ratio is not None and not np.isfinite(ratio):
+        metrics["ratio"] = None
+        ratio = None
+    if ratio is not None:
+        metrics["status"] = "pass" if 0.8 <= ratio <= 1.2 else "fail"
+    else:
+        metrics["status"] = "no_phot"
+    return metrics
 
-def make_thumbnail(date, epoch):
-    fits_p = find_mosaic(date, epoch)
-    if not fits_p: return None
-    mtime = fits_p.stat().st_mtime
-    key = hashlib.md5(f"{fits_p}{mtime}".encode()).hexdigest()[:8]
-    out = THUMB_DIR / f"{date}_{epoch}_{key}.png"
-    if out.exists(): return out
-    # Clear old thumbs for this date
-    for old in THUMB_DIR.glob(f"{date}_{epoch}_*.png"):
+
+def make_thumbnail(config: DashboardConfig, date: str, epoch: str) -> Path | None:
+    """Build or reuse a cached PNG for one hourly-epoch mosaic."""
+    fits_path = find_mosaic(config, date, epoch)
+    if not fits_path:
+        return None
+    key = hashlib.md5(f"{fits_path}{fits_path.stat().st_mtime}".encode()).hexdigest()[:8]
+    output = config.thumb_dir / f"{date}_{epoch}_{key}.png"
+    if output.exists():
+        return output
+    for old in config.thumb_dir.glob(f"{date}_{epoch}_*.png"):
         old.unlink(missing_ok=True)
     try:
-        d = fits.open(fits_p)[0].data.squeeze().astype(np.float32)
-        fig, ax = plt.subplots(figsize=(12, 4), dpi=90)
-        vmax = float(np.nanpercentile(d[np.isfinite(d)], 99.5))
-        rms  = float(np.nanstd(d[np.abs(d) < 0.05]))
-        ax.imshow(d, origin="lower", cmap="inferno",
-                  norm=PowerNorm(gamma=0.35, vmin=0, vmax=vmax), aspect="auto")
-        peak = float(np.nanmax(d))
-        ax.set_title(f"{date}  |  Peak {peak:.2f} Jy  RMS {rms*1000:.1f} mJy/beam  DR {peak/rms:.0f}",
-                     color="white", fontsize=10, pad=4)
-        ax.axis("off")
-        fig.patch.set_facecolor("#111")
+        with fits.open(fits_path, memmap=True) as hdus:
+            data = hdus[0].data.squeeze().astype(np.float32)
+        finite = data[np.isfinite(data)]
+        if not finite.size:
+            return None
+        vmax = float(np.nanpercentile(finite, 99.5))
+        background = data[np.isfinite(data) & (np.abs(data) < 0.05)]
+        rms = float(np.nanstd(background)) if background.size else 0.0
+        peak = float(np.nanmax(finite))
+        figure, axis = plt.subplots(figsize=(12, 4), dpi=90)
+        axis.imshow(
+            data,
+            origin="lower",
+            cmap="inferno",
+            norm=PowerNorm(gamma=0.35, vmin=0, vmax=max(vmax, np.finfo(float).eps)),
+            aspect="auto",
+        )
+        dynamic_range = f"{peak / rms:.0f}" if rms else "--"
+        axis.set_title(
+            f"{date}  |  Peak {peak:.2f} Jy  RMS {rms * 1000:.1f} mJy/beam  DR {dynamic_range}",
+            color="white",
+            fontsize=10,
+            pad=4,
+        )
+        axis.axis("off")
+        figure.patch.set_facecolor("#111")
         plt.tight_layout(pad=0.2)
-        plt.savefig(out, dpi=90, bbox_inches="tight", facecolor="#111")
-        plt.close()
-        return out
-    except Exception as e:
-        logger.error(f"Thumbnail error {date}: {e}")
+        plt.savefig(output, dpi=90, bbox_inches="tight", facecolor="#111")
+        plt.close(figure)
+        return output
+    except Exception as exc:
+        logger.error("Thumbnail error %s %s: %s", date, epoch, exc)
         return None
 
-@app.get("/thumb/{date}/{epoch}.png")
-def thumbnail(date: str, epoch: str):
-    p = make_thumbnail(date, epoch)
-    if not p: return Response(status_code=404)
-    return Response(content=p.read_bytes(), media_type="image/png",
-                    headers={"Cache-Control": "max-age=60"})
 
-@app.get("/", response_class=HTMLResponse)
-def dashboard():
-    all_metrics = [get_metrics(d, e) for d, e in EPOCHS]
-    cals = cal_tables()
-    now = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+def _file_record(path: Path | None) -> dict | None:
+    if path is None or not path.exists():
+        return None
+    stat = path.stat()
+    return {
+        "path": str(path),
+        "size_bytes": stat.st_size,
+        "modified": datetime.fromtimestamp(stat.st_mtime, timezone.utc).isoformat(),
+    }
 
-    n_pass = sum(1 for m in all_metrics if m["status"] == "pass")
-    n_fail = sum(1 for m in all_metrics if m["status"] == "fail")
-    n_miss = sum(1 for m in all_metrics if m["status"] in ("missing", "no_phot"))
 
-    def sc(v, dec=2): return f"{v:.{dec}f}" if v is not None and not (isinstance(v, float) and np.isnan(v)) else "—"
-    def badge(s):
-        cols = {"pass":"#4caf50","fail":"#f44336","missing":"#888","no_phot":"#ff9800"}
-        return f'<span style="background:{cols.get(s,"#888")};color:#fff;padding:3px 8px;border-radius:10px;font-size:.85em">{s.upper()}</span>'
-    def cal_badge(date):
-        has = any(date in c for c in cals)
-        return f'<span style="background:{"#4caf50" if has else "#f44336"};color:#fff;padding:2px 6px;border-radius:8px;font-size:.8em">{"✓ yes" if has else "✗ no"}</span>'
-    def ratio_cell(r):
-        if r is None or (isinstance(r, float) and np.isnan(r)): return "—"
-        ok = 0.8 <= r <= 1.2
-        c = "#4caf50" if ok else "#f44336"
-        return f'<span style="color:{c};font-weight:bold">{r:.3f}</span>'
+def _latest(paths: list[Path]) -> Path | None:
+    existing = [path for path in paths if path.is_file()]
+    return max(existing, key=lambda path: path.stat().st_mtime) if existing else None
 
-    rows = ""
-    cards = ""
-    for m in all_metrics:
-        rows += f"""<tr>
-            <td><b>{m['date']}</b></td>
-            <td>{badge(m['status'])}</td>
-            <td>{cal_badge(m['date'])}</td>
-            <td>{sc(m['peak'])}</td>
-            <td>{sc(m['rms'],1)}</td>
-            <td>{sc(m['dr'],0)}</td>
-            <td>{ratio_cell(m['ratio'])}</td>
-            <td>{m['n_bright']}</td>
-        </tr>"""
-        thumb_url = f"/thumb/{m['date']}/{m['epoch']}.png"
-        has_thumb = find_mosaic(m['date'], m['epoch']) is not None
-        img_html = f'<img src="{thumb_url}" style="width:100%;border-radius:4px" loading="lazy">' if has_thumb else '<div style="color:#666;padding:20px;text-align:center">No mosaic</div>'
-        status_bar = {"pass":"#4caf50","fail":"#f44336","missing":"#555","no_phot":"#ff9800"}.get(m['status'],"#555")
-        cards += f"""<div style="background:#1a1a1a;border-radius:8px;overflow:hidden;border:1px solid {status_bar}">
-            <div style="background:{status_bar};padding:6px 12px;font-size:.9em;color:#fff;display:flex;justify-content:space-between">
-                <b>{m['date']}</b><span>{m['status'].upper()}</span>
-            </div>
-            {img_html}
-            <div style="padding:8px 12px;font-size:.85em;color:#aaa">
-                Peak: {sc(m['peak'])} Jy &nbsp;|&nbsp; RMS: {sc(m['rms'],1)} mJy &nbsp;|&nbsp; Ratio: {ratio_cell(m['ratio'])}
-            </div>
-        </div>"""
 
-    html = f"""<!DOCTYPE html><html><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>DSA-110 QA Dashboard</title>
+def _tail(path: Path | None, lines: int = 24) -> list[str]:
+    if path is None:
+        return []
+    try:
+        with path.open(errors="replace") as stream:
+            return stream.readlines()[-lines:]
+    except OSError as exc:
+        return [f"Unable to read {path}: {exc}"]
+
+
+def disk_status() -> dict:
+    """Report read-only capacity information for the data volumes."""
+    result = {}
+    for path in (Path("/stage"), Path("/data")):
+        try:
+            usage = shutil.disk_usage(path)
+            result[str(path)] = {
+                "total_bytes": usage.total,
+                "used_bytes": usage.used,
+                "free_bytes": usage.free,
+                "pct_used": round(usage.used / usage.total * 100, 1),
+            }
+        except OSError as exc:
+            result[str(path)] = {"error": str(exc)}
+    return result
+
+
+def process_status() -> list[dict]:
+    """List only continuum pipeline processes relevant to operators."""
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid=,etimes=,stat=,args="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return [{"error": str(exc)}]
+    processes = []
+    for line in result.stdout.splitlines():
+        if not any(name in line.lower() for name in PROCESS_NAMES):
+            continue
+        parts = line.strip().split(maxsplit=3)
+        if len(parts) == 4:
+            processes.append(
+                {
+                    "pid": int(parts[0]),
+                    "elapsed_seconds": int(parts[1]),
+                    "state": parts[2],
+                    "command": parts[3],
+                }
+            )
+    return processes
+
+
+def _pid_hints(config: DashboardConfig) -> list[dict]:
+    hints = []
+    if not config.campaign_outputs.is_dir():
+        return hints
+    for path in sorted(config.campaign_outputs.glob("*.pid")):
+        try:
+            content = path.read_text(errors="replace")
+        except OSError:
+            continue
+        for label, raw_pid in re.findall(r"([A-Z_]*PID)=(\d+)", content):
+            pid = int(raw_pid)
+            hints.append(
+                {
+                    "label": label,
+                    "pid": pid,
+                    "visible": Path(f"/proc/{pid}").exists(),
+                    "source": str(path),
+                }
+            )
+    return hints
+
+
+def campaign_status(config: DashboardConfig, date: str, hour: int) -> dict:
+    """Collect current filesystem, log, disk, and process state for an epoch."""
+    _validate_date_epoch(date)
+    if not 0 <= hour <= 23:
+        raise HTTPException(status_code=400, detail="Hour must be between 0 and 23")
+    prefix = f"{date}T{hour:02d}"
+    ms_dir = config.stage / "ms"
+    image_dir = config.stage / f"images/mosaic_{date}"
+    product_dir = config.products / date
+    ms_files = sorted(ms_dir.glob(f"{prefix}:*.ms")) if ms_dir.is_dir() else []
+    bandpass = sorted(ms_dir.glob(f"{prefix}:*.b")) if ms_dir.is_dir() else []
+    gains = sorted(ms_dir.glob(f"{prefix}:*.g")) if ms_dir.is_dir() else []
+    tile_images = sorted(image_dir.glob(f"{prefix}:*-image.fits")) if image_dir.is_dir() else []
+    mosaic = image_dir / f"{date}T{hour:02d}00_mosaic.fits"
+    incoming_files = (
+        sorted(config.incoming.glob(f"{prefix}:*_sb*.hdf5")) if config.incoming.is_dir() else []
+    )
+    logs = list(product_dir.glob("run_*.log")) if product_dir.is_dir() else []
+    if config.campaign_outputs.is_dir():
+        logs.extend(config.campaign_outputs.glob(f"batch_run_h{hour:02d}*.log"))
+        logs.extend(config.campaign_outputs.glob(f"batch_run_h{hour}*.log"))
+    latest_log = _latest(list(dict.fromkeys(logs)))
+    manifest = product_dir / f"{date}_manifest.json"
+    summary = product_dir / f"{date}_run_summary.json"
+    report = product_dir / "run_report.md"
+    processes = process_status()
+    stages = [
+        {
+            "name": "Measurement Sets",
+            "state": "ready" if ms_files else "not_yet",
+            "count": len(ms_files),
+        },
+        {
+            "name": "Calibration tables",
+            "state": "ready" if bandpass and gains else "not_yet",
+            "count": len(bandpass) + len(gains),
+        },
+        {
+            "name": "Tile images",
+            "state": "ready" if tile_images else "not_yet",
+            "count": len(tile_images),
+        },
+        {
+            "name": "Hourly-epoch mosaic",
+            "state": "ready" if mosaic.is_file() else "not_yet",
+            "count": int(mosaic.is_file()),
+        },
+    ]
+    return {
+        "date": date,
+        "hour": hour,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "stages": stages,
+        "measurement_sets": {"count": len(ms_files), "paths": [str(path) for path in ms_files]},
+        "calibration": {
+            "bandpass": [_file_record(path) for path in bandpass],
+            "gains": [_file_record(path) for path in gains],
+        },
+        "tiles": {"count": len(tile_images), "latest": _file_record(_latest(tile_images))},
+        "mosaic": _file_record(mosaic),
+        "run_products": {
+            "manifest": _file_record(manifest),
+            "summary": _file_record(summary),
+            "report": _file_record(report),
+        },
+        "log": {"file": _file_record(latest_log), "tail": _tail(latest_log)},
+        "incoming": {
+            "directory": str(config.incoming),
+            "hdf5_count": len(incoming_files),
+            "latest": _file_record(_latest(incoming_files)),
+        },
+        "disks": disk_status(),
+        "processes": processes,
+        "pid_hints": _pid_hints(config),
+    }
+
+
+def _format_number(value, decimals: int = 2) -> str:
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return "—"
+    return f"{value:.{decimals}f}"
+
+
+def _human_bytes(value: int | None) -> str:
+    if value is None:
+        return "—"
+    number = float(value)
+    for unit in ("B", "KB", "MB", "GB", "TB", "PB"):
+        if number < 1024 or unit == "PB":
+            return f"{number:.1f} {unit}"
+        number /= 1024
+    return "—"
+
+
+def _badge(state: str, label: str | None = None) -> str:
+    colors = {
+        "pass": "#41c97a",
+        "ready": "#41c97a",
+        "active": "#4eb8ff",
+        "fail": "#ff6470",
+        "missing": "#69717d",
+        "not_yet": "#d99b35",
+        "no_phot": "#d99b35",
+    }
+    text = label or state.replace("_", " ")
+    return f'<span class="badge" style="--badge:{colors.get(state, "#69717d")}">{html.escape(text.upper())}</span>'
+
+
+def _ratio_cell(ratio) -> str:
+    if ratio is None or (isinstance(ratio, float) and np.isnan(ratio)):
+        return "—"
+    color = "#41c97a" if 0.8 <= ratio <= 1.2 else "#ff6470"
+    return f'<span style="color:{color};font-weight:700">{ratio:.3f}</span>'
+
+
+def render_dashboard(config: DashboardConfig) -> str:
+    """Render the consolidated QA and operations dashboard."""
+    all_metrics = [get_metrics(config, date, epoch) for date, epoch in EPOCHS]
+    cals = cal_tables(config)
+    campaign = campaign_status(config, config.campaign_date, config.campaign_hour)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    n_pass = sum(metric["status"] == "pass" for metric in all_metrics)
+    n_fail = sum(metric["status"] == "fail" for metric in all_metrics)
+    n_missing = sum(metric["status"] in ("missing", "no_phot") for metric in all_metrics)
+
+    rows = []
+    cards = []
+    for metric in all_metrics:
+        has_cal = any(metric["date"] in name for name in cals)
+        rows.append(
+            f"<tr><td><b>{metric['date']}</b><small>{metric['epoch']}</small></td>"
+            f"<td>{_badge(metric['status'])}</td>"
+            f"<td>{_badge('ready' if has_cal else 'missing', 'yes' if has_cal else 'no')}</td>"
+            f"<td>{_format_number(metric['peak'])}</td>"
+            f"<td>{_format_number(metric['rms'], 1)}</td>"
+            f"<td>{_format_number(metric['dr'], 0)}</td>"
+            f"<td>{_ratio_cell(metric['ratio'])}</td><td>{metric['n_bright']}</td></tr>"
+        )
+        if metric["fits"]:
+            image = (
+                f'<img src="{metric["thumbnail_url"]}" alt="{metric["date"]} mosaic" '
+                'loading="lazy">'
+            )
+        else:
+            image = '<div class="empty">No mosaic</div>'
+        cards.append(
+            f'<article class="mosaic-card status-{metric["status"]}"><header><b>{metric["date"]}</b>'
+            f"{_badge(metric['status'])}</header>{image}<footer>Peak {_format_number(metric['peak'])} Jy"
+            f"<span>RMS {_format_number(metric['rms'], 1)} mJy</span>"
+            f"<span>Ratio {_ratio_cell(metric['ratio'])}</span></footer></article>"
+        )
+
+    stage_cards = []
+    for stage in campaign["stages"]:
+        stage_cards.append(
+            f'<div class="stage"><span>{html.escape(stage["name"])}</span>'
+            f"{_badge(stage['state'])}<strong>{stage['count']}</strong></div>"
+        )
+    disk_cards = []
+    for path, disk in campaign["disks"].items():
+        if "error" in disk:
+            detail = html.escape(disk["error"])
+            percent = "unknown"
+        else:
+            detail = (
+                f"{_human_bytes(disk['free_bytes'])} free of {_human_bytes(disk['total_bytes'])}"
+            )
+            percent = f"{disk['pct_used']}% used"
+        disk_cards.append(
+            f'<div class="info-card"><span>{html.escape(path)}</span><strong>{percent}</strong><small>{detail}</small></div>'
+        )
+    processes = campaign["processes"]
+    if processes:
+        process_rows = "".join(
+            f"<li><code>PID {process.get('pid', '—')}</code><span>{html.escape(process.get('command', process.get('error', '')))}</span></li>"
+            for process in processes
+        )
+    elif campaign["pid_hints"]:
+        process_rows = "".join(
+            f"<li><code>PID {hint['pid']}</code><span>{html.escape(hint['label'])} recorded in "
+            f"{html.escape(hint['source'])}; "
+            f"{'visible' if hint['visible'] else 'not visible in the server process namespace'}</span></li>"
+            for hint in campaign["pid_hints"]
+        )
+    else:
+        process_rows = (
+            '<li class="empty-row">No batch_pipeline, WSClean, or AOFlagger process visible</li>'
+        )
+    log_record = campaign["log"]["file"]
+    log_title = html.escape(log_record["path"]) if log_record else "No campaign log found"
+    log_tail = html.escape("".join(campaign["log"]["tail"]) or "No log lines available")
+    mosaic_path = campaign["mosaic"]["path"] if campaign["mosaic"] else "Not yet produced"
+    run_summary = campaign["run_products"]["summary"]
+    run_summary_path = run_summary["path"] if run_summary else "Not yet produced"
+    incoming = campaign["incoming"]
+
+    return f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>DSA-110 Continuum Observatory</title>
 <style>
-  body{{background:#111;color:#eee;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;margin:0;padding:16px}}
-  h1{{color:#ddd;font-size:1.4em;margin:0 0 4px}}
-  .subtitle{{color:#666;font-size:.85em;margin-bottom:20px}}
-  .summary{{display:flex;gap:12px;margin-bottom:24px;flex-wrap:wrap}}
-  .stat{{background:#1a1a1a;border-radius:8px;padding:12px 20px;text-align:center;min-width:80px}}
-  .stat .n{{font-size:2em;font-weight:bold}}
-  .stat .l{{font-size:.8em;color:#888;margin-top:2px}}
-  table{{width:100%;border-collapse:collapse;font-size:.88em;margin-bottom:32px}}
-  th,td{{padding:10px 12px;text-align:center;border-bottom:1px solid #2a2a2a}}
-  th{{background:#1a1a1a;color:#aaa;font-weight:600}}
-  tr:hover{{background:#1a1a1a}}
-  .grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:16px;margin-top:8px}}
-  @media(max-width:600px){{.grid{{grid-template-columns:1fr}}}}
-</style>
-<script>setTimeout(()=>location.reload(),60000)</script>
-</head><body>
-<h1>DSA-110 Continuum QA</h1>
-<div class="subtitle">Updated: {now} &nbsp;·&nbsp; Auto-refresh: 60s &nbsp;·&nbsp; Target ratio: 0.8–1.2</div>
-<div class="summary">
-  <div class="stat"><div class="n" style="color:#4caf50">{n_pass}</div><div class="l">PASS</div></div>
-  <div class="stat"><div class="n" style="color:#f44336">{n_fail}</div><div class="l">FAIL</div></div>
-  <div class="stat"><div class="n" style="color:#888">{n_miss}</div><div class="l">MISSING</div></div>
-  <div class="stat"><div class="n">{len(EPOCHS)}</div><div class="l">TOTAL</div></div>
-</div>
-<table>
-  <tr><th>Date</th><th>Status</th><th>Cal Tables</th><th>Peak (Jy)</th><th>RMS (mJy)</th><th>Dyn Range</th><th>DSA/NVSS Ratio</th><th>Bright Srcs</th></tr>
-  {rows}
-</table>
-<h2 style="color:#bbb;font-size:1.1em;margin-bottom:12px">Mosaic Thumbnails</h2>
-<div class="grid">{cards}</div>
-</body></html>"""
-    return HTMLResponse(html)
+:root{{--ink:#e8edf2;--muted:#87919d;--panel:#171b20;--line:#2a3038;--blue:#4eb8ff;--green:#41c97a}}
+*{{box-sizing:border-box}} body{{background:#0d1014;color:var(--ink);font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0}}
+body:before{{content:"";display:block;height:3px;background:linear-gradient(90deg,#4eb8ff,#41c97a 45%,#d99b35)}}
+.shell{{max-width:1500px;margin:auto;padding:22px}} h1{{font-size:1.5rem;margin:0;letter-spacing:.01em}} h2{{font-size:1rem;margin:0 0 14px;text-transform:uppercase;letter-spacing:.12em;color:#bcc6d0}}
+.subtitle{{color:var(--muted);font-size:.82rem;margin:5px 0 24px}} section{{margin-bottom:34px}} .summary,.stage-grid,.info-grid{{display:grid;gap:10px}}
+.summary{{grid-template-columns:repeat(4,minmax(110px,1fr));max-width:620px}} .stat,.stage,.info-card{{background:var(--panel);border:1px solid var(--line);border-radius:8px;padding:13px 16px}}
+.stat strong{{display:block;font-size:1.7rem}} .stat span,.stage span,.info-card span{{color:var(--muted);font-size:.75rem;text-transform:uppercase;letter-spacing:.08em}}
+.campaign{{border:1px solid #2f4553;background:linear-gradient(135deg,#131a20,#14181d);border-radius:12px;padding:18px}} .campaign-head{{display:flex;justify-content:space-between;gap:16px;align-items:flex-start;margin-bottom:16px}}
+.campaign-head h2{{margin:0;color:#dce9f2}} .campaign-head p{{margin:4px 0 0;color:var(--muted);font-size:.82rem}} .stage-grid{{grid-template-columns:repeat(4,1fr)}}
+.stage{{display:grid;grid-template-columns:1fr auto;gap:10px;align-items:center}} .stage strong{{grid-column:1/-1;font-size:1.8rem}} .info-grid{{grid-template-columns:repeat(3,1fr);margin-top:10px}}
+.info-card strong,.info-card small{{display:block;margin-top:7px}} .info-card small{{color:var(--muted)}} .path{{font-family:ui-monospace,SFMono-Regular,monospace;word-break:break-all;color:#a9c8dd}}
+.badge{{display:inline-block;background:var(--badge);color:#081014;padding:3px 8px;border-radius:999px;font-size:.68rem;font-weight:800;letter-spacing:.05em;white-space:nowrap}}
+.ops-grid{{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px}} .panel{{background:#101419;border:1px solid var(--line);border-radius:8px;padding:14px;min-width:0}}
+.panel h3{{font-size:.76rem;text-transform:uppercase;letter-spacing:.1em;color:var(--muted);margin:0 0 10px}} .process-list{{list-style:none;padding:0;margin:0;max-height:180px;overflow:auto}} .process-list li{{display:flex;gap:10px;padding:7px 0;border-top:1px solid var(--line);font-size:.76rem}} .process-list li:first-child{{border:0}} .process-list span{{word-break:break-all;color:#bdc6cf}}
+pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;margin:0;max-height:250px;overflow:auto;font-size:.72rem;line-height:1.45;white-space:pre-wrap}} .log-path{{color:var(--muted);font-size:.68rem;word-break:break-all;margin-bottom:8px}}
+.table-wrap{{overflow:auto;border:1px solid var(--line);border-radius:9px}} table{{width:100%;border-collapse:collapse;font-size:.82rem}} th,td{{padding:10px 12px;text-align:center;border-bottom:1px solid var(--line);white-space:nowrap}} th{{background:#171b20;color:#9da8b4;font-weight:600}} td:first-child{{text-align:left}} td small{{display:block;color:var(--muted);margin-top:2px}} tr:last-child td{{border:0}} tr:hover{{background:#14191f}}
+.grid{{display:grid;grid-template-columns:repeat(auto-fill,minmax(330px,1fr));gap:14px}} .mosaic-card{{background:var(--panel);border:1px solid var(--line);border-radius:9px;overflow:hidden}} .mosaic-card header,.mosaic-card footer{{display:flex;align-items:center;justify-content:space-between;gap:10px;padding:9px 12px}} .mosaic-card img{{display:block;width:100%;min-height:140px;object-fit:cover;background:#090b0e}} .mosaic-card footer{{font-size:.75rem;color:#aeb7c0;flex-wrap:wrap}} .empty{{display:grid;place-items:center;min-height:140px;background:#101318;color:#5d6670}} .empty-row{{color:var(--muted)}}
+@media(max-width:850px){{.stage-grid,.info-grid{{grid-template-columns:repeat(2,1fr)}}.ops-grid{{grid-template-columns:1fr}}}} @media(max-width:560px){{.shell{{padding:16px}}.summary,.stage-grid,.info-grid{{grid-template-columns:1fr 1fr}}.grid{{grid-template-columns:1fr}}}}
+</style><script>setTimeout(()=>location.reload(),30000)</script></head>
+<body><main class="shell"><h1>DSA-110 Continuum Observatory</h1><div class="subtitle">Updated {now} · auto-refresh 30s · read-only</div>
+<section class="campaign"><div class="campaign-head"><div><h2>Active campaign · {campaign["date"]} hour {campaign["hour"]:02d}</h2><p>Hourly-epoch mosaic progress from incoming HDF5 through science products</p></div>{_badge("active" if processes else "not_yet", "process visible" if processes else ("PID recorded" if campaign["pid_hints"] else "process not visible"))}</div>
+<div class="stage-grid">{"".join(stage_cards)}</div><div class="info-grid">{"".join(disk_cards)}
+<div class="info-card"><span>Incoming slow-vis</span><strong>{incoming["hdf5_count"]} HDF5</strong><small class="path">{html.escape(incoming["directory"])}</small></div></div>
+<div class="info-grid"><div class="info-card"><span>MS root</span><strong>{campaign["measurement_sets"]["count"]} hour-11 MS</strong><small class="path">{html.escape(str(config.stage / "ms"))}</small></div>
+<div class="info-card"><span>Tile root</span><strong>{campaign["tiles"]["count"]} image FITS</strong><small class="path">{html.escape(str(config.stage / f"images/mosaic_{campaign['date']}"))}</small></div>
+<div class="info-card"><span>Hourly-epoch mosaic</span><strong>{"available" if campaign["mosaic"] else "not yet"}</strong><small class="path">{html.escape(mosaic_path)}</small></div>
+<div class="info-card"><span>Run summary</span><strong>{"available" if run_summary else "not yet"}</strong><small class="path">{html.escape(run_summary_path)}</small></div></div>
+<div class="ops-grid"><div class="panel"><h3>Pipeline heartbeat</h3><ul class="process-list">{process_rows}</ul></div>
+<div class="panel"><h3>Latest batch log</h3><div class="log-path">{log_title}</div><pre>{log_tail}</pre></div></div></section>
+<section><h2>Historical hourly-epoch QA</h2><div class="summary"><div class="stat"><strong style="color:#41c97a">{n_pass}</strong><span>Pass</span></div><div class="stat"><strong style="color:#ff6470">{n_fail}</strong><span>Fail</span></div><div class="stat"><strong style="color:#d99b35">{n_missing}</strong><span>Missing / pending photometry</span></div><div class="stat"><strong>{len(EPOCHS)}</strong><span>Total</span></div></div>
+<div class="table-wrap"><table><thead><tr><th>Date</th><th>Status</th><th>Cal tables</th><th>Peak (Jy)</th><th>RMS (mJy)</th><th>Dyn range</th><th>DSA/NVSS</th><th>Bright sources</th></tr></thead><tbody>{"".join(rows)}</tbody></table></div></section>
+<section><h2>Mosaic thumbnails</h2><div class="grid">{"".join(cards)}</div></section></main></body></html>"""
+
+
+mosaic_router = APIRouter(prefix="/artifacts/mosaic", tags=["mosaic artifacts"])
+ops_router = APIRouter(prefix="/api", tags=["read-only operations"])
+legacy_router = APIRouter(include_in_schema=False)
+
+
+@mosaic_router.get("/{date}/{epoch}/status")
+def mosaic_status(date: str, epoch: str, request: Request):
+    """Return the data used by the mosaic dashboard card."""
+    _validate_date_epoch(date, epoch)
+    return get_metrics(_config(request), date, epoch)
+
+
+@mosaic_router.get("/{date}/{epoch}/thumb.png")
+def mosaic_thumbnail(date: str, epoch: str, request: Request):
+    """Return a cached or newly rendered mosaic PNG."""
+    _validate_date_epoch(date, epoch)
+    path = make_thumbnail(_config(request), date, epoch)
+    if not path:
+        return Response(status_code=404)
+    return Response(
+        content=path.read_bytes(),
+        media_type="image/png",
+        headers={"Cache-Control": "max-age=60"},
+    )
+
+
+@legacy_router.get("/thumb/{date}/{epoch}.png")
+def legacy_thumbnail(date: str, epoch: str, request: Request):
+    """Preserve the original thumbnail URL."""
+    return mosaic_thumbnail(date, epoch, request)
+
+
+@ops_router.get("/status")
+def operations_status(request: Request, date: str | None = None, hour: int | None = None):
+    """Return the read-only campaign and telescope operations snapshot."""
+    config = _config(request)
+    return campaign_status(
+        config,
+        date or config.campaign_date,
+        config.campaign_hour if hour is None else hour,
+    )
+
+
+def create_app(config: DashboardConfig | None = None) -> FastAPI:
+    """Create a routed dashboard application."""
+    dashboard_config = config or DashboardConfig()
+    dashboard_config.thumb_dir.mkdir(parents=True, exist_ok=True)
+    application = FastAPI(title="DSA-110 Continuum Observatory", version="2.0")
+    application.state.dashboard_config = dashboard_config
+    application.include_router(mosaic_router)
+    application.include_router(ops_router)
+    application.include_router(legacy_router)
+
+    @application.get("/", response_class=HTMLResponse)
+    def dashboard():
+        return HTMLResponse(render_dashboard(dashboard_config))
+
+    @application.get("/health")
+    def health():
+        return {"status": "ok", "time": datetime.now(timezone.utc).isoformat()}
+
+    return application
+
+
+app = create_app()
+
 
 if __name__ == "__main__":
+    import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8767, log_level="warning")

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -549,7 +549,8 @@ def render_dashboard(config: DashboardConfig) -> str:
     for metric in all_metrics:
         has_cal = any(metric["date"] in name for name in cals)
         rows.append(
-            f"<tr><td><b>{metric['date']}</b><small>{metric['epoch']}</small></td>"
+            f'<tr><td><b><a href="/runs/{metric["date"]}">{metric["date"]}</a></b>'
+            f"<small>{metric['epoch']}</small></td>"
             f"<td>{_badge(metric['status'])}</td>"
             f"<td>{_badge('ready' if has_cal else 'missing', 'yes' if has_cal else 'no')}</td>"
             f"<td>{_format_number(metric['peak'])}</td>"
@@ -790,6 +791,91 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;max-height:
 <tr><th>Log file</th><td><code>{html.escape(record["log_path"])}</code></td></tr>
 </table>
 <h2>Log tail</h2><pre>{log_tail}</pre></main></body></html>"""
+    )
+
+
+def _manifest_value(value, decimals: int | None = None) -> str:
+    if value is None:
+        return "—"
+    if decimals is not None and isinstance(value, (int, float)):
+        return f"{value:.{decimals}f}"
+    return html.escape(str(value))
+
+
+@control_page_router.get("/runs/{date}", response_class=HTMLResponse)
+def run_provenance_page(date: str, request: Request):
+    """Render one date's manifest: verdict, gates, epochs, and the run report."""
+    _validate_date_epoch(date)
+    config = _config(request)
+    manifest_path = config.products / date / f"{date}_manifest.json"
+    if not manifest_path.is_file():
+        raise HTTPException(status_code=404, detail="no manifest for this date")
+    try:
+        manifest = json.loads(manifest_path.read_text(errors="replace"))
+    except (OSError, ValueError) as exc:
+        raise HTTPException(status_code=502, detail=f"unreadable manifest: {exc}") from None
+    if not isinstance(manifest, dict):
+        manifest = {}
+    verdict = str(manifest.get("pipeline_verdict") or "UNKNOWN")
+    verdict_badge = _badge("pass" if verdict == "CLEAN" else "fail", verdict)
+    gates = manifest.get("gates") or []
+    gate_rows = (
+        "".join(
+            f"<tr><td>{_manifest_value(gate.get('gate'))}</td>"
+            f"<td>{_manifest_value(gate.get('verdict'))}</td>"
+            f"<td>{_manifest_value(gate.get('reason'))}</td></tr>"
+            for gate in gates
+            if isinstance(gate, dict)
+        )
+        or '<tr><td colspan="3">No gates triggered</td></tr>'
+    )
+    epoch_rows = []
+    for epoch in manifest.get("epochs") or []:
+        if not isinstance(epoch, dict):
+            continue
+        hour = epoch.get("hour")
+        token = f"T{hour:02d}00" if isinstance(hour, int) else "—"
+        link = (
+            f'<a href="/artifacts/mosaic/{date}/{token}/status">{token}</a>'
+            if token != "—"
+            else token
+        )
+        qa_result = str(epoch.get("qa_result") or "—")
+        qa_badge = _badge({"PASS": "pass", "FAIL": "fail"}.get(qa_result, "missing"), qa_result)
+        epoch_rows.append(
+            f"<tr><td>{link}</td><td>{_manifest_value(epoch.get('n_tiles'))}</td>"
+            f"<td>{_manifest_value(epoch.get('status'))}</td><td>{qa_badge}</td>"
+            f"<td>{_manifest_value(epoch.get('peak'), 2)}</td>"
+            f"<td>{_manifest_value(epoch.get('rms'), 4)}</td>"
+            f"<td>{_manifest_value(epoch.get('n_sources'))}</td>"
+            f"<td>{_manifest_value(epoch.get('median_ratio'), 3)}</td></tr>"
+        )
+    epoch_table = "".join(epoch_rows) or '<tr><td colspan="8">No epochs recorded</td></tr>'
+    report_path = config.products / date / "run_report.md"
+    report_text = (
+        html.escape(report_path.read_text(errors="replace"))
+        if report_path.is_file()
+        else "No run report found"
+    )
+    return HTMLResponse(
+        f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Run {html.escape(date)}</title>
+<style>body{{background:#0d1014;color:#e8edf2;font-family:Inter,-apple-system,sans-serif;margin:0}}
+.shell{{max-width:1250px;margin:auto;padding:22px}} a{{color:#4eb8ff}} h2{{font-size:1rem;text-transform:uppercase;letter-spacing:.1em;color:#bcc6d0}}
+table{{border-collapse:collapse;font-size:.83rem;margin:12px 0;width:100%}} td,th{{padding:8px 12px;border-bottom:1px solid #2a3038;text-align:left}} th{{background:#171b20;color:#9da8b4}}
+.badge{{display:inline-block;background:var(--badge);color:#081014;padding:3px 8px;border-radius:999px;font-size:.68rem;font-weight:800}}
+code{{color:#a9c8dd;word-break:break-all}}
+pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;max-height:520px;overflow:auto;font-size:.74rem;line-height:1.45;white-space:pre-wrap}}</style></head>
+<body><main class="shell"><p><a href="/">← Dashboard</a></p>
+<h1>Pipeline run · {html.escape(date)} {verdict_badge}</h1>
+<p><code>{_manifest_value(manifest.get("command_line"))}</code></p>
+<p>cal date {_manifest_value(manifest.get("cal_date"))} · git {_manifest_value(manifest.get("git_sha"))} · log {_manifest_value(manifest.get("run_log"))}</p>
+<h2>QA gates</h2>
+<table><thead><tr><th>Gate</th><th>Verdict</th><th>Reason</th></tr></thead><tbody>{gate_rows}</tbody></table>
+<h2>Epochs</h2>
+<table><thead><tr><th>Epoch</th><th>Tiles</th><th>Status</th><th>QA</th><th>Peak (Jy)</th><th>RMS (Jy)</th><th>Sources</th><th>Median ratio</th></tr></thead><tbody>{epoch_table}</tbody></table>
+<h2>Run report</h2><pre>{report_text}</pre></main></body></html>"""
     )
 
 

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -88,8 +88,8 @@ def find_csv(config: DashboardConfig, date: str, epoch: str) -> Path | None:
     directory = config.products / date
     if not directory.is_dir():
         return None
-    matches = sorted(directory.glob(f"*{epoch}*phot.csv"))
-    return matches[-1] if matches else None
+    matches = list(directory.glob(f"*{epoch}*phot.csv"))
+    return max(matches, key=lambda path: path.stat().st_mtime) if matches else None
 
 
 def cal_tables(config: DashboardConfig) -> set[str]:

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -100,6 +100,77 @@ def cal_tables(config: DashboardConfig) -> set[str]:
 
 
 MOSAIC_NAME_RE = re.compile(r"(\d{4}-\d{2}-\d{2})(T\d{4})_mosaic\.fits")
+PHOT_NAME_RE = re.compile(r"(\d{4}-\d{2}-\d{2})(T\d{4})_forced_phot\.csv")
+
+
+def lightcurve_points(
+    config: DashboardConfig, ra_deg: float, dec_deg: float, radius_arcsec: float = 30.0
+) -> list[dict]:
+    """Nearest forced-photometry match per epoch within the match radius."""
+    points: list[dict] = []
+    if not config.products.is_dir():
+        return points
+    radius_deg = radius_arcsec / 3600.0
+    cos_dec = max(float(np.cos(np.radians(dec_deg))), 1e-6)
+    for csv_path in sorted(config.products.glob("*/*_forced_phot.csv")):
+        match = PHOT_NAME_RE.fullmatch(csv_path.name)
+        if not match:
+            continue
+        try:
+            frame = pd.read_csv(csv_path)
+        except Exception as exc:
+            logger.warning("Lightcurve CSV error %s: %s", csv_path, exc)
+            continue
+        if not {"ra_deg", "dec_deg", "dsa_peak_jyb"}.issubset(frame.columns) or not len(frame):
+            continue
+        separation = np.hypot((frame["ra_deg"] - ra_deg) * cos_dec, frame["dec_deg"] - dec_deg)
+        index = separation.idxmin()
+        if not np.isfinite(separation[index]) or separation[index] > radius_deg:
+            continue
+        row = frame.loc[index]
+        error = row.get("dsa_peak_err_jyb")
+        points.append(
+            {
+                "epoch": match.group(1) + match.group(2),
+                "date": match.group(1),
+                "epoch_token": match.group(2),
+                "flux_jy": float(row["dsa_peak_jyb"]),
+                "flux_err_jy": float(error) if error is not None else float("nan"),
+                "separation_arcsec": float(separation[index] * 3600.0),
+                "csv": str(csv_path),
+            }
+        )
+    points.sort(key=lambda point: point["epoch"])
+    return points
+
+
+def _lightcurve_metrics(points: list[dict]) -> dict:
+    """Compute eta/V from the matched series via the canonical formulas."""
+    if len(points) < 2:
+        return {"eta": None, "v": None}
+    from dsa110_continuum.photometry.metrics import calculate_eta_metric, calculate_v_metric
+
+    fluxes = np.array([point["flux_jy"] for point in points], dtype=float)
+    errors = np.array([point["flux_err_jy"] for point in points], dtype=float)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        weights = np.where(np.isfinite(errors) & (errors > 0), 1.0 / errors**2, 1.0)
+    try:
+        return {
+            "eta": float(calculate_eta_metric(fluxes, weights)),
+            "v": float(calculate_v_metric(fluxes)),
+        }
+    except Exception as exc:
+        logger.warning("Variability metric error: %s", exc)
+        return {"eta": None, "v": None}
+
+
+def _validate_lightcurve_query(ra: float, dec: float, radius_arcsec: float) -> None:
+    if not 0 <= ra < 360:
+        raise HTTPException(status_code=400, detail="ra must be in [0, 360)")
+    if not -90 <= dec <= 90:
+        raise HTTPException(status_code=400, detail="dec must be in [-90, 90]")
+    if not 1 <= radius_arcsec <= 300:
+        raise HTTPException(status_code=400, detail="radius_arcsec must be in [1, 300]")
 
 
 def discover_epochs(config: DashboardConfig, limit: int = 24) -> list[tuple[str, str]]:
@@ -653,7 +724,14 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;margin:0;ma
 {control_section}
 <section><h2>Historical hourly-epoch QA</h2><div class="summary"><div class="stat"><strong style="color:#41c97a">{n_pass}</strong><span>Pass</span></div><div class="stat"><strong style="color:#ff6470">{n_fail}</strong><span>Fail</span></div><div class="stat"><strong style="color:#d99b35">{n_missing}</strong><span>Missing / pending photometry</span></div><div class="stat"><strong>{len(epochs)}</strong><span>Total</span></div></div>
 <div class="table-wrap"><table><thead><tr><th>Date</th><th>Status</th><th>Cal tables</th><th>Peak (Jy)</th><th>RMS (mJy)</th><th>Dyn range</th><th>DSA/NVSS</th><th>Bright sources</th></tr></thead><tbody>{"".join(rows)}</tbody></table></div></section>
-<section><h2>Mosaic thumbnails</h2><div class="grid">{"".join(cards)}</div></section></main></body></html>"""
+<section><h2>Mosaic thumbnails</h2><div class="grid">{"".join(cards)}</div></section>
+<section><h2>Light curve lookup</h2>
+<form action="/sources/lightcurve" method="get" style="display:flex;gap:10px;flex-wrap:wrap;align-items:center">
+<input name="ra" type="number" step="any" min="0" max="359.9999" required placeholder="RA (deg)">
+<input name="dec" type="number" step="any" min="-90" max="90" required placeholder="Dec (deg)">
+<input name="radius_arcsec" type="number" step="any" min="1" max="300" value="30" title="match radius (arcsec)">
+<button type="submit">Show light curve</button>
+</form></section></main></body></html>"""
 
 
 mosaic_router = APIRouter(prefix="/artifacts/mosaic", tags=["mosaic artifacts"])
@@ -791,6 +869,89 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;max-height:
 <tr><th>Log file</th><td><code>{html.escape(record["log_path"])}</code></td></tr>
 </table>
 <h2>Log tail</h2><pre>{log_tail}</pre></main></body></html>"""
+    )
+
+
+sources_router = APIRouter(prefix="/sources", tags=["science sources"])
+
+
+@sources_router.get("/lightcurve", response_class=HTMLResponse)
+def lightcurve_page(request: Request, ra: float, dec: float, radius_arcsec: float = 30.0):
+    """Render the positional light curve across all epochs with metrics."""
+    _validate_lightcurve_query(ra, dec, radius_arcsec)
+    config = _config(request)
+    points = lightcurve_points(config, ra, dec, radius_arcsec)
+    metrics = _lightcurve_metrics(points)
+    if points:
+        point_rows = "".join(
+            f'<tr><td><a href="/artifacts/mosaic/{point["date"]}/{point["epoch_token"]}/status">'
+            f"{point['epoch']}</a></td>"
+            f"<td>{point['flux_jy']:.4f}</td>"
+            f"<td>{point['flux_err_jy']:.4f}</td>"
+            f"<td>{point['separation_arcsec']:.1f}</td></tr>"
+            for point in points
+        )
+        plot = (
+            f'<img src="/sources/lightcurve.png?ra={ra}&dec={dec}'
+            f'&radius_arcsec={radius_arcsec}" alt="light curve" '
+            'style="max-width:100%;border-radius:8px">'
+        )
+    else:
+        point_rows = '<tr><td colspan="4">No matching source in any epoch</td></tr>'
+        plot = ""
+    eta = f"{metrics['eta']:.3f}" if metrics["eta"] is not None else "—"
+    v_metric = f"{metrics['v']:.3f}" if metrics["v"] is not None else "—"
+    return HTMLResponse(
+        f"""<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Light curve {ra:.4f} {dec:+.4f}</title>
+<style>body{{background:#0d1014;color:#e8edf2;font-family:Inter,-apple-system,sans-serif;margin:0}}
+.shell{{max-width:1100px;margin:auto;padding:22px}} a{{color:#4eb8ff}} h2{{font-size:1rem;text-transform:uppercase;letter-spacing:.1em;color:#bcc6d0}}
+table{{border-collapse:collapse;font-size:.83rem;margin:12px 0}} td,th{{padding:8px 14px;border-bottom:1px solid #2a3038;text-align:left}} th{{background:#171b20;color:#9da8b4}}</style></head>
+<body><main class="shell"><p><a href="/">← Dashboard</a></p>
+<h1>Light curve · RA {ra:.4f}° Dec {dec:+.4f}° (r={radius_arcsec:.0f}&Prime;)</h1>
+<p>eta = {eta} · V = {v_metric} · {len(points)} epochs matched</p>
+{plot}
+<h2>Forced photometry</h2>
+<table><thead><tr><th>Epoch</th><th>Flux (Jy/beam)</th><th>Error</th><th>Sep (&Prime;)</th></tr></thead>
+<tbody>{point_rows}</tbody></table></main></body></html>"""
+    )
+
+
+@sources_router.get("/lightcurve.png")
+def lightcurve_png(request: Request, ra: float, dec: float, radius_arcsec: float = 30.0):
+    """Render the light-curve plot as PNG."""
+    _validate_lightcurve_query(ra, dec, radius_arcsec)
+    config = _config(request)
+    points = lightcurve_points(config, ra, dec, radius_arcsec)
+    if not points:
+        return Response(status_code=404)
+    labels = [point["epoch"] for point in points]
+    fluxes = [point["flux_jy"] for point in points]
+    errors = [
+        point["flux_err_jy"] if np.isfinite(point["flux_err_jy"]) else 0.0 for point in points
+    ]
+    figure, axis = plt.subplots(figsize=(10, 4), dpi=100)
+    axis.errorbar(range(len(points)), fluxes, yerr=errors, fmt="o-", color="#4eb8ff", capsize=3)
+    axis.set_xticks(range(len(points)))
+    axis.set_xticklabels(labels, rotation=30, ha="right", fontsize=7, color="white")
+    axis.set_ylabel("Peak flux (Jy/beam)", color="white")
+    axis.tick_params(colors="white")
+    axis.set_title(f"RA {ra:.4f}  Dec {dec:+.4f}", color="white", fontsize=10)
+    for spine in axis.spines.values():
+        spine.set_color("#2a3038")
+    axis.set_facecolor("#111")
+    figure.patch.set_facecolor("#111")
+    plt.tight_layout()
+    from io import BytesIO
+
+    buffer = BytesIO()
+    plt.savefig(buffer, format="png", facecolor="#111")
+    plt.close(figure)
+    return Response(
+        content=buffer.getvalue(),
+        media_type="image/png",
+        headers={"Cache-Control": "max-age=60"},
     )
 
 
@@ -941,6 +1102,7 @@ def create_app(config: DashboardConfig | None = None) -> FastAPI:
     application.include_router(ops_router)
     application.include_router(control_router)
     application.include_router(control_page_router)
+    application.include_router(sources_router)
     application.include_router(legacy_router)
 
     @application.get("/", response_class=HTMLResponse)

--- a/tests/test_auto_pipeline.py
+++ b/tests/test_auto_pipeline.py
@@ -1,0 +1,51 @@
+"""Tests for the scheduled batch-pipeline launcher."""
+
+import sys
+import time
+from pathlib import Path
+
+from dsa110_continuum.observability.control import ControlConfig, get_run
+from scripts.auto_pipeline import decide_and_launch
+
+
+def _config(tmp_path: Path) -> ControlConfig:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "batch_pipeline.py").write_text("print('auto ok')\n")
+    return ControlConfig(
+        repo_root=tmp_path, python=sys.executable, control_dir=tmp_path / "control"
+    )
+
+
+def test_launches_and_registers_run(tmp_path):
+    config = _config(tmp_path)
+    outcome = decide_and_launch(date="2026-01-25", config=config)
+    assert outcome["action"] == "launched"
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        row = get_run(outcome["run_id"], config)
+        if row["status"] != "running":
+            break
+        time.sleep(0.2)
+    assert row["status"] == "succeeded"
+    assert "--retry-failed" in row["argv_json"]
+
+
+def test_skips_when_a_run_is_already_active(tmp_path):
+    config = _config(tmp_path)
+    (tmp_path / "scripts" / "batch_pipeline.py").write_text("import time; time.sleep(60)\n")
+    first = decide_and_launch(date="2026-01-25", config=config)
+    assert first["action"] == "launched"
+    try:
+        second = decide_and_launch(date="2026-01-25", config=config)
+        assert second["action"] == "skipped_running"
+    finally:
+        from dsa110_continuum.observability.control import terminate_run
+
+        terminate_run(first["run_id"], config, grace_seconds=2.0)
+
+
+def test_invalid_date_reports_error_outcome(tmp_path):
+    config = _config(tmp_path)
+    outcome = decide_and_launch(date="not-a-date", config=config)
+    assert outcome["action"] == "invalid_request"

--- a/tests/test_observability_control.py
+++ b/tests/test_observability_control.py
@@ -1,10 +1,16 @@
 """Tests for the pipeline control module (launcher, registry, terminate)."""
 
+import json
+import os
+import signal
+import sqlite3
+import subprocess
 import sys
 import time
 from pathlib import Path
 
 import pytest
+from dsa110_continuum.observability import control as control_module
 from dsa110_continuum.observability.control import (
     ControlConfig,
     RunConflictError,
@@ -184,3 +190,85 @@ class TestLaunchAndReap:
         launch_run(RunRequest(date="2026-01-25"), config)
         with pytest.raises(KeyError):
             get_run("nope", config)
+
+
+class TestProcessIdentity:
+    """Criterion: a registry row may only be treated as live — and signaled —
+    when the current occupant of its PID is the same process that was launched
+    (verified via /proc/<pid>/stat start time). PID reuse after a reboot or
+    wraparound must reconcile to 'orphaned' and make terminate refuse; it must
+    never signal a stranger's process group. Basis: PR #117 review finding 1."""
+
+    def test_identity_mismatch_reconciles_orphaned_and_refuses_terminate(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_SLEEPER)
+        config = _config(tmp_path)
+        record = launch_run(RunRequest(date="2026-01-25"), config)
+        try:
+            with sqlite3.connect(config.db_path) as connection:
+                connection.execute(
+                    "UPDATE runs SET proc_start = proc_start + 991 WHERE run_id = ?",
+                    (record["run_id"],),
+                )
+            assert get_run(record["run_id"], config)["status"] == "orphaned"
+            with pytest.raises(RunConflictError):
+                terminate_run(record["run_id"], config, grace_seconds=1.0)
+            assert Path(f"/proc/{record['pid']}").exists(), "refusal must not signal the pgid"
+        finally:
+            os.killpg(record["pid"], signal.SIGKILL)
+
+    def test_legacy_row_without_identity_is_orphaned_and_not_killable(self, tmp_path):
+        config = _config(tmp_path)
+        config.control_dir.mkdir(parents=True, exist_ok=True)
+        decoy = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(120)"], start_new_session=True
+        )
+        try:
+            with control_module._connect(config.db_path) as connection:
+                connection.execute(
+                    "INSERT INTO runs (run_id, created_at, finished_at, request_json,"
+                    " argv_json, pid, log_path, status, exit_code, proc_start)"
+                    " VALUES (?, ?, NULL, '{}', '[]', ?, ?, 'running', NULL, NULL)",
+                    ("legacy-1", "2026-07-15T00:00:00+00:00", decoy.pid, str(tmp_path / "x.log")),
+                )
+            assert get_run("legacy-1", config)["status"] == "orphaned"
+            with pytest.raises(RunConflictError):
+                terminate_run("legacy-1", config, grace_seconds=1.0)
+            assert decoy.poll() is None, "legacy row must never be signaled"
+        finally:
+            decoy.kill()
+            decoy.wait()
+
+    def test_terminate_survives_exit_race_without_error(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_SLEEPER)
+        config = _config(tmp_path)
+        record = launch_run(RunRequest(date="2026-01-25"), config)
+        try:
+
+            def _gone(pgid, sig):
+                raise ProcessLookupError(pgid)
+
+            with pytest.MonkeyPatch.context() as patcher:
+                patcher.setattr(os, "killpg", _gone)
+                result = terminate_run(record["run_id"], config, grace_seconds=0.5)
+            assert result["run_id"] == record["run_id"]
+        finally:
+            os.killpg(record["pid"], signal.SIGKILL)
+
+    def test_child_env_excludes_control_token(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DSA110_CONTROL_TOKEN", "sekrit-test-token")
+        body = (
+            "import json, os, sys, pathlib\n"
+            "pathlib.Path(sys.argv[sys.argv.index('--date') + 1] + '.env.json')"
+            ".write_text(json.dumps({'token': os.environ.get('DSA110_CONTROL_TOKEN'),"
+            " 'pythonpath': os.environ.get('PYTHONPATH')}))\n"
+        )
+        _install_fake_pipeline(tmp_path, body)
+        config = _config(tmp_path)
+        launch_run(RunRequest(date="2026-01-25"), config)
+        marker = tmp_path / "2026-01-25.env.json"
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline and not marker.exists():
+            time.sleep(0.1)
+        data = json.loads(marker.read_text())
+        assert data["token"] is None, "control token must not leak into pipeline env"
+        assert data["pythonpath"] == str(tmp_path)

--- a/tests/test_observability_control.py
+++ b/tests/test_observability_control.py
@@ -1,0 +1,186 @@
+"""Tests for the pipeline control module (launcher, registry, terminate)."""
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from dsa110_continuum.observability.control import (
+    ControlConfig,
+    RunConflictError,
+    RunRequest,
+    get_run,
+    launch_run,
+    list_runs,
+    run_dry_run,
+    terminate_run,
+)
+
+
+def _config(tmp_path: Path) -> ControlConfig:
+    return ControlConfig(
+        repo_root=tmp_path,
+        python=sys.executable,
+        control_dir=tmp_path / "control",
+    )
+
+
+FAKE_OK = "import sys; print('plan ok', ' '.join(sys.argv[1:])); sys.exit(0)\n"
+FAKE_SLEEPER = (
+    "import subprocess, sys, time, pathlib\n"
+    "child = subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(120)'])\n"
+    "pathlib.Path(sys.argv[sys.argv.index('--date') + 1] + '.childpid')"
+    ".write_text(str(child.pid))\n"
+    "time.sleep(120)\n"
+)
+
+
+def _install_fake_pipeline(tmp_path: Path, body: str) -> None:
+    scripts = tmp_path / "scripts"
+    scripts.mkdir(exist_ok=True)
+    (scripts / "batch_pipeline.py").write_text(body)
+
+
+class TestRunRequestValidation:
+    """Criterion: every field that reaches argv is validated against a closed
+    grammar (dates, hour ranges, enums, bounded ints) so no request can smuggle
+    shell metacharacters or unexpected flags; argv is built exclusively from an
+    allowlist. Basis: injection-safety invariant for a control surface."""
+
+    def test_rejects_shell_metacharacters_in_date(self):
+        for bad in ("2026-01-25; rm -rf /", "$(reboot)", "2026-01-25x", "..", ""):
+            with pytest.raises(ValueError):
+                RunRequest(date=bad)
+
+    def test_rejects_impossible_calendar_date(self):
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-13-45")
+
+    def test_rejects_out_of_range_hours_and_bad_rfi_mode(self):
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-01-25", start_hour=24)
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-01-25", end_hour=-1)
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-01-25", start_hour=5, end_hour=3)
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-01-25", rfi_mode="sometimes")
+
+    def test_rejects_out_of_bound_numeric_knobs(self):
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-01-25", tile_timeout=10)
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-01-25", quarantine_after_failures=100)
+        with pytest.raises(ValueError):
+            RunRequest(date="2026-01-25", photometry_workers=0)
+
+    def test_argv_is_allowlisted_flags_only(self, tmp_path):
+        request = RunRequest(
+            date="2026-01-25",
+            cal_date="2026-01-25",
+            start_hour=22,
+            end_hour=23,
+            force_recal=True,
+            retry_failed=True,
+            lenient_qa=True,
+            rfi_mode="conditional",
+            quarantine_after_failures=3,
+        )
+        argv = request.to_argv(_config(tmp_path))
+        assert argv[0] == sys.executable
+        assert argv[1] == "scripts/batch_pipeline.py"
+        assert "--date" in argv and "2026-01-25" in argv
+        assert "--start-hour" in argv and "22" in argv
+        assert "--force-recal" in argv and "--retry-failed" in argv
+        assert "--rfi-mode" in argv and "conditional" in argv
+        assert "--skip-photometry" not in argv and "--dry-run" not in argv
+        joined = " ".join(argv)
+        assert ";" not in joined and "$(" not in joined
+
+
+class TestLaunchAndReap:
+    """Criterion: a launched run is registered immediately with status running,
+    its exit is reaped into succeeded/failed with the real exit code, its output
+    lands in the per-run log, and only one launcher-owned run may be alive at a
+    time. Basis: run-registry state machine contract."""
+
+    def test_launch_registers_run_and_reaper_marks_succeeded(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_OK)
+        config = _config(tmp_path)
+        record = launch_run(RunRequest(date="2026-01-25"), config)
+        assert record["status"] == "running" and record["pid"] > 0
+        deadline = time.monotonic() + 15
+        row = record
+        while time.monotonic() < deadline:
+            row = get_run(record["run_id"], config)
+            if row["status"] not in ("running", "orphaned"):
+                break
+            time.sleep(0.2)
+        assert row["status"] == "succeeded" and row["exit_code"] == 0
+        assert "plan ok" in Path(row["log_path"]).read_text()
+
+    def test_failed_pipeline_is_reaped_as_failed(self, tmp_path):
+        _install_fake_pipeline(tmp_path, "import sys; sys.exit(3)\n")
+        config = _config(tmp_path)
+        record = launch_run(RunRequest(date="2026-01-25"), config)
+        deadline = time.monotonic() + 15
+        row = record
+        while time.monotonic() < deadline:
+            row = get_run(record["run_id"], config)
+            if row["status"] not in ("running", "orphaned"):
+                break
+            time.sleep(0.2)
+        assert row["status"] == "failed" and row["exit_code"] == 3
+
+    def test_single_flight_guard_rejects_concurrent_launch(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_SLEEPER)
+        config = _config(tmp_path)
+        first = launch_run(RunRequest(date="2026-01-25"), config)
+        try:
+            with pytest.raises(RunConflictError):
+                launch_run(RunRequest(date="2026-01-26"), config)
+        finally:
+            terminate_run(first["run_id"], config, grace_seconds=2.0)
+
+    def test_terminate_kills_whole_process_group(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_SLEEPER)
+        config = _config(tmp_path)
+        record = launch_run(RunRequest(date="2026-01-25"), config)
+        childpid_file = tmp_path / "2026-01-25.childpid"
+        deadline = time.monotonic() + 10
+        while time.monotonic() < deadline and not childpid_file.exists():
+            time.sleep(0.1)
+        assert childpid_file.exists(), "fake pipeline never spawned its child"
+        child_pid = int(childpid_file.read_text())
+        terminate_run(record["run_id"], config, grace_seconds=2.0)
+        row = get_run(record["run_id"], config)
+        assert row["status"] == "terminated"
+        time.sleep(0.5)
+        assert not Path(f"/proc/{record['pid']}").exists()
+        assert not Path(f"/proc/{child_pid}").exists()
+
+    def test_terminate_non_running_run_raises(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_OK)
+        config = _config(tmp_path)
+        record = launch_run(RunRequest(date="2026-01-25"), config)
+        deadline = time.monotonic() + 15
+        while time.monotonic() < deadline:
+            if get_run(record["run_id"], config)["status"] == "succeeded":
+                break
+            time.sleep(0.2)
+        with pytest.raises(RunConflictError):
+            terminate_run(record["run_id"], config)
+
+    def test_dry_run_returns_plan_text_and_registers_nothing(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_OK)
+        config = _config(tmp_path)
+        output = run_dry_run(RunRequest(date="2026-01-25", dry_run=True), config)
+        assert "plan ok" in output and "--dry-run" in output
+        assert list_runs(config) == []
+
+    def test_get_unknown_run_raises_keyerror(self, tmp_path):
+        _install_fake_pipeline(tmp_path, FAKE_OK)
+        config = _config(tmp_path)
+        launch_run(RunRequest(date="2026-01-25"), config)
+        with pytest.raises(KeyError):
+            get_run("nope", config)

--- a/tests/test_observability_hour_state.py
+++ b/tests/test_observability_hour_state.py
@@ -1,0 +1,406 @@
+import os
+from datetime import datetime
+from pathlib import Path
+
+import dsa110_continuum.observability.dagster_defs as dagster_defs
+import pytest
+from dsa110_continuum.observability.dagster_defs import ASSET_NAMES, _readiness_markdown, defs
+from dsa110_continuum.observability.hour_state import HourStateConfig, collect_hour_state
+from dsa110_continuum.observability.mosaic_preview import (
+    mosaic_preview_markdown,
+    qa_thumb_url,
+    resolve_thumb_source,
+    sync_mosaic_thumb,
+)
+
+
+def _tmp_config(tmp_path: Path, **overrides) -> HourStateConfig:
+    kwargs = {
+        "stage": tmp_path / "stage",
+        "products": tmp_path / "products",
+        "incoming": tmp_path / "incoming",
+        "campaign_outputs": tmp_path / "campaign",
+        "disk_roots": (tmp_path,),
+    }
+    kwargs.update(overrides)
+    return HourStateConfig(**kwargs)
+
+
+def _no_processes(monkeypatch):
+    monkeypatch.setattr("dsa110_continuum.observability.hour_state._process_status", lambda: [])
+
+
+def test_collect_hour_state_reports_external_products(tmp_path: Path, monkeypatch):
+    stage = tmp_path / "stage"
+    ms_dir = stage / "ms"
+    image_dir = stage / "images" / "mosaic_2026-07-13"
+    incoming = tmp_path / "incoming"
+    products = tmp_path / "products"
+    campaign = tmp_path / "campaign"
+    for directory in (ms_dir, image_dir, incoming, products / "2026-07-13", campaign):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    (ms_dir / "2026-07-13T11:01:00.ms").mkdir()
+    (ms_dir / "2026-07-13T11:01:00.b").write_text("bandpass")
+    (ms_dir / "2026-07-13T11:01:00.g").write_text("gain")
+    (image_dir / "2026-07-13T11:01:00-image.fits").write_text("tile")
+    (image_dir / "2026-07-13T1100_mosaic.fits").write_text("mosaic")
+    (incoming / "2026-07-13T11:01:00_sb00.hdf5").write_text("hdf5")
+    (campaign / "batch_run_h11.log").write_text("campaign running\n")
+    (campaign / "batch_attempt5.pid").write_text("999999\n")
+    monkeypatch.setattr(
+        "dsa110_continuum.observability.hour_state._process_status",
+        lambda: [{"pid": 42, "command": "scripts/batch_pipeline.py"}],
+    )
+
+    state = collect_hour_state(
+        HourStateConfig(
+            stage=stage,
+            products=products,
+            incoming=incoming,
+            campaign_outputs=campaign,
+            disk_roots=(tmp_path,),
+        )
+    )
+
+    assert state["measurement_sets"]["count"] == 1
+    assert state["calibration"]["bandpass_count"] == 1
+    assert state["calibration"]["gain_count"] == 1
+    assert state["tiles"]["count"] == 1
+    assert state["mosaic"]["path"].endswith("2026-07-13T1100_mosaic.fits")
+    assert state["incoming"]["count"] == 1
+    assert state["campaign"]["log_tail"] == ["campaign running"]
+    assert state["campaign"]["state"] == "running"
+    assert state["summary"]["campaign_state"] == "running"
+    assert state["summary"]["campaign_process_visible"] is True
+
+
+def test_collect_hour_state_distinguishes_absent_and_finished_campaigns(
+    tmp_path: Path, monkeypatch
+):
+    campaign = tmp_path / "campaign"
+    campaign.mkdir()
+    monkeypatch.setattr("dsa110_continuum.observability.hour_state._process_status", lambda: [])
+    config = HourStateConfig(
+        stage=tmp_path / "stage",
+        products=tmp_path / "products",
+        incoming=tmp_path / "incoming",
+        campaign_outputs=campaign,
+        disk_roots=(tmp_path,),
+    )
+
+    assert collect_hour_state(config)["campaign"]["state"] == "absent"
+
+    (campaign / "batch_run_h11.log").write_text("complete\n")
+
+    assert collect_hour_state(config)["campaign"]["state"] == "finished"
+
+
+def test_dagster_definitions_expose_six_observability_assets():
+    asset_graph = defs.resolve_asset_graph()
+    asset_keys = {key.to_user_string() for key in asset_graph.get_all_asset_keys()}
+
+    assert asset_keys == set(ASSET_NAMES)
+    assert all(asset_graph.get(key).description for key in asset_graph.get_all_asset_keys())
+    assert defs.resolve_sensor_def("refresh_hour_11_observability_sensor") is not None
+
+
+def test_readiness_markdown_is_an_operator_checklist():
+    state = {
+        "date": "2026-07-13",
+        "hour": 11,
+        "summary": {
+            "campaign_state": "finished",
+            "measurement_sets_present": True,
+            "calibration_present": True,
+            "tiles_present": True,
+            "mosaic_present": False,
+            "incoming_hdf5_present": True,
+            "campaign_process_visible": False,
+            "campaign_pid_visible": False,
+        },
+    }
+
+    checklist = _readiness_markdown(state)
+
+    assert "2026-07-13 UTC hour 11" in checklist
+    assert "Campaign state:** `finished`" in checklist
+    assert "| hourly-epoch mosaic | not visible |" in checklist
+    assert "does not launch or retry pipeline work" in checklist
+
+
+def test_qa_thumb_url_uses_epoch_token():
+    assert qa_thumb_url("2026-07-13", 11) == (
+        "http://127.0.0.1:8767/artifacts/mosaic/2026-07-13/T1100/thumb.png"
+    )
+
+
+def test_sync_mosaic_thumb_copies_png_into_static_root(tmp_path: Path):
+    campaign = tmp_path / "campaign"
+    preview_dir = campaign / "previews"
+    preview_dir.mkdir(parents=True)
+    source = preview_dir / "2026-07-13T1100_mosaic_qa_thumb.png"
+    source.write_bytes(b"\x89PNG\r\n\x1a\n" + b"fake-thumb")
+    static_root = tmp_path / "dagster-static"
+    config = HourStateConfig(
+        stage=tmp_path / "stage",
+        products=tmp_path / "products",
+        incoming=tmp_path / "incoming",
+        campaign_outputs=campaign,
+        disk_roots=(tmp_path,),
+    )
+
+    assert resolve_thumb_source(config) == source
+    preview = sync_mosaic_thumb(
+        config,
+        fits_path="/stage/example.fits",
+        static_root=static_root,
+    )
+
+    assert preview["synced"] is True
+    assert preview["epoch"] == "T1100"
+    dest = static_root / "dsa110" / "2026-07-13_T1100_mosaic_thumb.png"
+    assert dest.is_file()
+    assert (static_root / "dsa110" / "hour11_mosaic.html").is_file()
+    md = mosaic_preview_markdown(preview, mosaic_path="/stage/example.fits")
+    assert "![mosaic thumbnail]" in md
+    assert preview["dagster_page_url"] in md
+
+
+class TestHourStateConfigValidation:
+    """Correctness criterion: input-domain boundary behavior (fail-loud).
+
+    Valid inputs are exactly the UTC hours 0..23 inclusive and real Gregorian
+    calendar dates in YYYY-MM-DD form. Anything outside must raise ValueError
+    at construction; accepting it would silently produce an all-absent snapshot
+    for a nonsense epoch. Basis: UTC hour definition and calendar arithmetic
+    (closed-form domain), not a pinned output.
+    """
+
+    def test_hour_boundaries_accepted(self, tmp_path):
+        assert _tmp_config(tmp_path, hour=0).hour == 0
+        assert _tmp_config(tmp_path, hour=23).hour == 23
+
+    @pytest.mark.parametrize("hour", [-1, 24, 100])
+    def test_out_of_range_hour_rejected(self, tmp_path, hour):
+        with pytest.raises(ValueError):
+            _tmp_config(tmp_path, hour=hour)
+
+    @pytest.mark.parametrize("date", ["2026-13-01", "2026-02-30", "2026-00-10"])
+    def test_non_calendar_date_rejected(self, tmp_path, date):
+        with pytest.raises(ValueError):
+            _tmp_config(tmp_path, date=date)
+
+    @pytest.mark.parametrize("date", ["2026-7-13", "20260713", "2026-07-13T11"])
+    def test_malformed_date_rejected(self, tmp_path, date):
+        with pytest.raises(ValueError):
+            _tmp_config(tmp_path, date=date)
+
+
+class TestUtcHourBinSelection:
+    """Correctness criterion: UTC-hour bin definition.
+
+    An artifact belongs to hour H iff its filename timestamp falls in
+    [H:00:00, H+1:00:00) — equivalently, the HH field of the
+    YYYY-MM-DDTHH:MM:SS stem equals H, zero-padded. Basis: the stage/incoming
+    filename convention shared with scripts/qa_server.py; verified with
+    boundary timestamps on both bin edges (analytic bin edges, not pinned
+    counts of an arbitrary fixture).
+    """
+
+    def test_hour_bin_edges_include_hour_exclude_neighbours(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        ms_dir = tmp_path / "stage" / "ms"
+        ms_dir.mkdir(parents=True)
+        for stamp in (
+            "2026-07-13T10:59:59",
+            "2026-07-13T11:00:00",
+            "2026-07-13T11:59:59",
+            "2026-07-13T12:00:00",
+        ):
+            (ms_dir / f"{stamp}.ms").mkdir()
+
+        state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13", hour=11))
+
+        assert state["measurement_sets"]["count"] == 2
+        names = [Path(p).name for p in state["measurement_sets"]["paths"]]
+        assert names == ["2026-07-13T11:00:00.ms", "2026-07-13T11:59:59.ms"]
+
+    def test_single_digit_hour_is_zero_padded(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        ms_dir = tmp_path / "stage" / "ms"
+        ms_dir.mkdir(parents=True)
+        (ms_dir / "2026-07-13T05:30:00.ms").mkdir()
+
+        state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13", hour=5))
+
+        assert state["measurement_sets"]["count"] == 1
+
+    def test_campaign_log_glob_accepts_padded_and_unpadded_hour(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        campaign = tmp_path / "campaign"
+        campaign.mkdir()
+        padded = campaign / "batch_run_h05_a.log"
+        unpadded = campaign / "batch_run_h5_b.log"
+        padded.write_text("old\n")
+        unpadded.write_text("new\n")
+        os.utime(padded, (1_000, 1_000))
+        os.utime(unpadded, (2_000, 2_000))
+
+        state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13", hour=5))
+
+        assert state["campaign"]["log"]["path"].endswith("batch_run_h5_b.log")
+
+
+class TestCampaignStateMachine:
+    """Correctness criterion: campaign-state precedence invariant.
+
+    running > finished > absent: any live evidence (matching process OR a
+    recorded PID visible in /proc) forces `running` regardless of artifacts;
+    artifacts without live evidence give `finished`; neither gives `absent`.
+    Basis: the state machine's documented precedence — adding stronger
+    evidence must never demote the state (monotonicity), verified by
+    constructing each evidence combination explicitly.
+    """
+
+    def test_visible_pid_hint_alone_means_running(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        campaign = tmp_path / "campaign"
+        campaign.mkdir()
+        (campaign / "watch.pid").write_text(f"{os.getpid()}\n")
+
+        state = collect_hour_state(_tmp_config(tmp_path))
+
+        assert state["summary"]["campaign_pid_visible"] is True
+        assert state["summary"]["campaign_process_visible"] is False
+        assert state["campaign"]["state"] == "running"
+
+    def test_manifest_alone_means_finished(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        product_dir = tmp_path / "products" / "2026-07-13"
+        product_dir.mkdir(parents=True)
+        (product_dir / "2026-07-13_manifest.json").write_text("{}")
+
+        state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13"))
+
+        assert state["campaign"]["state"] == "finished"
+
+    def test_running_takes_precedence_over_finished_artifacts(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "dsa110_continuum.observability.hour_state._process_status",
+            lambda: [{"pid": 42, "elapsed_seconds": 1, "state": "S", "command": "wsclean"}],
+        )
+        campaign = tmp_path / "campaign"
+        campaign.mkdir()
+        (campaign / "batch_run_h11.log").write_text("done\n")
+
+        state = collect_hour_state(_tmp_config(tmp_path, hour=11))
+
+        assert state["campaign"]["state"] == "running"
+
+
+class TestFileRecordTailOrdering:
+    """Correctness criteria for the filesystem probe helpers.
+
+    (a) `_file_record` timestamps: a file whose mtime is set to the Unix epoch
+        must report modified_utc == 1970-01-01T00:00:00+00:00 (closed-form:
+        definition of the Unix epoch in UTC) and size_bytes equal to the exact
+        byte count written. Exact string/int equality is valid — no float
+        arithmetic is involved for an integer mtime.
+    (b) `_latest` ordering invariant: selection is by mtime, never by name —
+        verified by making the lexicographically-first name the newest file.
+    (c) `_tail` boundary: exactly the last 24 lines of a longer file, in file
+        order, with trailing whitespace stripped (definition of a tail).
+    """
+
+    def test_file_record_epoch_mtime_and_exact_size(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        image_dir = tmp_path / "stage" / "images" / "mosaic_2026-07-13"
+        image_dir.mkdir(parents=True)
+        mosaic = image_dir / "2026-07-13T1100_mosaic.fits"
+        mosaic.write_bytes(b"12345")
+        os.utime(mosaic, (0, 0))
+
+        state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13", hour=11))
+
+        assert state["mosaic"]["size_bytes"] == 5
+        assert state["mosaic"]["modified_utc"] == "1970-01-01T00:00:00+00:00"
+
+    def test_latest_tile_selected_by_mtime_not_name(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        image_dir = tmp_path / "stage" / "images" / "mosaic_2026-07-13"
+        image_dir.mkdir(parents=True)
+        first_name = image_dir / "2026-07-13T11:01:00-image.fits"
+        last_name = image_dir / "2026-07-13T11:02:00-image.fits"
+        first_name.write_text("tile")
+        last_name.write_text("tile")
+        os.utime(first_name, (2_000, 2_000))
+        os.utime(last_name, (1_000, 1_000))
+
+        state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13", hour=11))
+
+        assert state["tiles"]["latest"]["path"].endswith("T11:01:00-image.fits")
+
+    def test_log_tail_is_last_24_lines_rstripped(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        campaign = tmp_path / "campaign"
+        campaign.mkdir()
+        lines = [f"line-{i:02d}   " for i in range(30)]
+        (campaign / "batch_run_h11.log").write_text("\n".join(lines) + "\n")
+
+        state = collect_hour_state(_tmp_config(tmp_path, hour=11))
+
+        assert state["campaign"]["log_tail"] == [f"line-{i:02d}" for i in range(6, 30)]
+
+
+class TestSnapshotIdempotence:
+    """Correctness criterion: the probe is read-only and idempotent.
+
+    Basis: module contract ("Read-only filesystem and process probes").
+    Two consecutive calls on an unchanged filesystem must return identical
+    state apart from `generated_at` (wall clock) and `disks` (usage of a live
+    volume), and must not create, remove, or modify any probed file.
+    """
+
+    def test_collect_twice_identical_and_creates_nothing(self, tmp_path, monkeypatch):
+        _no_processes(monkeypatch)
+        campaign = tmp_path / "campaign"
+        campaign.mkdir()
+        (campaign / "batch_run_h11.log").write_text("done\n")
+        ms_dir = tmp_path / "stage" / "ms"
+        ms_dir.mkdir(parents=True)
+        (ms_dir / "2026-07-13T11:01:00.ms").mkdir()
+        config = _tmp_config(tmp_path, date="2026-07-13", hour=11)
+
+        before = sorted(str(p) for p in tmp_path.rglob("*"))
+        first = collect_hour_state(config)
+        second = collect_hour_state(config)
+        after = sorted(str(p) for p in tmp_path.rglob("*"))
+
+        assert after == before
+        for state in (first, second):
+            state.pop("generated_at")
+            state.pop("disks")
+        assert first == second
+
+
+class TestSensorRunKey:
+    """Correctness criterion: sensor run-key granularity is one UTC minute.
+
+    Dagster de-duplicates runs by run_key, so the key must be constant within
+    a minute (seconds and microseconds truncated) to cap the refresh rate at
+    the sensor's minimum_interval_seconds=60. Basis: Dagster run_key dedupe
+    semantics; verified with a frozen clock at an arbitrary in-minute instant.
+    """
+
+    def test_run_key_truncates_to_minute(self, monkeypatch):
+        class _Frozen(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 7, 13, 11, 42, 37, 123456, tzinfo=tz)
+
+        monkeypatch.setattr(dagster_defs, "datetime", _Frozen)
+
+        request = dagster_defs.refresh_hour_11_observability_sensor()
+
+        assert request.run_key == "2026-07-13T11:42:00+00:00"

--- a/tests/test_observability_hour_state.py
+++ b/tests/test_observability_hour_state.py
@@ -135,7 +135,10 @@ def test_qa_thumb_url_uses_epoch_token():
     )
 
 
-def test_sync_mosaic_thumb_copies_png_into_static_root(tmp_path: Path):
+def test_sync_mosaic_thumb_copies_png_into_static_root(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(
+        "dsa110_continuum.observability.mosaic_preview.webapp_build_dir", lambda: None
+    )
     campaign = tmp_path / "campaign"
     preview_dir = campaign / "previews"
     preview_dir.mkdir(parents=True)
@@ -250,6 +253,23 @@ class TestUtcHourBinSelection:
         state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13", hour=5))
 
         assert state["campaign"]["log"]["path"].endswith("batch_run_h5_b.log")
+
+    def test_campaign_log_glob_rejects_other_hours_sharing_digit_prefix(
+        self, tmp_path, monkeypatch
+    ):
+        _no_processes(monkeypatch)
+        campaign = tmp_path / "campaign"
+        campaign.mkdir()
+        own = campaign / "batch_run_h1_a.log"
+        other = campaign / "batch_run_h11_b.log"
+        own.write_text("own\n")
+        other.write_text("other\n")
+        os.utime(own, (1_000, 1_000))
+        os.utime(other, (2_000, 2_000))
+
+        state = collect_hour_state(_tmp_config(tmp_path, date="2026-07-13", hour=1))
+
+        assert state["campaign"]["log"]["path"].endswith("batch_run_h1_a.log")
 
 
 class TestCampaignStateMachine:

--- a/tests/test_observability_mosaic_preview.py
+++ b/tests/test_observability_mosaic_preview.py
@@ -1,0 +1,223 @@
+import os
+import re
+from pathlib import Path
+
+from dsa110_continuum.observability import mosaic_preview
+from dsa110_continuum.observability.hour_state import HourStateConfig, collect_hour_state
+from dsa110_continuum.observability.mosaic_preview import (
+    dagster_public_url,
+    epoch_label,
+    mosaic_preview_markdown,
+    qa_thumb_url,
+    resolve_thumb_source,
+    sync_mosaic_thumb,
+)
+
+QA_SERVER_EPOCH_RE = re.compile(r"T\d{4}")
+
+
+def _config(tmp_path: Path, date: str = "2026-07-12", hour: int = 7) -> HourStateConfig:
+    return HourStateConfig(
+        date=date,
+        hour=hour,
+        stage=tmp_path / "stage",
+        products=tmp_path / "products",
+        incoming=tmp_path / "incoming",
+        campaign_outputs=tmp_path / "campaign",
+        disk_roots=(tmp_path,),
+    )
+
+
+def _isolate_thumb_fallback(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("DSA110_QA_THUMBS", str(tmp_path / "qa_thumbs"))
+
+
+class TestEpochTokenContract:
+    """Correctness criterion: cross-module epoch-token agreement.
+
+    Reference implementation: scripts/qa_server.py validates epochs with
+    EPOCH_RE = `T\\d{4}` (fullmatch), serves thumbnails at
+    /artifacts/mosaic/{date}/{epoch}/thumb.png, and resolves mosaics as
+    {date}{epoch}_mosaic.fits — the same filename hour_state constructs.
+    epoch_label/qa_thumb_url must reproduce those exact tokens and routes for
+    every valid hour, zero-padded, or dashboard links 404 silently.
+    """
+
+    def test_epoch_label_matches_qa_server_regex_for_all_hours(self):
+        for hour in range(24):
+            assert QA_SERVER_EPOCH_RE.fullmatch(epoch_label(hour))
+        assert epoch_label(5) == "T0500"
+        assert epoch_label(23) == "T2300"
+
+    def test_qa_thumb_url_matches_qa_server_route(self):
+        assert qa_thumb_url("2026-07-12", 7, base="http://qa:1") == (
+            "http://qa:1/artifacts/mosaic/2026-07-12/T0700/thumb.png"
+        )
+
+    def test_epoch_label_composes_hour_state_mosaic_filename(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("dsa110_continuum.observability.hour_state._process_status", lambda: [])
+        image_dir = tmp_path / "stage" / "images" / "mosaic_2026-07-12"
+        image_dir.mkdir(parents=True)
+        (image_dir / f"2026-07-12{epoch_label(7)}_mosaic.fits").write_text("mosaic")
+
+        state = collect_hour_state(_config(tmp_path))
+
+        assert state["mosaic"] is not None
+        assert state["summary"]["mosaic_present"] is True
+
+
+class TestUrlEnvHandling:
+    """Correctness criterion: URL well-formedness under env variation.
+
+    A base URL configured with a trailing slash must not yield `//` in the
+    route (route matching would fail), and a wildcard bind host (0.0.0.0/::)
+    must be rewritten to loopback because a bind address is not
+    browser-routable. Basis: URL syntax and bind-vs-connect address semantics.
+    """
+
+    def test_trailing_slash_base_produces_single_slash_route(self, monkeypatch):
+        monkeypatch.setenv("DSA110_QA_BASE_URL", "http://host:8767/")
+
+        url = qa_thumb_url("2026-07-12", 7)
+
+        assert url == "http://host:8767/artifacts/mosaic/2026-07-12/T0700/thumb.png"
+        assert "//" not in url.split("://", 1)[1]
+
+    def test_wildcard_bind_host_rewritten_to_loopback(self, monkeypatch):
+        monkeypatch.delenv("DSA110_DAGSTER_PUBLIC_URL", raising=False)
+        monkeypatch.setenv("DSA110_DAGSTER_HOST", "0.0.0.0")
+        monkeypatch.setenv("DSA110_DAGSTER_PORT", "1234")
+
+        assert dagster_public_url() == "http://127.0.0.1:1234"
+
+
+class TestThumbSourceResolution:
+    """Correctness criteria for resolve_thumb_source.
+
+    (a) A zero-byte file is never a valid PNG, so empty candidates must be
+        skipped (file-format invariant, not a pinned value).
+    (b) Candidate precedence follows the documented order: campaign previews
+        beat the stage qa_diag copy; the DSA110_QA_THUMBS cache is a last
+        resort and within it the newest mtime wins.
+    (c) With no candidates the result is None (never a guess).
+    Tests use date 2026-07-12 / hour 7 so the hard-coded 2026-07-13 candidate
+    directory on H17 cannot leak in.
+    """
+
+    def _preview_png(self, tmp_path: Path, content: bytes = b"png-bytes") -> Path:
+        preview_dir = tmp_path / "campaign" / "previews"
+        preview_dir.mkdir(parents=True, exist_ok=True)
+        path = preview_dir / "2026-07-12T0700_mosaic_qa_thumb.png"
+        path.write_bytes(content)
+        return path
+
+    def _stage_png(self, tmp_path: Path) -> Path:
+        image_dir = tmp_path / "stage" / "images" / "mosaic_2026-07-12"
+        image_dir.mkdir(parents=True, exist_ok=True)
+        path = image_dir / "2026-07-12T0700_mosaic_qa_diag.png"
+        path.write_bytes(b"diag-bytes")
+        return path
+
+    def test_no_candidates_returns_none(self, tmp_path, monkeypatch):
+        _isolate_thumb_fallback(monkeypatch, tmp_path)
+
+        assert resolve_thumb_source(_config(tmp_path)) is None
+
+    def test_zero_byte_candidate_skipped(self, tmp_path, monkeypatch):
+        _isolate_thumb_fallback(monkeypatch, tmp_path)
+        self._preview_png(tmp_path, content=b"")
+        stage = self._stage_png(tmp_path)
+
+        assert resolve_thumb_source(_config(tmp_path)) == stage
+
+    def test_campaign_preview_preferred_over_stage_diag(self, tmp_path, monkeypatch):
+        _isolate_thumb_fallback(monkeypatch, tmp_path)
+        preview = self._preview_png(tmp_path)
+        self._stage_png(tmp_path)
+
+        assert resolve_thumb_source(_config(tmp_path)) == preview
+
+    def test_qa_thumbs_fallback_picks_newest_match(self, tmp_path, monkeypatch):
+        thumbs = tmp_path / "qa_thumbs"
+        thumbs.mkdir()
+        monkeypatch.setenv("DSA110_QA_THUMBS", str(thumbs))
+        older = thumbs / "2026-07-12_T0700_aaa.png"
+        newer = thumbs / "2026-07-12_T0700_bbb.png"
+        older.write_bytes(b"old")
+        newer.write_bytes(b"new")
+        os.utime(older, (2_000, 2_000))
+        os.utime(newer, (3_000, 3_000))
+
+        assert resolve_thumb_source(_config(tmp_path)) == newer
+
+
+class TestSyncMosaicThumb:
+    """Correctness criteria for sync_mosaic_thumb.
+
+    (a) With no thumbnail source the call must report synced=False and write
+        nothing (read-only-when-nothing-to-do invariant).
+    (b) The sync is idempotent: a second call with unchanged inputs succeeds,
+        the destination byte-for-byte equals the source, and the static-root
+        file set does not grow.
+    (c) The hard-coded hour-11 alias files are written only for the
+        2026-07-13/11 campaign, never for other epochs.
+    webapp_build_dir is patched to None so tests never write into the real
+    dagster_webserver site-packages tree.
+    """
+
+    def test_no_source_is_unsynced_and_writes_nothing(self, tmp_path, monkeypatch):
+        _isolate_thumb_fallback(monkeypatch, tmp_path)
+        monkeypatch.setattr(mosaic_preview, "webapp_build_dir", lambda: None)
+        static_root = tmp_path / "static"
+
+        result = sync_mosaic_thumb(_config(tmp_path), static_root=static_root)
+
+        assert result["synced"] is False
+        assert result["source_path"] is None
+        assert not static_root.exists()
+
+    def test_sync_idempotent_and_no_hour11_alias_for_other_epochs(self, tmp_path, monkeypatch):
+        _isolate_thumb_fallback(monkeypatch, tmp_path)
+        monkeypatch.setattr(mosaic_preview, "webapp_build_dir", lambda: None)
+        preview_dir = tmp_path / "campaign" / "previews"
+        preview_dir.mkdir(parents=True)
+        source = preview_dir / "2026-07-12T0700_mosaic_qa_thumb.png"
+        source.write_bytes(b"\x89PNG\r\n\x1a\npixels")
+        static_root = tmp_path / "static"
+        config = _config(tmp_path)
+
+        first = sync_mosaic_thumb(config, static_root=static_root)
+        files_after_first = sorted(p.name for p in (static_root / "dsa110").iterdir())
+        second = sync_mosaic_thumb(config, static_root=static_root)
+        files_after_second = sorted(p.name for p in (static_root / "dsa110").iterdir())
+
+        assert first["synced"] is True and second["synced"] is True
+        assert files_after_first == files_after_second
+        dest = static_root / "dsa110" / "2026-07-12_T0700_mosaic_thumb.png"
+        assert dest.read_bytes() == source.read_bytes()
+        assert not (static_root / "dsa110" / "hour11_mosaic_thumb.png").exists()
+        assert not (static_root / "dsa110" / "hour11_mosaic.html").exists()
+
+
+class TestPreviewMarkdownFallback:
+    """Correctness criterion: the markdown always references a renderable image.
+
+    When the static sync did not happen but a qa_server URL exists, the inline
+    image must point at qa_server — pointing at the never-written dagster
+    static path would render a broken image silently. Basis: the unsynced
+    dagster thumb path has no file behind it by construction.
+    """
+
+    def test_unsynced_preview_embeds_qa_server_image(self):
+        preview = {
+            "epoch": "T0700",
+            "qa_thumb_url": "http://qa:1/artifacts/mosaic/2026-07-12/T0700/thumb.png",
+            "dagster_thumb_url": "http://d:2/dsa110/2026-07-12_T0700_mosaic_thumb.png",
+            "dagster_page_url": "http://d:2/dsa110/2026-07-12_T0700_mosaic.html",
+            "synced": False,
+        }
+
+        md = mosaic_preview_markdown(preview, mosaic_path=None)
+
+        assert f"![mosaic thumbnail]({preview['qa_thumb_url']})" in md
+        assert f"![mosaic thumbnail]({preview['dagster_thumb_url']})" not in md

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -657,3 +657,82 @@ class TestControlAuth:
                 headers={"Authorization": "Bearer s3cret"},
             )
             assert client.get("/api/runs/nope").status_code == 404
+
+
+class TestEpochDiscovery:
+    """Criterion: the historical QA list derives from actual mosaics on stage
+    (newest mtime first, canonical names only), falling back to the static
+    EPOCHS list when stage is empty so the dashboard never renders blank.
+    Basis: filesystem-truth navigation replacing the hardcoded epoch list."""
+
+    def test_discovers_epochs_from_stage_newest_first(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        old = _write_mosaic(config, "2026-01-25", "T0200", np.ones((4, 4), np.float32))
+        _write_mosaic(config, "2026-07-13", "T1100", np.ones((4, 4), np.float32))
+        os.utime(old, (1, 1))
+        discovered = qa_server.discover_epochs(config)
+        assert discovered[0] == ("2026-07-13", "T1100")
+        assert ("2026-01-25", "T0200") in discovered
+
+    def test_falls_back_to_static_epochs_when_stage_empty(self, tmp_path: Path):
+        assert qa_server.discover_epochs(_make_config(tmp_path)) == qa_server.EPOCHS
+
+    def test_ignores_malformed_names_and_respects_limit(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        directory = config.stage / "images" / "mosaic_2026-01-25"
+        directory.mkdir(parents=True)
+        (directory / "junk_mosaic.fits").write_bytes(b"x")
+        assert qa_server.discover_epochs(config) == qa_server.EPOCHS
+        for hour in range(5):
+            _write_mosaic(config, "2026-01-25", f"T{hour:02d}00", np.ones((2, 2), np.float32))
+        assert len(qa_server.discover_epochs(config, limit=3)) == 3
+
+
+class TestControlUi:
+    """Criterion: the dashboard exposes the control surface (form posting to
+    /api/runs) and per-run detail pages render registry state plus an
+    HTML-escaped log tail. Basis: operator-facing contract of the control UI."""
+
+    def test_dashboard_shows_pipeline_control_panel(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        monkeypatch.setenv("DSA110_CONTROL_DIR", str(tmp_path / "control"))
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            page = client.get("/").text
+        assert "Pipeline control" in page
+        assert 'id="run-form"' in page and "/api/runs" in page
+        assert 'id="control-token"' in page
+
+    def test_run_detail_page_renders_log_tail_escaped(self, tmp_path: Path, monkeypatch):
+        import sys as _sys
+        import time as _time
+
+        monkeypatch.setenv("DSA110_CONTROL_DIR", str(tmp_path / "control"))
+        monkeypatch.setenv("DSA110_PIPELINE_PYTHON", _sys.executable)
+        monkeypatch.setenv("DSA110_REPO_ROOT", str(tmp_path))
+        (tmp_path / "scripts").mkdir()
+        (tmp_path / "scripts" / "batch_pipeline.py").write_text(
+            "print('hello from run <script>bad</script>')\n"
+        )
+        from dsa110_continuum.observability.control import (
+            ControlConfig,
+            RunRequest,
+            launch_run,
+        )
+
+        record = launch_run(
+            RunRequest(date="2026-01-25"),
+            ControlConfig(
+                repo_root=tmp_path, python=_sys.executable, control_dir=tmp_path / "control"
+            ),
+        )
+        _time.sleep(1.0)
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            page = client.get(f"/control/runs/{record['run_id']}")
+        assert page.status_code == 200
+        assert "hello from run" in page.text
+        assert "<script>bad</script>" not in page.text
+
+    def test_unknown_run_page_is_404(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("DSA110_CONTROL_DIR", str(tmp_path / "control"))
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            assert client.get("/control/runs/nope").status_code == 404

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -812,3 +812,80 @@ class TestRunProvenancePage:
         with TestClient(create_app(_make_config(tmp_path))) as client:
             assert client.get("/runs/2026-01-26").status_code == 404
             assert 400 <= client.get("/runs/..%2f..%2fetc").status_code < 500
+
+
+class TestLightcurveView:
+    """Criterion: /sources/lightcurve matches the nearest forced-photometry
+    source per epoch within a positional radius (RA scaled by cos(dec)), renders
+    a table + PNG + eta/V variability metrics from the canonical formulas, and
+    rejects out-of-range coordinates. Basis: forced-phot CSV schema on disk
+    (ra_deg, dec_deg, dsa_peak_jyb, ...) and beam-scale positional matching."""
+
+    HEADER = "ra_deg,dec_deg,nvss_flux_jy,dsa_peak_jyb,dsa_peak_err_jyb,dsa_nvss_ratio\n"
+
+    def _write_epoch_csv(self, config: DashboardConfig, date: str, epoch: str, flux: float):
+        directory = config.products / date
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / f"{date}{epoch}_forced_phot.csv").write_text(
+            self.HEADER
+            + f"47.499,17.099833,4.87,{flux},0.02,0.95\n"
+            + "120.0,-5.0,1.0,1.1,0.05,1.1\n"
+        )
+
+    def test_matches_position_across_epochs(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        self._write_epoch_csv(config, "2026-01-25", "T0200", 3.9)
+        self._write_epoch_csv(config, "2026-02-12", "T0000", 4.1)
+        points = qa_server.lightcurve_points(
+            config, ra_deg=47.499, dec_deg=17.0998, radius_arcsec=30.0
+        )
+        assert len(points) == 2
+        assert {point["epoch"] for point in points} == {"2026-01-25T0200", "2026-02-12T0000"}
+        assert all(abs(point["flux_jy"] - 4.0) < 0.2 for point in points)
+        assert all(point["separation_arcsec"] < 30.0 for point in points)
+
+    def test_no_match_outside_radius(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        self._write_epoch_csv(config, "2026-01-25", "T0200", 3.9)
+        assert qa_server.lightcurve_points(config, 47.499, 18.5, 30.0) == []
+
+    def test_csv_missing_columns_is_skipped(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        directory = config.products / "2026-01-25"
+        directory.mkdir(parents=True)
+        (directory / "2026-01-25T0200_forced_phot.csv").write_text("other\n1\n")
+        assert qa_server.lightcurve_points(config, 47.499, 17.0998, 30.0) == []
+
+    def test_lightcurve_page_and_png(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        self._write_epoch_csv(config, "2026-01-25", "T0200", 3.9)
+        self._write_epoch_csv(config, "2026-02-12", "T0000", 4.1)
+        with TestClient(create_app(config)) as client:
+            page = client.get("/sources/lightcurve?ra=47.499&dec=17.0998")
+            png = client.get("/sources/lightcurve.png?ra=47.499&dec=17.0998")
+        assert page.status_code == 200 and "2026-01-25" in page.text
+        assert "eta" in page.text.lower()
+        assert png.status_code == 200 and png.content.startswith(b"\x89PNG")
+
+    def test_no_points_page_is_200_png_is_404(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            page = client.get("/sources/lightcurve?ra=47.499&dec=17.0998")
+            png = client.get("/sources/lightcurve.png?ra=47.499&dec=17.0998")
+        assert page.status_code == 200 and "No matching source" in page.text
+        assert png.status_code == 404
+
+    def test_bad_coords_rejected(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            assert 400 <= client.get("/sources/lightcurve?ra=999&dec=0").status_code < 500
+            assert 400 <= client.get("/sources/lightcurve?ra=10&dec=95").status_code < 500
+            assert (
+                400
+                <= client.get("/sources/lightcurve?ra=10&dec=10&radius_arcsec=9999").status_code
+                < 500
+            )
+
+    def test_dashboard_links_lightcurve_lookup(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            page = client.get("/").text
+        assert "/sources/lightcurve" in page

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -561,6 +561,24 @@ class TestDashboardAndHealth:
         assert parsed.tzinfo is not None
 
 
+class TestFindCsv:
+    """Criterion: find_csv's contract is the newest matching table (docstring);
+    newest means max mtime, not lexicographically last."""
+
+    def test_returns_newest_by_mtime_not_lexicographic(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        directory = config.products / "2026-01-25"
+        directory.mkdir(parents=True)
+        newer_lex_first = directory / "2026-01-25T0200_a_phot.csv"
+        older_lex_last = directory / "2026-01-25T0200_z_phot.csv"
+        newer_lex_first.write_text("x\n")
+        older_lex_last.write_text("x\n")
+        os.utime(older_lex_last, (1_000, 1_000))
+        os.utime(newer_lex_first, (2_000, 2_000))
+
+        assert qa_server.find_csv(config, "2026-01-25", "T0200") == newer_lex_first
+
+
 class TestCampaignStatusLogSelection:
     """Criterion: an epoch's status may only adopt campaign logs whose filename
     hour equals the requested hour (padded or unpadded form); hour 1 must never

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -559,3 +559,101 @@ class TestDashboardAndHealth:
         assert body["status"] == "ok"
         parsed = datetime.fromisoformat(body["time"])
         assert parsed.tzinfo is not None
+
+
+class TestControlAuth:
+    """Criterion: mutating control routes fail closed -- no DSA110_CONTROL_TOKEN
+    in the environment means 403 for every mutating request regardless of the
+    header; a wrong or missing bearer is 403; the correct bearer is accepted;
+    request fields that fail RunRequest's closed grammar are 4xx; the audit log
+    records mutating requests without ever containing the token; run listing
+    stays readable without a token (read-only surface). Basis: fail-closed
+    auth invariant for a publicly-tunneled control surface."""
+
+    def _client(self, tmp_path, monkeypatch, token_env):
+        if token_env is None:
+            monkeypatch.delenv("DSA110_CONTROL_TOKEN", raising=False)
+        else:
+            monkeypatch.setenv("DSA110_CONTROL_TOKEN", token_env)
+        monkeypatch.setenv("DSA110_CONTROL_DIR", str(tmp_path / "control"))
+        monkeypatch.setenv("DSA110_REPO_ROOT", str(tmp_path))
+        import sys as _sys
+
+        monkeypatch.setenv("DSA110_PIPELINE_PYTHON", _sys.executable)
+        scripts = tmp_path / "scripts"
+        scripts.mkdir(exist_ok=True)
+        (scripts / "batch_pipeline.py").write_text("print('plan ok')\n")
+        return TestClient(create_app(_make_config(tmp_path)))
+
+    def test_launch_without_token_env_is_403_even_with_header(self, tmp_path, monkeypatch):
+        with self._client(tmp_path, monkeypatch, token_env=None) as client:
+            response = client.post(
+                "/api/runs",
+                json={"date": "2026-01-25", "dry_run": True},
+                headers={"Authorization": "Bearer anything"},
+            )
+        assert response.status_code == 403
+
+    def test_wrong_or_missing_token_is_403(self, tmp_path, monkeypatch):
+        with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+            wrong = client.post(
+                "/api/runs",
+                json={"date": "2026-01-25", "dry_run": True},
+                headers={"Authorization": "Bearer wrong"},
+            )
+            missing = client.post("/api/runs", json={"date": "2026-01-25", "dry_run": True})
+        assert wrong.status_code == 403
+        assert missing.status_code == 403
+
+    def test_dry_run_with_token_returns_plan_and_audits(self, tmp_path, monkeypatch):
+        with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+            response = client.post(
+                "/api/runs",
+                json={"date": "2026-01-25", "dry_run": True},
+                headers={"Authorization": "Bearer s3cret"},
+            )
+        assert response.status_code == 200
+        assert "plan ok" in response.json()["plan"]
+        audit = (tmp_path / "control" / "audit.jsonl").read_text()
+        assert '"dry_run": true' in audit
+        assert "s3cret" not in audit
+
+    def test_injection_shaped_date_is_4xx(self, tmp_path, monkeypatch):
+        with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+            response = client.post(
+                "/api/runs",
+                json={"date": "2026-01-25; rm -rf /", "dry_run": True},
+                headers={"Authorization": "Bearer s3cret"},
+            )
+        assert response.status_code in (400, 422)
+
+    def test_run_listing_is_readable_without_token(self, tmp_path, monkeypatch):
+        with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+            response = client.get("/api/runs")
+        assert response.status_code == 200
+        assert response.json() == {"runs": []}
+
+    def test_launch_terminate_roundtrip_with_token(self, tmp_path, monkeypatch):
+        with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+            (tmp_path / "scripts" / "batch_pipeline.py").write_text("import time; time.sleep(60)\n")
+            headers = {"Authorization": "Bearer s3cret"}
+            launched = client.post("/api/runs", json={"date": "2026-01-25"}, headers=headers)
+            assert launched.status_code == 200
+            run_id = launched.json()["run_id"]
+            detail = client.get(f"/api/runs/{run_id}")
+            assert detail.status_code == 200
+            assert detail.json()["status"] == "running"
+            terminated = client.post(f"/api/runs/{run_id}/terminate", headers=headers)
+            assert terminated.status_code == 200
+            assert terminated.json()["status"] == "terminated"
+            unauth = client.post(f"/api/runs/{run_id}/terminate")
+            assert unauth.status_code == 403
+
+    def test_unknown_run_detail_is_404(self, tmp_path, monkeypatch):
+        with self._client(tmp_path, monkeypatch, token_env="s3cret") as client:
+            client.post(
+                "/api/runs",
+                json={"date": "2026-01-25", "dry_run": True},
+                headers={"Authorization": "Bearer s3cret"},
+            )
+            assert client.get("/api/runs/nope").status_code == 404

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -736,3 +736,79 @@ class TestControlUi:
         monkeypatch.setenv("DSA110_CONTROL_DIR", str(tmp_path / "control"))
         with TestClient(create_app(_make_config(tmp_path))) as client:
             assert client.get("/control/runs/nope").status_code == 404
+
+
+class TestRunProvenancePage:
+    """Criterion: /runs/{date} surfaces manifest truth (pipeline_verdict, gate
+    reasons, per-epoch QA) plus the run report; a partial manifest renders with
+    placeholder fields instead of 500; unknown dates are 404 and traversal
+    inputs are 4xx. Basis: manifest schema written by qa/provenance.py."""
+
+    def _write_manifest(self, config: DashboardConfig, date: str = "2026-01-25") -> None:
+        import json as _json
+
+        directory = config.products / date
+        directory.mkdir(parents=True, exist_ok=True)
+        manifest = {
+            "date": date,
+            "cal_date": date,
+            "git_sha": "abc1234",
+            "command_line": "batch_pipeline.py --date " + date,
+            "pipeline_verdict": "DEGRADED",
+            "gates": [
+                {
+                    "gate": "epoch_qa:22",
+                    "verdict": "FAIL",
+                    "reason": "catalog completeness 0.42 < 0.5",
+                }
+            ],
+            "epochs": [
+                {
+                    "hour": 22,
+                    "n_tiles": 11,
+                    "status": "ok",
+                    "qa_result": "FAIL",
+                    "peak": 12.5,
+                    "rms": 0.008,
+                    "mosaic_path": "/x.fits",
+                    "gaincal_status": "ok",
+                    "n_sources": 40,
+                    "median_ratio": 0.9,
+                    "weight_path": "/x.w.fits",
+                }
+            ],
+            "tiles": [],
+            "run_log": "run_x.log",
+        }
+        (directory / f"{date}_manifest.json").write_text(_json.dumps(manifest))
+        (directory / "run_report.md").write_text("# Run report\nverdict DEGRADED\n")
+
+    def test_renders_verdict_gates_and_epochs(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        self._write_manifest(config)
+        with TestClient(create_app(config)) as client:
+            page = client.get("/runs/2026-01-25")
+        assert page.status_code == 200
+        assert "DEGRADED" in page.text
+        assert "catalog completeness" in page.text
+        assert "T2200" in page.text
+        assert "Run report" in page.text
+
+    def test_partial_manifest_renders_without_500(self, tmp_path: Path):
+        import json as _json
+
+        config = _make_config(tmp_path)
+        directory = config.products / "2026-01-25"
+        directory.mkdir(parents=True)
+        (directory / "2026-01-25_manifest.json").write_text(
+            _json.dumps({"pipeline_verdict": "CLEAN"})
+        )
+        with TestClient(create_app(config)) as client:
+            page = client.get("/runs/2026-01-25")
+        assert page.status_code == 200
+        assert "CLEAN" in page.text
+
+    def test_missing_manifest_is_404_and_traversal_rejected(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            assert client.get("/runs/2026-01-26").status_code == 404
+            assert 400 <= client.get("/runs/..%2f..%2fetc").status_code < 500

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -1,0 +1,561 @@
+import os
+import subprocess
+import types
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+import pytest
+import scripts.qa_server as qa_server
+from astropy.io import fits
+from fastapi.testclient import TestClient
+from scripts.qa_server import DashboardConfig, create_app, get_metrics
+
+
+def test_dashboard_startup_and_mosaic_artifact_routes(tmp_path: Path):
+    stage = tmp_path / "stage"
+    products = tmp_path / "products"
+    incoming = tmp_path / "incoming"
+    mosaic_dir = stage / "images" / "mosaic_2026-01-25"
+    mosaic_dir.mkdir(parents=True)
+    (stage / "ms").mkdir()
+    products.mkdir()
+    incoming.mkdir()
+    photometry_dir = products / "2026-01-25"
+    photometry_dir.mkdir()
+    (photometry_dir / "2026-01-25T0200_phot.csv").write_text("nvss_flux_jy,dsa_nvss_ratio\n0.1,\n")
+    fits.writeto(
+        mosaic_dir / "2026-01-25T0200_mosaic.fits",
+        np.arange(64, dtype=np.float32).reshape(8, 8) / 1000,
+    )
+    config = DashboardConfig(
+        stage=stage,
+        products=products,
+        incoming=incoming,
+        thumb_dir=tmp_path / "thumbs",
+        campaign_outputs=tmp_path / "campaign",
+    )
+
+    with TestClient(create_app(config)) as client:
+        root = client.get("/")
+        status = client.get("/artifacts/mosaic/2026-01-25/T0200/status")
+        thumbnail = client.get("/artifacts/mosaic/2026-01-25/T0200/thumb.png")
+
+    assert root.status_code == 200
+    assert "DSA-110 Continuum Observatory" in root.text
+    assert status.status_code == 200
+    assert status.json()["fits"] is True
+    assert status.json()["ratio"] is None
+    assert status.json()["mosaic_path"].endswith("2026-01-25T0200_mosaic.fits")
+    assert thumbnail.status_code == 200
+    assert thumbnail.headers["content-type"] == "image/png"
+    assert thumbnail.content.startswith(b"\x89PNG")
+
+
+def _make_config(tmp_path: Path) -> DashboardConfig:
+    return DashboardConfig(
+        stage=tmp_path / "stage",
+        products=tmp_path / "products",
+        incoming=tmp_path / "incoming",
+        thumb_dir=tmp_path / "thumbs",
+        campaign_outputs=tmp_path / "campaign",
+        campaign_date="2026-07-13",
+        campaign_hour=11,
+    )
+
+
+def _write_mosaic(config: DashboardConfig, date: str, epoch: str, data: np.ndarray) -> Path:
+    mosaic_dir = config.stage / "images" / f"mosaic_{date}"
+    mosaic_dir.mkdir(parents=True, exist_ok=True)
+    path = mosaic_dir / f"{date}{epoch}_mosaic.fits"
+    fits.writeto(path, data, overwrite=True)
+    return path
+
+
+def _write_phot(config: DashboardConfig, date: str, epoch: str, text: str) -> Path:
+    directory = config.products / date
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{date}{epoch}_phot.csv"
+    path.write_text(text)
+    return path
+
+
+def _analytic_mosaic() -> np.ndarray:
+    """Synthetic mosaic with hand-computable QA metrics.
+
+    254 background pixels split evenly between -0.01 and +0.01 (mean 0,
+    std exactly 0.01 -> RMS 10.0 mJy), one 5.0 Jy peak, one NaN.
+    Dynamic range = 5.0 / 0.01 = 500.
+    """
+    flat = np.empty(256, dtype=np.float32)
+    flat[:127] = -0.01
+    flat[127:254] = 0.01
+    flat[254] = 5.0
+    flat[255] = np.nan
+    return flat.reshape(16, 16)
+
+
+class TestPathParameterSafety:
+    """Criterion: user-supplied date/epoch (path or query params) are interpolated
+    into filesystem paths (stage/images/mosaic_{date}/..., products/{date}/...),
+    so any value outside the canonical YYYY-MM-DD / THHMM formats must be rejected
+    with 4xx before any filesystem access, must never leak file content, and must
+    never produce a 500. Basis: independent path-traversal invariant for any
+    file-serving endpoint, not a pin of current behaviour."""
+
+    def test_traversal_date_in_mosaic_status_is_rejected(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            for value in ("..", "....", "%2e%2e%2f%2e%2e%2fetc%2fpasswd", "2026-01-25x"):
+                response = client.get(f"/artifacts/mosaic/{value}/T0200/status")
+                assert 400 <= response.status_code < 500, value
+                assert "root:" not in response.text
+
+    def test_traversal_epoch_in_mosaic_routes_is_rejected(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            for value in ("..", "passwd", "T12345", "%2e%2e"):
+                status = client.get(f"/artifacts/mosaic/2026-01-25/{value}/status")
+                thumb = client.get(f"/artifacts/mosaic/2026-01-25/{value}/thumb.png")
+                assert 400 <= status.status_code < 500, value
+                assert 400 <= thumb.status_code < 500, value
+                assert "root:" not in status.text
+
+    def test_traversal_on_legacy_thumb_route_is_rejected(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            response = client.get("/thumb/%2e%2e/T0200.png")
+            assert 400 <= response.status_code < 500
+            response = client.get("/thumb/2026-01-25/%2e%2e.png")
+            assert 400 <= response.status_code < 500
+
+    def test_ops_status_rejects_malformed_date_query(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            for value in ("../../../etc/passwd", "2026-01-25%0A", "26-01-25", "...."):
+                response = client.get(f"/api/status?date={value}")
+                assert response.status_code == 400, value
+                assert "root:" not in response.text
+
+    def test_ops_status_rejects_out_of_range_hour(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            assert client.get("/api/status?hour=24").status_code == 400
+            assert client.get("/api/status?hour=-1").status_code == 400
+            assert client.get("/api/status?hour=abc").status_code == 422
+
+    def test_wellformed_unknown_date_yields_empty_state_not_500(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            ops = client.get("/api/status?date=1999-01-01")
+            metrics = client.get("/artifacts/mosaic/1999-01-01/T0000/status")
+        assert ops.status_code == 200
+        assert all(stage["state"] == "not_yet" for stage in ops.json()["stages"])
+        assert metrics.status_code == 200
+        assert metrics.json()["status"] == "missing"
+
+
+class TestMosaicMetricsGroundTruth:
+    """Criterion: /artifacts/mosaic/{date}/{epoch}/status reports peak/rms/dr that
+    match analytic values hand-computed from a synthetic mosaic (background split
+    evenly between -0.01 and +0.01 -> std exactly 0.01 -> 10.0 mJy RMS; peak 5.0 Jy;
+    DR 500), and the DSA/NVSS ratio is the median over bright (>0.06 Jy) sources
+    only. Basis: analytic construction of the input array, not a regression pin.
+    Floats compared with tolerances (float32 storage)."""
+
+    def test_metrics_match_analytic_values(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        _write_phot(
+            config,
+            "2026-01-25",
+            "T0200",
+            "nvss_flux_jy,dsa_nvss_ratio\n0.1,1.0\n0.2,1.1\n0.5,0.9\n0.05,5.0\n",
+        )
+        with TestClient(create_app(config)) as client:
+            payload = client.get("/artifacts/mosaic/2026-01-25/T0200/status").json()
+        assert payload["fits"] is True
+        assert payload["csv"] is True
+        assert payload["peak"] == pytest.approx(5.0, rel=1e-5)
+        assert payload["rms"] == pytest.approx(10.0, rel=1e-3)
+        assert payload["dr"] == pytest.approx(500.0, rel=1e-3)
+        assert payload["n_bright"] == 3
+        assert payload["ratio"] == pytest.approx(1.0, rel=1e-9)
+        assert payload["status"] == "pass"
+        assert payload["mosaic_path"].endswith("2026-01-25T0200_mosaic.fits")
+
+    def test_missing_mosaic_reports_missing(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            payload = client.get("/artifacts/mosaic/2026-01-25/T0200/status").json()
+        assert payload["fits"] is False
+        assert payload["status"] == "missing"
+        assert payload["peak"] is None
+        assert payload["mosaic_path"] is None
+
+    def test_corrupt_fits_yields_controlled_nulls_not_500(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        mosaic_dir = config.stage / "images" / "mosaic_2026-01-25"
+        mosaic_dir.mkdir(parents=True)
+        (mosaic_dir / "2026-01-25T0200_mosaic.fits").write_bytes(b"this is not a FITS file")
+        with TestClient(create_app(config)) as client:
+            response = client.get("/artifacts/mosaic/2026-01-25/T0200/status")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["fits"] is True
+        assert payload["peak"] is None
+        assert payload["rms"] is None
+        assert payload["dr"] is None
+        assert payload["status"] == "no_phot"
+
+    def test_all_nan_mosaic_yields_null_metrics_not_500(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", np.full((8, 8), np.nan, dtype=np.float32))
+        with TestClient(create_app(config)) as client:
+            response = client.get("/artifacts/mosaic/2026-01-25/T0200/status")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["peak"] is None
+        assert payload["rms"] is None
+        assert payload["status"] == "no_phot"
+
+
+class TestStatusTruthTable:
+    """Criterion: QA verdict aggregation follows the documented truth table --
+    'pass' iff 0.8 <= median bright-source DSA/NVSS ratio <= 1.2 (the dashboard's
+    published target window, closed interval), 'fail' outside it, 'no_phot' when
+    the ratio is unavailable or non-finite, and 'missing' dominates everything
+    when no mosaic FITS exists. Basis: documented QA operating point (0.8-1.2)
+    and the >0.06 Jy bright-source definition. The strict exclusion of sources
+    at exactly 0.06 Jy is pinned current behaviour (UNVERIFIED as a science
+    contract). Exercised at unit level via get_metrics."""
+
+    @pytest.mark.parametrize(
+        ("ratio_text", "expected_status"),
+        [
+            ("1.0", "pass"),
+            ("0.8", "pass"),
+            ("1.2", "pass"),
+            ("0.79", "fail"),
+            ("1.21", "fail"),
+            ("0.5", "fail"),
+            ("2.0", "fail"),
+        ],
+    )
+    def test_ratio_window_verdicts(self, tmp_path: Path, ratio_text: str, expected_status: str):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        _write_phot(
+            config, "2026-01-25", "T0200", f"nvss_flux_jy,dsa_nvss_ratio\n0.1,{ratio_text}\n"
+        )
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["status"] == expected_status
+        assert metrics["ratio"] == pytest.approx(float(ratio_text), rel=1e-12)
+
+    def test_no_csv_is_no_phot(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["csv"] is False
+        assert metrics["ratio"] is None
+        assert metrics["status"] == "no_phot"
+
+    def test_empty_csv_file_is_no_phot_not_error(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        _write_phot(config, "2026-01-25", "T0200", "")
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["n_bright"] == 0
+        assert metrics["status"] == "no_phot"
+
+    def test_csv_missing_flux_column_is_no_phot(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        _write_phot(config, "2026-01-25", "T0200", "other_col\n1.0\n2.0\n")
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["n_bright"] == 0
+        assert metrics["ratio"] is None
+        assert metrics["status"] == "no_phot"
+
+    def test_csv_missing_ratio_column_counts_bright_but_no_phot(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        _write_phot(config, "2026-01-25", "T0200", "nvss_flux_jy\n0.1\n0.2\n")
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["n_bright"] == 2
+        assert metrics["ratio"] is None
+        assert metrics["status"] == "no_phot"
+
+    def test_non_finite_ratio_is_normalized_to_no_phot(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        _write_phot(config, "2026-01-25", "T0200", "nvss_flux_jy,dsa_nvss_ratio\n0.1,inf\n")
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["ratio"] is None
+        assert metrics["status"] == "no_phot"
+
+    def test_faint_only_sources_are_no_phot(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        _write_phot(
+            config, "2026-01-25", "T0200", "nvss_flux_jy,dsa_nvss_ratio\n0.05,1.0\n0.06,1.0\n"
+        )
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["n_bright"] == 0
+        assert metrics["status"] == "no_phot"
+
+    def test_missing_fits_dominates_valid_photometry(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_phot(config, "2026-01-25", "T0200", "nvss_flux_jy,dsa_nvss_ratio\n0.1,1.0\n")
+        metrics = get_metrics(config, "2026-01-25", "T0200")
+        assert metrics["fits"] is False
+        assert metrics["csv"] is True
+        assert metrics["status"] == "missing"
+        assert metrics["ratio"] is None
+
+
+class TestThumbnailEndpoints:
+    """Criterion: thumbnail routes return image/png for renderable mosaics on both
+    the canonical and legacy URLs with identical content; absent, corrupt, or
+    unrenderable (all-NaN) mosaics yield 404 -- never 500 and never a partial
+    body. A regenerated mosaic (new mtime) must invalidate the cached PNG: a
+    stale thumbnail is a silently wrong dashboard. Basis: HTTP contract plus the
+    cache-key-includes-mtime freshness invariant."""
+
+    def test_missing_mosaic_is_404_on_both_routes(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            assert client.get("/artifacts/mosaic/2026-01-25/T0200/thumb.png").status_code == 404
+            assert client.get("/thumb/2026-01-25/T0200.png").status_code == 404
+
+    def test_corrupt_fits_is_404_not_500(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        mosaic_dir = config.stage / "images" / "mosaic_2026-01-25"
+        mosaic_dir.mkdir(parents=True)
+        (mosaic_dir / "2026-01-25T0200_mosaic.fits").write_bytes(b"garbage")
+        with TestClient(create_app(config)) as client:
+            assert client.get("/artifacts/mosaic/2026-01-25/T0200/thumb.png").status_code == 404
+
+    def test_all_nan_mosaic_is_404_not_500(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", np.full((8, 8), np.nan, dtype=np.float32))
+        with TestClient(create_app(config)) as client:
+            assert client.get("/artifacts/mosaic/2026-01-25/T0200/thumb.png").status_code == 404
+
+    def test_legacy_and_canonical_routes_serve_identical_png(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        with TestClient(create_app(config)) as client:
+            canonical = client.get("/artifacts/mosaic/2026-01-25/T0200/thumb.png")
+            legacy = client.get("/thumb/2026-01-25/T0200.png")
+        assert canonical.status_code == 200
+        assert legacy.status_code == 200
+        assert canonical.content.startswith(b"\x89PNG")
+        assert canonical.content == legacy.content
+
+    def test_thumbnail_regenerates_when_mosaic_changes(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        path = _write_mosaic(config, "2026-01-25", "T0200", _analytic_mosaic())
+        with TestClient(create_app(config)) as client:
+            first = client.get("/artifacts/mosaic/2026-01-25/T0200/thumb.png")
+            changed = _analytic_mosaic()
+            changed[changed == 5.0] = 20.0
+            fits.writeto(path, changed, overwrite=True)
+            stat = path.stat()
+            os.utime(path, (stat.st_atime, stat.st_mtime + 100))
+            second = client.get("/artifacts/mosaic/2026-01-25/T0200/thumb.png")
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert second.content != first.content
+        assert len(list(config.thumb_dir.glob("2026-01-25_T0200_*.png"))) == 1
+
+
+class TestOpsStatusContract:
+    """Criterion: /api/status reflects filesystem truth -- stage states and counts
+    derive from actual artifact presence for the requested date/hour only; the
+    calibration stage is 'ready' only when BOTH bandpass (.b) and gain (.g)
+    tables exist (BP/G pair contract, docs/reference/calibration.md); missing
+    roots produce an empty-state 200, never 500; file records carry real path
+    and byte size; the log panel serves a suffix of the newest matching log
+    (tail length 24 is the module default -- pinned, UNVERIFIED as contract).
+    process_status is stubbed for determinism; it has its own parsing tests."""
+
+    def test_empty_environment_yields_empty_state(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            response = client.get("/api/status")
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["date"] == "2026-07-13"
+        assert payload["hour"] == 11
+        assert [stage["state"] for stage in payload["stages"]] == ["not_yet"] * 4
+        assert [stage["count"] for stage in payload["stages"]] == [0] * 4
+        assert payload["measurement_sets"] == {"count": 0, "paths": []}
+        assert payload["mosaic"] is None
+        assert payload["run_products"] == {"manifest": None, "summary": None, "report": None}
+        assert payload["log"] == {"file": None, "tail": []}
+        assert payload["incoming"]["hdf5_count"] == 0
+        assert "disks" in payload
+
+    def test_populated_environment_counts_only_requested_hour(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        config = _make_config(tmp_path)
+        ms_dir = config.stage / "ms"
+        ms_dir.mkdir(parents=True)
+        (ms_dir / "2026-07-13T11:02:03.ms").write_text("ms")
+        (ms_dir / "2026-07-13T11:30:00.ms").write_text("ms")
+        (ms_dir / "2026-07-13T12:00:00.ms").write_text("decoy other hour")
+        (ms_dir / "2026-07-13T11:26:05_0~23.b").write_text("bp")
+        (ms_dir / "2026-07-13T11:26:05_0~23.g").write_text("gain")
+        image_dir = config.stage / "images" / "mosaic_2026-07-13"
+        image_dir.mkdir(parents=True)
+        (image_dir / "2026-07-13T11:05:00-image.fits").write_text("tile")
+        (image_dir / "2026-07-13T12:05:00-image.fits").write_text("decoy other hour")
+        (image_dir / "2026-07-13T1100_mosaic.fits").write_text("mosaic")
+        config.incoming.mkdir(parents=True)
+        (config.incoming / "2026-07-13T11:00:00_sb01.hdf5").write_text("h5")
+        (config.incoming / "2026-07-13T11:00:00_sb02.hdf5").write_text("h5")
+        (config.incoming / "2026-07-13T12:00:00_sb01.hdf5").write_text("decoy other hour")
+        product_dir = config.products / "2026-07-13"
+        product_dir.mkdir(parents=True)
+        manifest_text = '{"pipeline_verdict": "DEGRADED"}'
+        (product_dir / "2026-07-13_manifest.json").write_text(manifest_text)
+        (product_dir / "2026-07-13_run_summary.json").write_text("{}")
+        (product_dir / "run_report.md").write_text("# report")
+        with TestClient(create_app(config)) as client:
+            payload = client.get("/api/status").json()
+        states = {stage["name"]: stage for stage in payload["stages"]}
+        assert states["Measurement Sets"] == {
+            "name": "Measurement Sets",
+            "state": "ready",
+            "count": 2,
+        }
+        assert states["Calibration tables"]["state"] == "ready"
+        assert states["Calibration tables"]["count"] == 2
+        assert states["Tile images"] == {"name": "Tile images", "state": "ready", "count": 1}
+        assert states["Hourly-epoch mosaic"]["state"] == "ready"
+        assert payload["mosaic"]["path"].endswith("2026-07-13T1100_mosaic.fits")
+        assert payload["incoming"]["hdf5_count"] == 2
+        manifest = payload["run_products"]["manifest"]
+        assert manifest["path"].endswith("2026-07-13_manifest.json")
+        assert manifest["size_bytes"] == len(manifest_text)
+        assert payload["run_products"]["summary"]["path"].endswith("2026-07-13_run_summary.json")
+        assert payload["run_products"]["report"]["path"].endswith("run_report.md")
+
+    def test_calibration_stage_requires_both_bandpass_and_gains(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        config = _make_config(tmp_path)
+        ms_dir = config.stage / "ms"
+        ms_dir.mkdir(parents=True)
+        (ms_dir / "2026-07-13T11:26:05_0~23.b").write_text("bp only, no gains")
+        with TestClient(create_app(config)) as client:
+            payload = client.get("/api/status").json()
+        cal = next(stage for stage in payload["stages"] if stage["name"] == "Calibration tables")
+        assert cal["state"] == "not_yet"
+        assert cal["count"] == 1
+
+    def test_log_tail_is_suffix_of_newest_log(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        config = _make_config(tmp_path)
+        product_dir = config.products / "2026-07-13"
+        product_dir.mkdir(parents=True)
+        old_log = product_dir / "run_old.log"
+        old_log.write_text("stale line\n")
+        new_lines = [f"line-{i:02d}\n" for i in range(30)]
+        new_log = product_dir / "run_new.log"
+        new_log.write_text("".join(new_lines))
+        now = new_log.stat().st_mtime
+        os.utime(old_log, (now - 100, now - 100))
+        os.utime(new_log, (now + 100, now + 100))
+        with TestClient(create_app(config)) as client:
+            payload = client.get("/api/status").json()
+        assert payload["log"]["file"]["path"].endswith("run_new.log")
+        assert payload["log"]["tail"] == new_lines[-24:]
+
+
+class TestProcessAndPidParsing:
+    """Criterion: operator heartbeat parsing contracts. ps rows (from
+    `ps -eo pid=,etimes=,stat=,args=`) are parsed positionally into
+    pid/elapsed_seconds/state/command for pipeline-relevant commands only;
+    malformed rows are skipped; a failing ps yields an error record instead of
+    raising. *.pid hint files yield labeled pids with /proc visibility, and a
+    missing campaign directory yields an empty list. Basis: the procps output
+    column contract and the campaign runbook LABEL_PID=N file format."""
+
+    def test_process_status_parses_ps_rows_positionally(self, monkeypatch):
+        stdout = (
+            "  1234    56 S    /opt/miniforge/envs/casa6/bin/python scripts/batch_pipeline.py --date 2026-07-13\n"
+            "  4321   999 R    wsclean -size 4800 4800 obs.ms\n"
+            "  5555    12 S    sshd: ubuntu@pts/0\n"
+            "  9999 5 wsclean\n"
+        )
+        fake = types.SimpleNamespace(
+            run=lambda *args, **kwargs: subprocess.CompletedProcess(
+                args=args, returncode=0, stdout=stdout, stderr=""
+            ),
+            SubprocessError=subprocess.SubprocessError,
+        )
+        monkeypatch.setattr(qa_server, "subprocess", fake)
+        assert qa_server.process_status() == [
+            {
+                "pid": 1234,
+                "elapsed_seconds": 56,
+                "state": "S",
+                "command": "/opt/miniforge/envs/casa6/bin/python scripts/batch_pipeline.py --date 2026-07-13",
+            },
+            {
+                "pid": 4321,
+                "elapsed_seconds": 999,
+                "state": "R",
+                "command": "wsclean -size 4800 4800 obs.ms",
+            },
+        ]
+
+    def test_process_status_returns_error_record_when_ps_fails(self, monkeypatch):
+        def boom(*args, **kwargs):
+            raise OSError("ps unavailable")
+
+        fake = types.SimpleNamespace(run=boom, SubprocessError=subprocess.SubprocessError)
+        monkeypatch.setattr(qa_server, "subprocess", fake)
+        assert qa_server.process_status() == [{"error": "ps unavailable"}]
+
+    def test_pid_hints_parse_labels_and_proc_visibility(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        config.campaign_outputs.mkdir(parents=True)
+        own_pid = os.getpid()
+        (config.campaign_outputs / "run.pid").write_text(
+            f"BATCH_PID={own_pid}\nWSCLEAN_PID=4000000000\nnot a pid line\n"
+        )
+        hints = qa_server._pid_hints(config)
+        assert [(hint["label"], hint["pid"]) for hint in hints] == [
+            ("BATCH_PID", own_pid),
+            ("WSCLEAN_PID", 4000000000),
+        ]
+        assert hints[0]["visible"] is True
+        assert hints[1]["visible"] is False
+        assert hints[0]["source"].endswith("run.pid")
+
+    def test_pid_hints_missing_directory_is_empty(self, tmp_path: Path):
+        assert qa_server._pid_hints(_make_config(tmp_path)) == []
+
+
+class TestDashboardAndHealth:
+    """Criterion: the root dashboard renders 200 HTML and must HTML-escape log
+    file content before embedding it -- batch logs echo external inputs
+    (filenames, casa/wsclean output), so unescaped injection is stored XSS in
+    an auto-refreshing operator dashboard. /health returns status ok with a
+    parseable timezone-aware UTC timestamp. Basis: output-encoding security
+    invariant and the health-probe contract."""
+
+    def test_dashboard_escapes_log_content(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        config = _make_config(tmp_path)
+        config.campaign_outputs.mkdir(parents=True)
+        payload = "<script>alert('qa-xss')</script>"
+        (config.campaign_outputs / "batch_run_h11_test.log").write_text(payload + "\n")
+        with TestClient(create_app(config)) as client:
+            response = client.get("/")
+        assert response.status_code == 200
+        assert payload not in response.text
+        assert "&lt;script&gt;alert(&#x27;qa-xss&#x27;)&lt;/script&gt;" in response.text
+
+    def test_health_contract(self, tmp_path: Path):
+        with TestClient(create_app(_make_config(tmp_path))) as client:
+            response = client.get("/health")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        parsed = datetime.fromisoformat(body["time"])
+        assert parsed.tzinfo is not None

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -561,6 +561,27 @@ class TestDashboardAndHealth:
         assert parsed.tzinfo is not None
 
 
+class TestCampaignStatusLogSelection:
+    """Criterion: an epoch's status may only adopt campaign logs whose filename
+    hour equals the requested hour (padded or unpadded form); hour 1 must never
+    adopt h11-h19 logs even when they are newer."""
+
+    def test_rejects_other_hours_sharing_digit_prefix(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setattr(qa_server, "process_status", lambda: [])
+        config = _make_config(tmp_path)
+        config.campaign_outputs.mkdir(parents=True)
+        own = config.campaign_outputs / "batch_run_h1_a.log"
+        other = config.campaign_outputs / "batch_run_h11_b.log"
+        own.write_text("own\n")
+        other.write_text("other\n")
+        os.utime(own, (1_000, 1_000))
+        os.utime(other, (2_000, 2_000))
+
+        status = qa_server.campaign_status(config, "2026-07-13", 1)
+
+        assert status["log"]["file"]["path"].endswith("batch_run_h1_a.log")
+
+
 class TestControlAuth:
     """Criterion: mutating control routes fail closed -- no DSA110_CONTROL_TOKEN
     in the environment means 403 for every mutating request regardless of the
@@ -889,3 +910,14 @@ class TestLightcurveView:
         with TestClient(create_app(_make_config(tmp_path))) as client:
             page = client.get("/").text
         assert "/sources/lightcurve" in page
+
+    def test_nan_flux_epochs_are_excluded(self, tmp_path: Path):
+        config = _make_config(tmp_path)
+        self._write_epoch_csv(config, "2026-01-25", "T0200", 3.9)
+        directory = config.products / "2026-02-12"
+        directory.mkdir(parents=True)
+        (directory / "2026-02-12T0100_forced_phot.csv").write_text(
+            self.HEADER + "47.499,17.099833,4.87,nan,nan,nan\n"
+        )
+        points = qa_server.lightcurve_points(config, 47.499, 17.0998, 30.0)
+        assert [point["epoch"] for point in points] == ["2026-01-25T0200"]

--- a/tests/test_qa_server.py
+++ b/tests/test_qa_server.py
@@ -939,3 +939,20 @@ class TestLightcurveView:
         )
         points = qa_server.lightcurve_points(config, 47.499, 17.0998, 30.0)
         assert [point["epoch"] for point in points] == ["2026-01-25T0200"]
+
+
+def test_non_ascii_authorization_header_is_403_not_500(monkeypatch):
+    monkeypatch.setenv("DSA110_CONTROL_TOKEN", "expected-token")
+    from fastapi import HTTPException
+    from starlette.requests import Request
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/runs",
+        "headers": [(b"authorization", "Bearer sekr\xedt".encode("latin-1"))],
+        "query_string": b"",
+    }
+    with pytest.raises(HTTPException) as excinfo:
+        qa_server._require_control_token(Request(scope))
+    assert excinfo.value.status_code == 403


### PR DESCRIPTION
Promotes the live-observability stack (issues #48–#62 work) from `dashboard-production` to `main`: routed QA dashboard, read-only observability package, token-gated pipeline control API with audit log, run launcher/registry/reaper, per-date provenance and run pages, positional light-curve science view, scheduled pipeline launcher + systemd units, and operations docs.

## Carries observability bug fixes (b6a303e)

This branch includes **b6a303e**, the observability hunks of the 2026-07-15 hardening campaign (re-landed from superseded #109; see the hunk→vehicle mapping in #109's closing comments):

- `observability/hour_state.py` — `campaign_hour_logs()` anchored hour-log matcher (`batch_run_h0?{hour}(?!\d)`), fixing unpadded-hour glob cross-matches at 2 sites
- `scripts/qa_server.py` — uses `campaign_hour_logs`; `find_csv` selects newest-by-mtime instead of lexicographic
- test isolation fix: `webapp_build_dir` patched so tests no longer write into site-packages

b6a303e was verified 106/106 by its lane and is byte-identical to independently verified versions from the hardening branch (2311a4d).

## Merge-time checks

- Merge preview vs `main` (base 2a62963): clean, no files changed on both sides.
- `scripts/qa_server.py` is LIVE production (H17 QA dashboard) — see operational follow-up below.

## Operational follow-up (after merge)

The H17 production checkout (`/data/dsa110-continuum`, live QA dashboard + scheduled pipeline) currently sits on `hardening-bugfixes-2026-07-15`. After this merges: move the host checkout to `main`, restart services per `docs/operations/dashboard.md`, then delete `hardening-bugfixes-2026-07-15` (local + origin). NOT before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xPNNhwUHRFMHm7e5G7xW1
