### PR TITLE
Per-MS QA view (#54)

### DIFF
--- a/dsa110_continuum/observability/caltable_qa.py
+++ b/dsa110_continuum/observability/caltable_qa.py
@@ -97,8 +97,8 @@ def render_plot(table_path: Path, kind: str, target: Path) -> None:
         shutil.move(str(produced), str(target))
     except ArtifactRenderError:
         raise
-    except (ImportError, RuntimeError, OSError, ValueError, KeyError) as exc:
-        raise ArtifactRenderError(f"{kind}: {exc}") from exc
+    except Exception as exc:
+        raise ArtifactRenderError(f"{kind}: {type(exc).__name__}: {exc}") from exc
     finally:
         shutil.rmtree(workdir, ignore_errors=True)
 

--- a/dsa110_continuum/observability/ms_qa.py
+++ b/dsa110_continuum/observability/ms_qa.py
@@ -1,0 +1,189 @@
+"""Per-Measurement-Set QA glue for the dashboard (bounded, lazy, cached by the caller)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dsa110_continuum.observability.artifacts import ArtifactRenderError
+
+UVW_SAMPLE = 2000
+# Contiguous rows (stride 1) keep complete baseline sets per integration —
+# strided sampling leaves most antenna triangles without all three baselines.
+CLOSURE_LIMITS = {"max_rows": 20000, "row_stride": 1, "max_channels": 4}
+
+BASE_KINDS = (
+    "uv_coverage",
+    "elevation",
+    "parallactic",
+    "rfi_waterfall",
+    "autocorr_heatmap",
+    "closure_hist",
+)
+
+
+def _bp_table(ms_path: Path) -> Path | None:
+    stem = ms_path.name.rsplit(".", 1)[0].replace("_meridian", "")
+    candidate = ms_path.parent / f"{stem}_0~23.b"
+    return candidate if candidate.is_dir() else None
+
+
+def plot_kinds(ms_path: Path) -> tuple[str, ...]:
+    """Return the plot kinds available for this MS."""
+    kinds = list(BASE_KINDS)
+    if _bp_table(ms_path) is not None:
+        kinds.append("bandpass_diag")
+    return tuple(kinds)
+
+
+def summary(ms_path: Path) -> dict:
+    """Conversion + UVW + RFI occupancy summary; every section degrades independently."""
+    from dsa110_continuum.qa.pipeline_quality import check_ms_after_conversion
+
+    passed, conversion = check_ms_after_conversion(str(ms_path))
+    result: dict = {"conversion": conversion, "conversion_passed": bool(passed)}
+    try:
+        from dsa110_continuum.qa.uvw_validation import validate_uvw_geometry
+
+        uvw = validate_uvw_geometry(str(ms_path), sample_size=UVW_SAMPLE)
+        result["uvw"] = {
+            "is_valid": uvw.is_valid,
+            "n_violations": uvw.n_violations,
+            "violation_fraction": uvw.violation_fraction,
+            "max_uvw_distance_m": uvw.max_uvw_distance_m,
+        }
+    except Exception as exc:
+        result["uvw"] = {"error": str(exc)}
+    try:
+        from dsa110_continuum.qa.rfi_metrics import calculate_rfi_occupancy
+
+        occupancy = calculate_rfi_occupancy(ms_path)
+        result["rfi"] = {
+            "total_occupancy": float(occupancy["total_occupancy"]),
+            "n_channels": int(occupancy["n_channels"]),
+            "n_rows": int(occupancy["n_rows"]),
+        }
+    except Exception as exc:
+        result["rfi"] = {"error": str(exc)}
+    return result
+
+
+def _uv_lambda(ms_path: Path):
+    import numpy as np
+    from dsa110_continuum.adapters.casa_tables import table
+
+    with table(str(ms_path)) as ms:
+        uvw = ms.getcol("UVW")
+    with table(str(ms_path) + "/SPECTRAL_WINDOW") as spw:
+        freq_hz = float(np.mean(spw.getcol("CHAN_FREQ")))
+    wavelength_m = 299792458.0 / freq_hz
+    return uvw[:, 0] / wavelength_m, uvw[:, 1] / wavelength_m
+
+
+def render_plot(ms_path: Path, kind: str, target: Path) -> None:
+    """Render one MS plot kind to ``target``; ArtifactRenderError carries the reason."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    try:
+        if kind == "uv_coverage":
+            from dsa110_continuum.visualization.uv_plots import plot_uv_coverage
+
+            u_lambda, v_lambda = _uv_lambda(ms_path)
+            figure = plot_uv_coverage(
+                u_lambda, v_lambda, output=str(target), title=f"UV coverage · {ms_path.name}"
+            )
+            plt.close(figure)
+        elif kind in ("elevation", "parallactic"):
+            from dsa110_continuum.visualization.elevation_plots import (
+                extract_geometry_from_ms,
+                plot_elevation_vs_time,
+                plot_parallactic_angle_vs_time,
+            )
+
+            geometry = extract_geometry_from_ms(str(ms_path))
+            if kind == "elevation":
+                figure = plot_elevation_vs_time(
+                    geometry["times"], geometry["elevation_deg"], output=str(target)
+                )
+            else:
+                figure = plot_parallactic_angle_vs_time(
+                    geometry["times"], geometry["parallactic_angle_deg"], output=str(target)
+                )
+            plt.close(figure)
+        elif kind == "rfi_waterfall":
+            import numpy as np
+            from dsa110_continuum.qa.rfi_metrics import get_rfi_waterfall_data
+
+            waterfall, times, freqs = get_rfi_waterfall_data(ms_path)
+            figure, axis = plt.subplots(figsize=(10, 4))
+            mesh = axis.imshow(
+                waterfall,
+                origin="lower",
+                aspect="auto",
+                cmap="inferno",
+                extent=[freqs.min() / 1e6, freqs.max() / 1e6, 0, len(np.atleast_1d(times))],
+            )
+            figure.colorbar(mesh, label="flag occupancy")
+            axis.set_xlabel("frequency (MHz)")
+            axis.set_ylabel("time bin")
+            axis.set_title(f"RFI flag waterfall · {ms_path.name}")
+            figure.savefig(target, dpi=110, bbox_inches="tight")
+            plt.close(figure)
+        elif kind == "autocorr_heatmap":
+            from dsa110_continuum.visualization.tsys_plots import (
+                extract_tsys_from_ms,
+                plot_tsys_heatmap,
+            )
+
+            data = extract_tsys_from_ms(str(ms_path))
+            figure = plot_tsys_heatmap(
+                data["times"],
+                data["tsys"],
+                output=str(target),
+                antenna_names=data.get("antenna_names"),
+                title="Autocorrelation amplitude (uncalibrated Tsys proxy)",
+            )
+            plt.close(figure)
+        elif kind == "closure_hist":
+            from dsa110_continuum.visualization.closure_phase_plots import (
+                compute_closure_phases,
+                extract_closure_phases_from_ms,
+                plot_closure_phase_histogram,
+            )
+
+            raw = extract_closure_phases_from_ms(str(ms_path), **CLOSURE_LIMITS)
+            closure = compute_closure_phases(raw["visibility"], raw["antenna1"], raw["antenna2"])
+            figure = plot_closure_phase_histogram(closure, output=str(target))
+            plt.close(figure)
+        elif kind == "bandpass_diag":
+            _render_bandpass_diag(ms_path, target)
+        else:
+            raise ArtifactRenderError(f"unknown plot kind {kind!r}")
+    except ArtifactRenderError:
+        raise
+    except Exception as exc:
+        raise ArtifactRenderError(f"{kind}: {type(exc).__name__}: {exc}") from exc
+
+
+def _render_bandpass_diag(ms_path: Path, target: Path) -> None:
+    """Figure 1 of the bandpass diagnostic set (per-antenna amplitude overview)."""
+    import shutil
+    import tempfile
+
+    from dsa110_continuum.visualization.bandpass_diagnostics import load_data, plot_figure1
+
+    bp_table = _bp_table(ms_path)
+    if bp_table is None:
+        raise ArtifactRenderError("no same-timestamp bandpass table on stage")
+    workdir = Path(tempfile.mkdtemp(prefix="bpdiag_", dir=str(target.parent)))
+    try:
+        data = load_data(str(ms_path), str(bp_table))
+        plot_figure1(data, workdir, ms_path.name)
+        pngs = sorted(workdir.glob("*.png"))
+        if not pngs:
+            raise ArtifactRenderError("bandpass diagnostics produced no figure")
+        shutil.move(str(pngs[0]), str(target))
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)

--- a/dsa110_continuum/observability/tile_qa.py
+++ b/dsa110_continuum/observability/tile_qa.py
@@ -129,8 +129,8 @@ def render_plot(
             raise ArtifactRenderError(f"unknown plot kind {kind!r}")
     except ArtifactRenderError:
         raise
-    except (ImportError, RuntimeError, OSError, ValueError, KeyError) as exc:
-        raise ArtifactRenderError(f"{kind}: {exc}") from exc
+    except Exception as exc:
+        raise ArtifactRenderError(f"{kind}: {type(exc).__name__}: {exc}") from exc
 
 
 def _render_scattering(image_path: Path, target: Path) -> None:

--- a/dsa110_continuum/qa/rfi_metrics.py
+++ b/dsa110_continuum/qa/rfi_metrics.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 import numpy as np
 
-
 try:
     from dsa110_continuum.adapters import casa_tables as casatables
 
@@ -67,9 +66,9 @@ def calculate_rfi_occupancy(ms_path: str | Path) -> dict[str, np.ndarray]:
         freqs = sw.getcol("CHAN_FREQ")[0]  # Assuming SPW 0 for now
 
     # Calculate occupancy vs Frequency (average over Time and Pol)
-    # flags shape: (n_row, n_chan, n_pol)
+    # flags shape via the casa_tables adapter: (n_row, n_pol, n_chan)
     # Result: (n_chan,)
-    freq_occupancy = np.mean(flags, axis=(0, 2)) * 100.0
+    freq_occupancy = np.mean(flags, axis=(0, 1)) * 100.0
 
     # Calculate occupancy vs Time (average over Freq and Pol)
     # Result: (n_row,) - This is per-baseline-time.
@@ -122,7 +121,7 @@ def get_rfi_waterfall_data(
 
     with casatables.table(ms_path, ack=False) as tb:
         times = tb.getcol("TIME")
-        flags = tb.getcol("FLAG")  # (Row, Chan, Pol)
+        flags = tb.getcol("FLAG")  # adapter layout: (Row, Pol, Chan)
 
     with casatables.table(f"{ms_path}/SPECTRAL_WINDOW", ack=False) as sw:
         freqs = sw.getcol("CHAN_FREQ")[0]
@@ -130,7 +129,7 @@ def get_rfi_waterfall_data(
     # Collapse Pol axis -> (Row, Chan)
     # If any pol is flagged, we count it? Or average?
     # Usually RFI affects all pols, but let's average to get a "fraction flagged" 0.0-1.0
-    flags_row_chan = np.mean(flags, axis=2)
+    flags_row_chan = np.mean(flags, axis=1)
 
     # Bin by time
     # Find unique times and inverse indices

--- a/dsa110_continuum/visualization/elevation_plots.py
+++ b/dsa110_continuum/visualization/elevation_plots.py
@@ -41,10 +41,10 @@ if TYPE_CHECKING:
     from matplotlib.figure import Figure
     from numpy.typing import NDArray
 
-from astropy.coordinates import SkyCoord, EarthLocation, AltAz
-from astropy.time import Time
 from astropy import units as u
-from dsa110_continuum.utils.constants import DSA110_LOCATION, DSA110_LATITUDE, DSA110_LONGITUDE
+from astropy.coordinates import AltAz, EarthLocation, SkyCoord
+from astropy.time import Time
+from dsa110_continuum.utils.constants import DSA110_LATITUDE, DSA110_LOCATION, DSA110_LONGITUDE
 from dsa110_continuum.utils.time_utils import detect_casa_time_format, jd_to_mjd
 from dsa110_continuum.visualization.config import FigureConfig, PlotStyle
 
@@ -86,7 +86,7 @@ def compute_parallactic_angle(
     # Ideally should pass location explicitly, but we'll use lat_deg for flexibility
     # We use a dummy longitude since HA is local
     loc = EarthLocation(lat=lat_deg * u.deg, lon=0 * u.deg, height=0 * u.m)
-    
+
     # Construct a dummy time where LST = 0 (so HA = -RA)
     # But simpler: HA = LST - RA.
     # If we set LST=0 (Time="..."), then RA = -HA.
@@ -735,7 +735,7 @@ def plot_observation_summary(
              # If lst_start is given, we can guess a date where LST matches? Too complex.
              # Fallback to geometry if no date.
              ts = None
-             
+
         if ts is not None:
              sc = SkyCoord(ra=ra_deg*u.deg, dec=dec_deg*u.deg, frame='icrs')
              # Transform
@@ -743,7 +743,7 @@ def plot_observation_summary(
              altaz = sc.transform_to(AltAz(obstime=ts, location=location))
              el = altaz.alt.deg
              az = altaz.az.deg
-             
+
              # Parallactic Angle
              # Astropy < 5.0 might not have it directly on SkyCoord, but let's check.
              # Easier to use the helper with calculated HA
@@ -849,7 +849,9 @@ def extract_geometry_from_ms(
 
     # Get field info
     with table(str(ms_path / "FIELD"), readonly=True, ack=False) as field_tb:
-        phase_dir = field_tb.getcol("PHASE_DIR")[0, 0]  # First field, first poly term
+        # First field, first poly term; squeeze handles both (nfields, 1, 2)
+        # and CASA column-major (nfields, 2, 1) layouts (CLAUDE.md invariant 4)
+        phase_dir = np.squeeze(field_tb.getcol("PHASE_DIR")[0])
         result["ra_rad"] = phase_dir[0]
         result["dec_rad"] = phase_dir[1]
         result["ra_deg"] = np.degrees(phase_dir[0])

--- a/scripts/artifact_pages.py
+++ b/scripts/artifact_pages.py
@@ -6,7 +6,7 @@ import html
 import json
 from pathlib import Path
 
-from dsa110_continuum.observability import artifacts, caltable_qa, tile_qa
+from dsa110_continuum.observability import artifacts, caltable_qa, ms_qa, tile_qa
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 
@@ -46,7 +46,8 @@ def _page(title: str, body: str) -> HTMLResponse:
 <title>{html.escape(title)}</title>{_STYLE}</head>
 <body><main class="shell"><p><a href="/">← Dashboard</a> ·
 <a href="/artifacts/caltable/">caltables</a> ·
-<a href="/artifacts/tile/">tiles</a></p>{body}</main></body></html>"""
+<a href="/artifacts/tile/">tiles</a> ·
+<a href="/artifacts/ms/">measurement sets</a></p>{body}</main></body></html>"""
     )
 
 
@@ -353,4 +354,119 @@ def tile_page(name: str, request: Request):
 <h2>QA gate</h2><table><tbody>{gate_rows}</tbody></table>
 <h2>Products</h2><table><tbody>{product_rows}</tbody></table>
 <h2>Diagnostics</h2>{_plot_grid(f"/artifacts/tile/{name}", tile_qa.plot_kinds(products, ms_path is not None))}""",
+    )
+
+
+# ---------------------------------------------------------------- ms (#54)
+
+ms_router = APIRouter(prefix="/artifacts/ms", tags=["ms artifacts"])
+
+
+def _resolve_ms_or_404(config, name: str) -> Path:
+    try:
+        return artifacts.resolve_ms(Path(config.stage) / "ms", name)
+    except artifacts.ArtifactNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from None
+
+
+@ms_router.get("/", response_class=HTMLResponse)
+def ms_index(request: Request):
+    """List the newest Measurement Sets on stage."""
+    config = _config(request)
+    records = artifacts.list_ms(Path(config.stage) / "ms")
+    rows = "".join(
+        f'<tr><td><a href="/artifacts/ms/{html.escape(record["name"])}">'
+        f"{html.escape(record['name'])}</a></td>"
+        f"<td>{html.escape(record['modified'][:19])}</td></tr>"
+        for record in records
+    ) or '<tr><td colspan="2" class="muted">No Measurement Sets on stage</td></tr>'
+    return _page(
+        "Measurement Sets",
+        f"""<h1>Measurement Sets</h1>
+<table><thead><tr><th>MS</th><th>Modified (UTC)</th></tr></thead>
+<tbody>{rows}</tbody></table>""",
+    )
+
+
+@ms_router.get("/{name}/status")
+def ms_status(name: str, request: Request):
+    """Machine-readable summary for one Measurement Set."""
+    config = _config(request)
+    path = _resolve_ms_or_404(config, name)
+    try:
+        summary = _cached_summary(config, "ms", name, path, lambda: ms_qa.summary(path))
+    except (artifacts.ArtifactRenderError, RuntimeError, ImportError) as exc:
+        raise HTTPException(status_code=424, detail=str(exc)) from None
+    return {
+        "file": artifacts.file_record(path),
+        "summary": summary,
+        "related": artifacts.related_artifacts(Path(config.stage), name[:19]),
+        "plot_kinds": list(ms_qa.plot_kinds(path)),
+    }
+
+
+@ms_router.get("/{name}/plot/{kind}.png")
+def ms_plot(name: str, kind: str, request: Request):
+    """Lazily render (and cache) one MS diagnostic plot."""
+    config = _config(request)
+    path = _resolve_ms_or_404(config, name)
+    if kind not in ms_qa.plot_kinds(path):
+        raise HTTPException(status_code=404, detail=f"unknown plot kind {kind!r}")
+    try:
+        png = artifacts.cached_artifact_file(
+            Path(config.thumb_dir),
+            "ms",
+            name,
+            kind,
+            path.stat().st_mtime,
+            ".png",
+            lambda tmp: ms_qa.render_plot(path, kind, tmp),
+        )
+    except (artifacts.ArtifactRenderError, RuntimeError, ImportError) as exc:
+        raise HTTPException(status_code=424, detail=str(exc)) from None
+    return Response(
+        content=png.read_bytes(),
+        media_type="image/png",
+        headers={"Cache-Control": "max-age=300"},
+    )
+
+
+@ms_router.get("/{name}", response_class=HTMLResponse)
+def ms_page(name: str, request: Request):
+    """Human-readable per-MS QA page with lifecycle state."""
+    config = _config(request)
+    path = _resolve_ms_or_404(config, name)
+    record = artifacts.file_record(path)
+    try:
+        summary = _cached_summary(config, "ms", name, path, lambda: ms_qa.summary(path))
+        note = ""
+    except (artifacts.ArtifactRenderError, RuntimeError, ImportError) as exc:
+        summary = {}
+        note = f'<p class="muted">metrics unavailable: {html.escape(str(exc))}</p>'
+    related = artifacts.related_artifacts(Path(config.stage), name[:19])
+    lifecycle = [
+        ("Calibration tables", bool(related["caltables"])),
+        ("Tile image", related["tile"] is not None),
+        ("Hourly-epoch mosaic", related["mosaic_exists"]),
+    ]
+    lifecycle_rows = "".join(
+        f"<tr><th>{stage_name}</th>"
+        f"<td>{_badge('pass' if done else 'warn', 'ready' if done else 'not yet')}</td></tr>"
+        for stage_name, done in lifecycle
+    )
+    summary_rows = "".join(
+        f"<tr><th>{html.escape(str(key))}</th><td>{html.escape(str(value))}</td></tr>"
+        for key, value in summary.items()
+    ) or '<tr><td colspan="2" class="muted">—</td></tr>'
+    return _page(
+        f"MS {name}",
+        f"""
+<h1>Measurement Set · {html.escape(name)}</h1>
+<p class="muted">{html.escape(record["path"])} ·
+modified {html.escape(record["modified"][:19])} ·
+<a href="/artifacts/ms/{html.escape(name)}/status">JSON</a></p>
+<p>{_related_row(related)}</p>{note}
+<h2>Lifecycle</h2><table><tbody>{lifecycle_rows}</tbody></table>
+<h2>Summary</h2><table><tbody>{summary_rows}</tbody></table>
+<h2>Diagnostics</h2>{_plot_grid(f"/artifacts/ms/{html.escape(name)}", ms_qa.plot_kinds(path))}""",
     )

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -715,7 +715,7 @@ pre{{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;margin:0;ma
 @media(max-width:850px){{.stage-grid,.info-grid{{grid-template-columns:repeat(2,1fr)}}.ops-grid{{grid-template-columns:1fr}}}} @media(max-width:560px){{.shell{{padding:16px}}.summary,.stage-grid,.info-grid{{grid-template-columns:1fr 1fr}}.grid{{grid-template-columns:1fr}}}}
 </style><script>setTimeout(()=>{{const token=document.getElementById("control-token");if(!token||!token.value)location.reload();}},30000)</script></head>
 <body><main class="shell"><h1>DSA-110 Continuum Observatory</h1><div class="subtitle">Updated {now} · auto-refresh 30s · read-only ·
-<a href="/artifacts/caltable/">caltables</a> · <a href="/artifacts/tile/">tiles</a></div>
+<a href="/artifacts/caltable/">caltables</a> · <a href="/artifacts/tile/">tiles</a> · <a href="/artifacts/ms/">measurement sets</a></div>
 <section class="campaign"><div class="campaign-head"><div><h2>Active campaign · {campaign["date"]} hour {campaign["hour"]:02d}</h2><p>Hourly-epoch mosaic progress from incoming HDF5 through science products</p></div>{_badge("active" if processes else "not_yet", "process visible" if processes else ("PID recorded" if campaign["pid_hints"] else "process not visible"))}</div>
 <div class="stage-grid">{"".join(stage_cards)}</div><div class="info-grid">{"".join(disk_cards)}
 <div class="info-card"><span>Incoming slow-vis</span><strong>{incoming["hdf5_count"]} HDF5</strong><small class="path">{html.escape(incoming["directory"])}</small></div></div>
@@ -1103,7 +1103,7 @@ def operations_status(request: Request, date: str | None = None, hour: int | Non
 
 def create_app(config: DashboardConfig | None = None) -> FastAPI:
     """Create a routed dashboard application."""
-    from scripts.artifact_pages import caltable_router, tile_router
+    from scripts.artifact_pages import caltable_router, ms_router, tile_router
 
     dashboard_config = config or DashboardConfig()
     dashboard_config.thumb_dir.mkdir(parents=True, exist_ok=True)
@@ -1112,6 +1112,7 @@ def create_app(config: DashboardConfig | None = None) -> FastAPI:
     application.include_router(mosaic_router)
     application.include_router(caltable_router)
     application.include_router(tile_router)
+    application.include_router(ms_router)
     application.include_router(ops_router)
     application.include_router(control_router)
     application.include_router(control_page_router)

--- a/scripts/run_cloud_safe_tests.py
+++ b/scripts/run_cloud_safe_tests.py
@@ -39,6 +39,7 @@ CLOUD_SAFE_TESTS = (
     "tests/test_artifact_substrate.py",
     "tests/test_caltable_pages.py",
     "tests/test_tile_pages.py",
+    "tests/test_ms_pages.py",
 )
 
 

--- a/tests/test_ms_pages.py
+++ b/tests/test_ms_pages.py
@@ -1,0 +1,158 @@
+"""MS view: glue units + routed pages (cloud-safe; H17 integration guarded)."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from dsa110_continuum.observability import artifacts, ms_qa
+from fastapi.testclient import TestClient
+from scripts.qa_server import DashboardConfig, create_app
+
+TS = "2026-01-25T22:26:05"
+MS = f"{TS}.ms"
+TINY_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGNgYGBg"
+    b"AAAABQABh6FO1AAAAABJRU5ErkJggg=="
+)
+
+BAD_PARAMS = [
+    "..",
+    "....",
+    "%2e%2e%2f%2e%2e%2fetc%2fpasswd",
+    "passwd.ms",
+    "../../../etc/passwd",
+    "%2e%2e",
+    f"{TS}.MS",
+]
+
+
+def _make_config(tmp_path: Path) -> DashboardConfig:
+    return DashboardConfig(
+        stage=tmp_path / "stage",
+        products=tmp_path / "products",
+        incoming=tmp_path / "incoming",
+        thumb_dir=tmp_path / "thumbs",
+        campaign_outputs=tmp_path / "campaign",
+        campaign_date="2026-07-13",
+        campaign_hour=11,
+    )
+
+
+def _make_ms(config: DashboardConfig, name: str = MS) -> Path:
+    path = config.stage / "ms" / name
+    path.mkdir(parents=True)
+    (path / "table.dat").write_bytes(b"x")
+    return path
+
+
+class TestMsGlue:
+    def test_summary_degrades_without_casa_data(self, tmp_path):
+        """check_ms_after_conversion is designed to degrade; summary must not raise."""
+        config = _make_config(tmp_path)
+        ms = _make_ms(config)
+        summary = ms_qa.summary(ms)
+        assert "conversion" in summary
+        assert summary["conversion"]["exists"] is True
+
+    def test_plot_kinds_gate_on_bpcal(self, tmp_path):
+        config = _make_config(tmp_path)
+        ms = _make_ms(config)
+        assert "bandpass_diag" not in ms_qa.plot_kinds(ms)
+        (config.stage / "ms" / f"{TS}_0~23.b").mkdir()
+        assert "bandpass_diag" in ms_qa.plot_kinds(ms)
+
+    def test_bp_table_strips_meridian_suffix(self, tmp_path):
+        config = _make_config(tmp_path)
+        ms = _make_ms(config, name=f"{TS}_meridian.ms")
+        (config.stage / "ms" / f"{TS}_0~23.b").mkdir()
+        assert "bandpass_diag" in ms_qa.plot_kinds(ms)
+
+
+class TestMsRoutes:
+    def test_traversal_payloads_rejected(self, tmp_path):
+        config = _make_config(tmp_path)
+        with TestClient(create_app(config)) as client:
+            for payload in BAD_PARAMS:
+                for route in (
+                    f"/artifacts/ms/{payload}",
+                    f"/artifacts/ms/{payload}/status",
+                    f"/artifacts/ms/{payload}/plot/uv_coverage.png",
+                ):
+                    response = client.get(route)
+                    assert 400 <= response.status_code < 500, route
+                    assert "root:" not in response.text
+
+    def test_index_page_and_lifecycle(self, tmp_path, monkeypatch):
+        config = _make_config(tmp_path)
+        _make_ms(config)
+        monkeypatch.setattr(
+            ms_qa,
+            "summary",
+            lambda path: {
+                "conversion": {"exists": True, "size_bytes": 1},
+                "conversion_passed": True,
+                "uvw": {"is_valid": True},
+                "rfi": {"total_occupancy": 0.02},
+            },
+        )
+        with TestClient(create_app(config)) as client:
+            index = client.get("/artifacts/ms/")
+            page = client.get(f"/artifacts/ms/{MS}")
+        assert f"/artifacts/ms/{MS}" in index.text
+        assert page.status_code == 200
+        assert "Lifecycle" in page.text
+
+    def test_plot_route_caches(self, tmp_path, monkeypatch):
+        config = _make_config(tmp_path)
+        _make_ms(config)
+        calls = []
+
+        def fake_render(path, kind, target):
+            calls.append(kind)
+            target.write_bytes(TINY_PNG)
+
+        monkeypatch.setattr(ms_qa, "render_plot", fake_render)
+        with TestClient(create_app(config)) as client:
+            for _ in range(2):
+                assert client.get(f"/artifacts/ms/{MS}/plot/uv_coverage.png").status_code == 200
+        assert calls == ["uv_coverage"]
+
+    def test_render_error_maps_to_424(self, tmp_path, monkeypatch):
+        config = _make_config(tmp_path)
+        _make_ms(config)
+
+        def broken(path, kind, target):
+            raise artifacts.ArtifactRenderError("casacore unavailable")
+
+        monkeypatch.setattr(ms_qa, "render_plot", broken)
+        with TestClient(create_app(config)) as client:
+            response = client.get(f"/artifacts/ms/{MS}/plot/uv_coverage.png")
+        assert response.status_code == 424
+
+
+STAGE_MS = Path("/stage/dsa110-contimg/ms")
+requires_stage = pytest.mark.skipif(not STAGE_MS.is_dir(), reason="H17 stage volume not present")
+
+
+@requires_stage
+class TestMsLiveIntegration:
+    """Issue #54 acceptance: renders for at least one real MS on stage."""
+
+    def test_real_ms_page_renders(self, tmp_path):
+        records = artifacts.list_ms(STAGE_MS, limit=1)
+        assert records, "no MS on stage"
+        config = DashboardConfig(thumb_dir=tmp_path / "thumbs")
+        with TestClient(create_app(config)) as client:
+            response = client.get(f"/artifacts/ms/{records[0]['name']}")
+        assert response.status_code == 200
+        assert "Lifecycle" in response.text
+
+    def test_real_uv_coverage_plot(self, tmp_path):
+        records = artifacts.list_ms(STAGE_MS, limit=1)
+        config = DashboardConfig(thumb_dir=tmp_path / "thumbs")
+        with TestClient(create_app(config)) as client:
+            response = client.get(f"/artifacts/ms/{records[0]['name']}/plot/uv_coverage.png")
+        assert response.status_code == 200
+        assert response.content[:4] == b"\x89PNG"


### PR DESCRIPTION
Phase A / PR 3 of the dashboard feature campaign (plan: `docs/rse/specs/plan-phase-a-artifact-qa-views-2026-07-15.md`). Closes #54.

## What
- `dsa110_continuum/observability/ms_qa.py` — per-MS glue: `check_ms_after_conversion` + bounded `validate_uvw_geometry` (sample_size=2000) + RFI occupancy summary (cached; sections degrade independently); lazy plots: UV coverage (reads UVW only — bypasses `extract_uv_from_ms`'s full-DATA read), elevation/parallactic, RFI waterfall, autocorr-amplitude heatmap (labeled as uncalibrated Tsys proxy), closure-phase histogram, bandpass diagnostics fig 1 when the same-timestamp `.b` exists.
- `scripts/artifact_pages.py` — `/artifacts/ms/` routes + Lifecycle card (caltables → tile → hourly-epoch mosaic readiness).

## Latent bugs found by live smoke and fixed
- `elevation_plots.extract_geometry_from_ms` hardcoded `(nfields, 1, 2)` `PHASE_DIR` indexing → IndexError on real MS (CLAUDE.md FIELD-shape invariant); now `np.squeeze`-normalized.
- `rfi_metrics`: waterfall and `freq_occupancy` collapsed the wrong axis (adapter FLAG layout is `(row, pol, chan)`, code assumed `(row, chan, pol)`) — waterfall crashed; `freq_occupancy` silently returned a 2-element array. `total_occupancy` (used by QA summaries) was unaffected.
- Closure-phase card: strided row sampling left most antenna triangles incomplete → contiguous-row decimation (`row_stride=1`, first ~4 integrations).

## Deviations recorded for the #54 close-out
- `coverage_moc` is not per-MS (reads the pointing-history SQLite DB) and `mocpy` is not installed in casa6 → no MOC card in v1.
- `uv_plots.extract_uv_from_ms` bypassed for coverage (full-DATA read); plot functions themselves are wired.

## Verification
- 131 passed on H17 (all four artifact test files + `test_qa_server.py`, incl. live MS page + UV PNG); all 7 MS plot kinds smoke-rendered against `2026-07-13T11:18:06.ms`.
- `make test-cloud` green (331 passed). ruff clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWfuZCVQgwkUZiBP1ByKwE