### PR TITLE
Per-tile QA view (#55)

### DIFF
--- a/dsa110_continuum/observability/artifacts.py
+++ b/dsa110_continuum/observability/artifacts.py
@@ -163,7 +163,7 @@ def cached_artifact_file(
     cache_dir.mkdir(parents=True, exist_ok=True)
     for stale in cache_dir.glob(f"{safe}_*{suffix}"):
         stale.unlink(missing_ok=True)
-    tmp = target.with_name(target.name + ".tmp")
+    tmp = target.with_name(f"{target.stem}.tmp{target.suffix}")
     builder(tmp)
     if not tmp.exists():
         raise ArtifactRenderError(f"renderer produced no output for {kind!r}")

--- a/dsa110_continuum/observability/tile_qa.py
+++ b/dsa110_continuum/observability/tile_qa.py
@@ -1,0 +1,185 @@
+"""Per-tile (single-tile FITS) QA glue for the dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+from dsa110_continuum.observability.artifacts import ArtifactRenderError
+
+SCATTER_PATCH = 256
+SCATTER_GRID = 3  # central 3x3 patches only — full-grid scattering is offline QA
+
+
+def _best_image(products: dict[str, Path | None]) -> Path:
+    image = products.get("image-pb") or products.get("image")
+    if image is None:
+        raise ArtifactRenderError("no image product for tile")
+    return image
+
+
+def _load_plane(path: Path):
+    import numpy as np
+    from astropy.io import fits
+
+    with fits.open(path, memmap=True) as hdus:
+        return np.squeeze(hdus[0].data).astype("float32")
+
+
+def summary(products: dict[str, Path | None], ms_path: Path | None) -> dict:
+    """Gate result + residual stats + PSF correlation for one tile."""
+    from dsa110_continuum.qa.image_gate import check_image_quality_for_source_finding
+    from dsa110_continuum.qa.image_metrics import (
+        calculate_psf_correlation,
+        calculate_residual_stats,
+    )
+
+    image = _best_image(products)
+    gate_kwargs = {}
+    if ms_path is not None:
+        try:
+            from dsa110_continuum.qa.noise_model import _extract_integration_time
+
+            gate_kwargs["integration_time_s"] = _extract_integration_time(str(ms_path))
+        except Exception:  # default 12.88 s stands
+            pass
+    gate = asdict(check_image_quality_for_source_finding(str(image), **gate_kwargs))
+
+    residual_path = products.get("residual-pb") or products.get("residual")
+    residual = None
+    if residual_path is not None:
+        try:
+            residual = calculate_residual_stats(str(residual_path))
+        except Exception as exc:
+            residual = {"error": str(exc)}
+
+    psf_correlation = None
+    if products.get("dirty") is not None and products.get("psf") is not None:
+        try:
+            psf_correlation = float(
+                calculate_psf_correlation(str(products["dirty"]), str(products["psf"]))
+            )
+        except Exception:
+            psf_correlation = None
+
+    return {
+        "gate": gate,
+        "residual": residual,
+        "psf_correlation": psf_correlation,
+        "noise": {"integration_time_s": gate_kwargs.get("integration_time_s")},
+    }
+
+
+def plot_kinds(products: dict[str, Path | None], ms_available: bool) -> tuple[str, ...]:
+    """Return the plot kinds available for this tile's on-disk products."""
+    kinds = ["image"]
+    if products.get("residual-pb") or products.get("residual"):
+        kinds.append("residual")
+    if products.get("psf") is not None:
+        kinds += ["psf_2d", "psf_radial", "sidelobe"]
+    kinds.append("scattering")
+    if ms_available:
+        kinds.append("residual_hist")
+    return tuple(kinds)
+
+
+def render_plot(
+    products: dict[str, Path | None], kind: str, target: Path, ms_path: Path | None = None
+) -> None:
+    """Render one tile plot kind to ``target``; ArtifactRenderError carries the reason."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    try:
+        if kind == "image":
+            from dsa110_continuum.visualization.fits_plots import plot_fits_image
+
+            figure = plot_fits_image(str(_best_image(products)), output=str(target))
+            plt.close(figure)
+        elif kind == "residual":
+            from dsa110_continuum.visualization.fits_plots import plot_fits_image
+
+            residual = products.get("residual-pb") or products.get("residual")
+            if residual is None:
+                raise ArtifactRenderError("no residual product")
+            figure = plot_fits_image(
+                str(residual), output=str(target), title=f"Residual {residual.name}"
+            )
+            plt.close(figure)
+        elif kind in ("psf_2d", "psf_radial", "sidelobe"):
+            from dsa110_continuum.visualization import beam_plots
+
+            if products.get("psf") is None:
+                raise ArtifactRenderError("no PSF product")
+            psf = _load_plane(products["psf"])
+            renderer = {
+                "psf_2d": beam_plots.plot_psf_2d,
+                "psf_radial": beam_plots.plot_psf_radial_profile,
+                "sidelobe": beam_plots.plot_sidelobe_analysis,
+            }[kind]
+            figure = renderer(psf, output=str(target))
+            plt.close(figure)
+        elif kind == "scattering":
+            _render_scattering(_best_image(products), target)
+        elif kind == "residual_hist":
+            _render_residual_hist(ms_path, target)
+        else:
+            raise ArtifactRenderError(f"unknown plot kind {kind!r}")
+    except ArtifactRenderError:
+        raise
+    except (ImportError, RuntimeError, OSError, ValueError, KeyError) as exc:
+        raise ArtifactRenderError(f"{kind}: {exc}") from exc
+
+
+def _render_scattering(image_path: Path, target: Path) -> None:
+    """Bounded scattering card: score the central 3x3 patch grid only."""
+    try:
+        import scattering  # noqa: F401
+        import torch  # noqa: F401
+    except ImportError as exc:
+        raise ArtifactRenderError(
+            f"scattering library unavailable in this environment: {exc}"
+        ) from exc
+    import matplotlib.pyplot as plt
+    import numpy as np
+    from dsa110_continuum.qa.scattering_qa import _get_scattering_calculator, score_patch
+
+    data = _load_plane(image_path)
+    ny, nx = data.shape
+    if ny < SCATTER_PATCH or nx < SCATTER_PATCH:
+        raise ArtifactRenderError(f"image smaller than one {SCATTER_PATCH}px patch")
+    half = SCATTER_GRID // 2
+    cy, cx = ny // 2, nx // 2
+    stc = _get_scattering_calculator(SCATTER_PATCH, 7, 4)  # check_tile_scattering defaults
+    scores = np.full((SCATTER_GRID, SCATTER_GRID), np.nan)
+    for row in range(SCATTER_GRID):
+        for col in range(SCATTER_GRID):
+            y0 = cy + (row - half) * SCATTER_PATCH - SCATTER_PATCH // 2
+            x0 = cx + (col - half) * SCATTER_PATCH - SCATTER_PATCH // 2
+            if y0 < 0 or x0 < 0 or y0 + SCATTER_PATCH > ny or x0 + SCATTER_PATCH > nx:
+                continue
+            patch = data[y0 : y0 + SCATTER_PATCH, x0 : x0 + SCATTER_PATCH]
+            scores[row, col] = score_patch(patch, stc)[0]
+    figure, axis = plt.subplots(figsize=(6, 5))
+    image = axis.imshow(scores, cmap="RdYlGn", vmin=0.5, vmax=1.0)
+    figure.colorbar(image, label="scattering score (central patches)")
+    axis.set_title("Scattering QA — central 3×3 patches (bounded; full grid is offline QA)")
+    figure.savefig(target, dpi=110, bbox_inches="tight")
+    plt.close(figure)
+
+
+def _render_residual_hist(ms_path: Path | None, target: Path) -> None:
+    import matplotlib.pyplot as plt
+
+    if ms_path is None:
+        raise ArtifactRenderError("parent MS not on stage")
+    from dsa110_continuum.visualization.residual_diagnostics import (
+        extract_residuals_from_ms,
+        plot_residual_histogram,
+    )
+
+    data = extract_residuals_from_ms(str(ms_path), average_channels=True)
+    figure = plot_residual_histogram(data, output=str(target))
+    plt.close(figure)

--- a/scripts/artifact_pages.py
+++ b/scripts/artifact_pages.py
@@ -6,7 +6,7 @@ import html
 import json
 from pathlib import Path
 
-from dsa110_continuum.observability import artifacts, caltable_qa
+from dsa110_continuum.observability import artifacts, caltable_qa, tile_qa
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 
@@ -45,7 +45,8 @@ def _page(title: str, body: str) -> HTMLResponse:
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{html.escape(title)}</title>{_STYLE}</head>
 <body><main class="shell"><p><a href="/">← Dashboard</a> ·
-<a href="/artifacts/caltable/">caltables</a></p>{body}</main></body></html>"""
+<a href="/artifacts/caltable/">caltables</a> ·
+<a href="/artifacts/tile/">tiles</a></p>{body}</main></body></html>"""
     )
 
 
@@ -222,4 +223,134 @@ modified {html.escape(record["modified"][:19])} ·
 <table><thead><tr><th>SPW</th><th>Flagged</th><th></th></tr></thead>
 <tbody>{spw_rows}</tbody></table>
 <h2>Diagnostics</h2>{_plot_grid(f"/artifacts/caltable/{html.escape(name)}", caltable_qa.plot_kinds(name))}""",
+    )
+
+
+# ---------------------------------------------------------------- tile (#55)
+
+tile_router = APIRouter(prefix="/artifacts/tile", tags=["tile artifacts"])
+
+
+def _resolve_tile_or_404(config, ts: str) -> dict:
+    try:
+        return artifacts.tile_products(Path(config.stage) / "images", ts)
+    except artifacts.ArtifactNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+
+
+def _tile_ms_path(config, ts: str) -> Path | None:
+    related = artifacts.related_artifacts(Path(config.stage), ts)
+    name = related.get("ms_meridian") or related.get("ms")
+    return (Path(config.stage) / "ms" / name) if name else None
+
+
+@tile_router.get("/", response_class=HTMLResponse)
+def tile_index(request: Request):
+    """List the newest single-tile FITS products on stage."""
+    config = _config(request)
+    records = artifacts.list_tiles(Path(config.stage) / "images")
+    rows = (
+        "".join(
+            f'<tr><td><a href="/artifacts/tile/{record["name"]}">{record["name"]}</a></td>'
+            f"<td>{html.escape(record['modified'][:19])}</td></tr>"
+            for record in records
+        )
+        or '<tr><td colspan="2" class="muted">No tiles on stage</td></tr>'
+    )
+    return _page(
+        "Tiles",
+        f"""<h1>Single-tile FITS</h1>
+<table><thead><tr><th>Tile</th><th>Modified (UTC)</th></tr></thead>
+<tbody>{rows}</tbody></table>""",
+    )
+
+
+@tile_router.get("/{name}/status")
+def tile_status(name: str, request: Request):
+    """Machine-readable summary for one tile."""
+    config = _config(request)
+    products = _resolve_tile_or_404(config, name)
+    source = next(path for path in products.values() if path is not None)
+    ms_path = _tile_ms_path(config, name)
+    try:
+        summary = _cached_summary(
+            config, "tile", name, source, lambda: tile_qa.summary(products, ms_path)
+        )
+    except (artifacts.ArtifactRenderError, RuntimeError, ImportError) as exc:
+        raise HTTPException(status_code=424, detail=str(exc)) from None
+    return {
+        "products": {key: artifacts.file_record(path) for key, path in products.items()},
+        "summary": summary,
+        "related": artifacts.related_artifacts(Path(config.stage), name),
+        "plot_kinds": list(tile_qa.plot_kinds(products, ms_path is not None)),
+    }
+
+
+@tile_router.get("/{name}/plot/{kind}.png")
+def tile_plot(name: str, kind: str, request: Request):
+    """Lazily render (and cache) one tile diagnostic plot."""
+    config = _config(request)
+    products = _resolve_tile_or_404(config, name)
+    ms_path = _tile_ms_path(config, name)
+    if kind not in tile_qa.plot_kinds(products, ms_path is not None):
+        raise HTTPException(status_code=404, detail=f"unknown plot kind {kind!r}")
+    source = next(path for path in products.values() if path is not None)
+    try:
+        png = artifacts.cached_artifact_file(
+            Path(config.thumb_dir),
+            "tile",
+            name,
+            kind,
+            source.stat().st_mtime,
+            ".png",
+            lambda tmp: tile_qa.render_plot(products, kind, tmp, ms_path=ms_path),
+        )
+    except (artifacts.ArtifactRenderError, RuntimeError, ImportError) as exc:
+        raise HTTPException(status_code=424, detail=str(exc)) from None
+    return Response(
+        content=png.read_bytes(),
+        media_type="image/png",
+        headers={"Cache-Control": "max-age=300"},
+    )
+
+
+@tile_router.get("/{name}", response_class=HTMLResponse)
+def tile_page(name: str, request: Request):
+    """Human-readable per-tile QA page."""
+    config = _config(request)
+    products = _resolve_tile_or_404(config, name)
+    source = next(path for path in products.values() if path is not None)
+    ms_path = _tile_ms_path(config, name)
+    try:
+        summary = _cached_summary(
+            config, "tile", name, source, lambda: tile_qa.summary(products, ms_path)
+        )
+        note = ""
+    except (artifacts.ArtifactRenderError, RuntimeError, ImportError) as exc:
+        summary = {"gate": None, "residual": None, "psf_correlation": None}
+        note = f'<p class="muted">metrics unavailable: {html.escape(str(exc))}</p>'
+    gate = summary.get("gate") or {}
+    overall = str(gate.get("overall", "—"))
+    gate_badge = _badge({"PASS": "pass", "WARN": "warn"}.get(overall, "fail"), overall)
+    gate_rows = (
+        "".join(
+            f"<tr><th>{html.escape(str(key))}</th><td>{html.escape(str(value))}</td></tr>"
+            for key, value in gate.items()
+        )
+        or '<tr><td colspan="2" class="muted">—</td></tr>'
+    )
+    product_rows = "".join(
+        f"<tr><th>{key}</th><td>{html.escape(path.name) if path else '—'}</td></tr>"
+        for key, path in products.items()
+    )
+    related = artifacts.related_artifacts(Path(config.stage), name)
+    return _page(
+        f"Tile {name}",
+        f"""
+<h1>Single-tile FITS · {name} {gate_badge}</h1>
+<p class="muted"><a href="/artifacts/tile/{name}/status">JSON</a></p>
+<p>{_related_row(related)}</p>{note}
+<h2>QA gate</h2><table><tbody>{gate_rows}</tbody></table>
+<h2>Products</h2><table><tbody>{product_rows}</tbody></table>
+<h2>Diagnostics</h2>{_plot_grid(f"/artifacts/tile/{name}", tile_qa.plot_kinds(products, ms_path is not None))}""",
     )

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -715,7 +715,7 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;margin:0;ma
 @media(max-width:850px){{.stage-grid,.info-grid{{grid-template-columns:repeat(2,1fr)}}.ops-grid{{grid-template-columns:1fr}}}} @media(max-width:560px){{.shell{{padding:16px}}.summary,.stage-grid,.info-grid{{grid-template-columns:1fr 1fr}}.grid{{grid-template-columns:1fr}}}}
 </style><script>setTimeout(()=>{{const token=document.getElementById("control-token");if(!token||!token.value)location.reload();}},30000)</script></head>
 <body><main class="shell"><h1>DSA-110 Continuum Observatory</h1><div class="subtitle">Updated {now} · auto-refresh 30s · read-only ·
-<a href="/artifacts/caltable/">caltables</a></div>
+<a href="/artifacts/caltable/">caltables</a> · <a href="/artifacts/tile/">tiles</a></div>
 <section class="campaign"><div class="campaign-head"><div><h2>Active campaign · {campaign["date"]} hour {campaign["hour"]:02d}</h2><p>Hourly-epoch mosaic progress from incoming HDF5 through science products</p></div>{_badge("active" if processes else "not_yet", "process visible" if processes else ("PID recorded" if campaign["pid_hints"] else "process not visible"))}</div>
 <div class="stage-grid">{"".join(stage_cards)}</div><div class="info-grid">{"".join(disk_cards)}
 <div class="info-card"><span>Incoming slow-vis</span><strong>{incoming["hdf5_count"]} HDF5</strong><small class="path">{html.escape(incoming["directory"])}</small></div></div>
@@ -1103,7 +1103,7 @@ def operations_status(request: Request, date: str | None = None, hour: int | Non
 
 def create_app(config: DashboardConfig | None = None) -> FastAPI:
     """Create a routed dashboard application."""
-    from scripts.artifact_pages import caltable_router
+    from scripts.artifact_pages import caltable_router, tile_router
 
     dashboard_config = config or DashboardConfig()
     dashboard_config.thumb_dir.mkdir(parents=True, exist_ok=True)
@@ -1111,6 +1111,7 @@ def create_app(config: DashboardConfig | None = None) -> FastAPI:
     application.state.dashboard_config = dashboard_config
     application.include_router(mosaic_router)
     application.include_router(caltable_router)
+    application.include_router(tile_router)
     application.include_router(ops_router)
     application.include_router(control_router)
     application.include_router(control_page_router)

--- a/scripts/run_cloud_safe_tests.py
+++ b/scripts/run_cloud_safe_tests.py
@@ -38,6 +38,7 @@ CLOUD_SAFE_TESTS = (
     "tests/test_qa_server.py",
     "tests/test_artifact_substrate.py",
     "tests/test_caltable_pages.py",
+    "tests/test_tile_pages.py",
 )
 
 

--- a/tests/test_tile_pages.py
+++ b/tests/test_tile_pages.py
@@ -1,0 +1,152 @@
+"""Tile view: glue units + routed pages (cloud-safe; H17 integration guarded)."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io import fits
+from dsa110_continuum.observability import artifacts, tile_qa
+from fastapi.testclient import TestClient
+from scripts.qa_server import DashboardConfig, create_app
+
+TS = "2026-01-25T02:01:43"
+TINY_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBg"
+    b"AAAABQABh6FO1AAAAABJRU5ErkJggg=="
+)
+
+BAD_PARAMS = [
+    "..",
+    "....",
+    "%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+    "passwd",
+    "../../../etc/passwd",
+    "%2e%2e",
+    "2026-01-25%0A",
+    "2026-01-25",
+]
+
+
+def _make_config(tmp_path: Path) -> DashboardConfig:
+    return DashboardConfig(
+        stage=tmp_path / "stage",
+        products=tmp_path / "products",
+        incoming=tmp_path / "incoming",
+        thumb_dir=tmp_path / "thumbs",
+        campaign_outputs=tmp_path / "campaign",
+        campaign_date="2026-07-13",
+        campaign_hour=11,
+    )
+
+
+def _make_tile(config: DashboardConfig, suffixes=("image-pb", "residual", "psf")) -> Path:
+    tile_dir = config.stage / "images" / f"mosaic_{TS[:10]}"
+    tile_dir.mkdir(parents=True, exist_ok=True)
+    data = np.zeros((16, 16), dtype=np.float32)
+    data[8, 8] = 5.0
+    for suffix in suffixes:
+        fits.writeto(tile_dir / f"{TS}-{suffix}.fits", data, overwrite=True)
+    return tile_dir
+
+
+class TestTileGlue:
+    def test_summary_on_synthetic_tile(self, tmp_path):
+        config = _make_config(tmp_path)
+        _make_tile(config)
+        products = artifacts.tile_products(config.stage / "images", TS)
+        summary = tile_qa.summary(products, ms_path=None)
+        assert summary["gate"]["overall"] in ("PASS", "WARN", "FAIL")
+        assert summary["residual"] is not None
+        assert summary["psf_correlation"] is None  # no dirty plane written
+
+    def test_plot_kinds_reflect_products(self, tmp_path):
+        config = _make_config(tmp_path)
+        _make_tile(config, suffixes=("image",))
+        products = artifacts.tile_products(config.stage / "images", TS)
+        kinds = tile_qa.plot_kinds(products, ms_available=False)
+        assert "image" in kinds
+        assert "residual" not in kinds  # product absent
+        assert "residual_hist" not in kinds  # no MS
+
+
+class TestTileRoutes:
+    def test_traversal_payloads_rejected(self, tmp_path):
+        config = _make_config(tmp_path)
+        with TestClient(create_app(config)) as client:
+            for payload in BAD_PARAMS:
+                for route in (
+                    f"/artifacts/tile/{payload}",
+                    f"/artifacts/tile/{payload}/status",
+                    f"/artifacts/tile/{payload}/plot/image.png",
+                ):
+                    response = client.get(route)
+                    assert 400 <= response.status_code < 500, route
+                    assert "root:" not in response.text
+
+    def test_index_and_page_render(self, tmp_path, monkeypatch):
+        config = _make_config(tmp_path)
+        tile_dir = _make_tile(config)
+        fits.writeto(
+            tile_dir / f"{TS[:10]}T0200_mosaic.fits",
+            np.zeros((4, 4), dtype=np.float32),
+            overwrite=True,
+        )
+        monkeypatch.setattr(
+            tile_qa,
+            "summary",
+            lambda products, ms_path: {
+                "gate": {"overall": "PASS", "dynamic_range": 500.0},
+                "residual": {"rms": 0.01},
+                "psf_correlation": 0.9,
+                "noise": None,
+            },
+        )
+        with TestClient(create_app(config)) as client:
+            index = client.get("/artifacts/tile/")
+            page = client.get(f"/artifacts/tile/{TS}")
+        assert f"/artifacts/tile/{TS}" in index.text
+        assert page.status_code == 200
+        assert "PASS" in page.text
+        assert f"/artifacts/mosaic/{TS[:10]}/T0200/status" in page.text  # downstream link
+
+    def test_plot_route_renders_real_image_plot(self, tmp_path):
+        """Plot kind 'image' uses fits_plots on the synthetic FITS — no CASA needed."""
+        config = _make_config(tmp_path)
+        _make_tile(config)
+        with TestClient(create_app(config)) as client:
+            response = client.get(f"/artifacts/tile/{TS}/plot/image.png")
+        assert response.status_code == 200
+        assert response.content[:4] == b"\x89PNG"
+
+    def test_scattering_unavailable_maps_to_424(self, tmp_path, monkeypatch):
+        config = _make_config(tmp_path)
+        _make_tile(config)
+
+        def no_scattering(products, kind, target, ms_path=None):
+            raise artifacts.ArtifactRenderError("scattering library unavailable")
+
+        monkeypatch.setattr(tile_qa, "render_plot", no_scattering)
+        with TestClient(create_app(config)) as client:
+            response = client.get(f"/artifacts/tile/{TS}/plot/scattering.png")
+        assert response.status_code == 424
+
+
+STAGE = Path("/stage/dsa110-contimg")
+requires_stage = pytest.mark.skipif(not STAGE.is_dir(), reason="H17 stage not present")
+
+
+@requires_stage
+class TestTileLiveIntegration:
+    """Issue #55 acceptance: renders for at least one real single-tile FITS."""
+
+    def test_real_tile_page_renders(self, tmp_path):
+        records = artifacts.list_tiles(STAGE / "images", limit=1)
+        assert records, "no tiles on stage"
+        config = DashboardConfig(thumb_dir=tmp_path / "thumbs")
+        with TestClient(create_app(config)) as client:
+            response = client.get(f"/artifacts/tile/{records[0]['name']}")
+        assert response.status_code == 200
+        assert "QA gate" in response.text


### PR DESCRIPTION
Phase A / PR 2 of the dashboard feature campaign (plan: `docs/rse/specs/plan-phase-a-artifact-qa-views-2026-07-15.md`). Closes #55.

## What
- `dsa110_continuum/observability/tile_qa.py` — tile glue: `image_gate` result (integration time from the parent MS when present), residual stats, PSF correlation; lazy plot renderers: image, residual, PSF 2D/radial/sidelobe, bounded scattering (central 3×3 patches via `score_patch`; full grid stays offline QA), MS-domain residual histogram.
- `scripts/artifact_pages.py` — `/artifacts/tile/` index + `/{ts}` page + `/{ts}/status` + `/{ts}/plot/{kind}.png` with upstream MS / downstream hourly-epoch-mosaic links; plot kinds gate on which products exist on disk.
- Cache fix in `artifacts.py`: temp file keeps the real suffix so `savefig` format inference works.
- `CLOUD_SAFE_TESTS` += `test_tile_pages.py`.

## Notes
- `scattering` library is not installed in casa6 → the scattering card returns HTTP 424 with that message (tested degrade); optional install is Jakob's call.
- `scattering_qa`'s WCS tile-footprint glob doesn't match production flat tile naming — the bounded card uses the patch grid directly.

## Verification
- 55 passed on H17 (tile + caltable + substrate, incl. live-integration test against a real tile).
- `make test-cloud` green (322 passed). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWfuZCVQgwkUZiBP1ByKwE