### PR TITLE
photometry.source: raw-DB relative photometry, eta TypeError, canonical v, haversine neighbor search (#118)

### DIFF
--- a/dsa110_continuum/photometry/source.py
+++ b/dsa110_continuum/photometry/source.py
@@ -202,6 +202,18 @@ class Source:
             if "normalized_flux_err_jy" not in df.columns:
                 df["normalized_flux_err_jy"] = np.nan
 
+            # All-NULL SQLite REAL columns arrive from pandas as object-dtype
+            # None arrays; coerce every flux/error column to float so numpy
+            # ufuncs downstream never see object arrays.
+            for col in (
+                "peak_jyb",
+                "peak_err_jyb",
+                "normalized_flux_jy",
+                "normalized_flux_err_jy",
+            ):
+                if col in df.columns:
+                    df[col] = pd.to_numeric(df[col], errors="coerce")
+
             # Convert measured_at to datetime if present
             if "measured_at" in df.columns:
                 df["measured_at"] = pd.to_datetime(df["measured_at"], unit="s", errors="coerce")
@@ -215,15 +227,18 @@ class Source:
     def _flux_columns(self) -> tuple[str, str]:
         """Select flux/error columns for downstream computations.
 
-        Normalized columns are used when the normalized flux carries at least
-        one finite value, otherwise the raw peak columns. A raw products DB
-        has no normalized photometry, so preferring the (NaN-filled)
-        normalized column unconditionally made every downstream computation
-        degenerate (issue #118).
+        Normalized columns are used when BOTH the normalized flux and its
+        error carry at least one finite value (weighted metrics are impossible
+        without errors), otherwise the raw peak columns. A raw products DB has
+        no normalized photometry, so preferring the (NaN-filled) normalized
+        column unconditionally made every downstream computation degenerate
+        (issue #118). A partially normalized target keeps NaN gaps at
+        unnormalized epochs rather than mixing normalizations.
         """
-        if "normalized_flux_jy" in self.measurements.columns:
-            normalized = pd.to_numeric(self.measurements["normalized_flux_jy"], errors="coerce")
-            if np.isfinite(normalized).any():
+        if {"normalized_flux_jy", "normalized_flux_err_jy"} <= set(self.measurements.columns):
+            flux = pd.to_numeric(self.measurements["normalized_flux_jy"], errors="coerce")
+            err = pd.to_numeric(self.measurements["normalized_flux_err_jy"], errors="coerce")
+            if bool(np.isfinite(flux).any()) and bool(np.isfinite(err).any()):
                 return "normalized_flux_jy", "normalized_flux_err_jy"
         return "peak_jyb", "peak_err_jyb"
 
@@ -282,9 +297,11 @@ class Source:
         if flux_col not in self.measurements.columns:
             raise SourceError(f"Flux column {flux_col} not found in measurements")
 
-        flux = self.measurements[flux_col].values
+        flux = pd.to_numeric(self.measurements[flux_col], errors="coerce").to_numpy()
         flux_err = (
-            self.measurements[err_col].values if err_col in self.measurements.columns else None
+            pd.to_numeric(self.measurements[err_col], errors="coerce").to_numpy()
+            if err_col in self.measurements.columns
+            else None
         )
 
         # Filter out NaN/inf values
@@ -567,8 +584,17 @@ class Source:
                 # Reindex to target epochs (puts NaNs where missing)
                 aligned = n_data.reindex(target_epochs.index)
 
-                neighbor_flux_matrix.append(aligned[flux_col].values)
-                neighbor_error_matrix.append(aligned[err_col].values)
+                flux_vals = pd.to_numeric(aligned[flux_col], errors="coerce").to_numpy()
+                err_vals = pd.to_numeric(aligned[err_col], errors="coerce").to_numpy()
+                # A neighbor with no finite flux or no finite error after
+                # alignment cannot contribute to the inverse-variance
+                # ensemble; counting it would return an all-NaN relative
+                # flux as success.
+                if not (np.isfinite(flux_vals).any() and np.isfinite(err_vals).any()):
+                    continue
+
+                neighbor_flux_matrix.append(flux_vals)
+                neighbor_error_matrix.append(err_vals)
                 valid_neighbor_ids.append(nid)
 
             except Exception as e:

--- a/dsa110_continuum/photometry/source.py
+++ b/dsa110_continuum/photometry/source.py
@@ -31,6 +31,7 @@ from dsa110_continuum.catalog.multiwavelength import (
 from dsa110_continuum.photometry.variability import (
     calculate_eta_metric,
     calculate_m_metric,
+    calculate_v_metric,
     calculate_vs_metric,
 )
 
@@ -153,14 +154,20 @@ class Source:
                 }
 
                 if "source_id" in columns:
-                    query = """
+                    normalized_select = (
+                        ", normalized_flux_jy, normalized_flux_err_jy"
+                        if {"normalized_flux_jy", "normalized_flux_err_jy"} <= columns
+                        else ""
+                    )
+                    query = f"""
                         SELECT
                             ra_deg, dec_deg, nvss_flux_mjy,
-                            peak_jyb, peak_err_jyb, measured_at, mjd, image_path
+                            peak_jyb, peak_err_jyb, measured_at, mjd,
+                            image_path{normalized_select}
                         FROM photometry
                         WHERE source_id = ? OR source_id LIKE ?
                         ORDER BY measured_at ASC
-                    """
+                    """  # nosec B608 - normalized_select is built from constants
                     df = pd.read_sql_query(
                         query, conn, params=(self.source_id, f"%{self.source_id}%")
                     )
@@ -171,10 +178,6 @@ class Source:
                             df["mjd"] = pd.to_datetime(
                                 df["measured_at"], unit="s", errors="coerce"
                             ).apply(lambda x: Time(x).mjd if pd.notna(x) else None)
-
-                    # Add normalized flux columns (will be NaN if not available)
-                    df["normalized_flux_jy"] = np.nan
-                    df["normalized_flux_err_jy"] = np.nan
                 else:
                     # No source_id column, can't query
                     df = pd.DataFrame()
@@ -209,6 +212,21 @@ class Source:
             conn.close()
             raise SourceError(f"Failed to load measurements for {self.source_id}: {e}") from e
 
+    def _flux_columns(self) -> tuple[str, str]:
+        """Select flux/error columns for downstream computations.
+
+        Normalized columns are used when the normalized flux carries at least
+        one finite value, otherwise the raw peak columns. A raw products DB
+        has no normalized photometry, so preferring the (NaN-filled)
+        normalized column unconditionally made every downstream computation
+        degenerate (issue #118).
+        """
+        if "normalized_flux_jy" in self.measurements.columns:
+            normalized = pd.to_numeric(self.measurements["normalized_flux_jy"], errors="coerce")
+            if np.isfinite(normalized).any():
+                return "normalized_flux_jy", "normalized_flux_err_jy"
+        return "peak_jyb", "peak_err_jyb"
+
     @property
     def coord(self) -> SkyCoord:
         """Source coordinates as SkyCoord object."""
@@ -235,16 +253,7 @@ class Source:
             return (self.measurements["snr"] > 5).sum()
 
         # Estimate from flux and error
-        flux_col = (
-            "normalized_flux_jy"
-            if "normalized_flux_jy" in self.measurements.columns
-            else "peak_jyb"
-        )
-        err_col = (
-            "normalized_flux_err_jy"
-            if "normalized_flux_err_jy" in self.measurements.columns
-            else "peak_err_jyb"
-        )
+        flux_col, err_col = self._flux_columns()
 
         if flux_col in self.measurements.columns and err_col in self.measurements.columns:
             flux = self.measurements[flux_col]
@@ -267,17 +276,8 @@ class Source:
                 "n_epochs": len(self.measurements),
             }
 
-        # Use normalized flux if available, otherwise peak flux
-        flux_col = (
-            "normalized_flux_jy"
-            if "normalized_flux_jy" in self.measurements.columns
-            else "peak_jyb"
-        )
-        err_col = (
-            "normalized_flux_err_jy"
-            if "normalized_flux_err_jy" in self.measurements.columns
-            else "peak_err_jyb"
-        )
+        # Use normalized flux when populated, otherwise peak flux
+        flux_col, err_col = self._flux_columns()
 
         if flux_col not in self.measurements.columns:
             raise SourceError(f"Flux column {flux_col} not found in measurements")
@@ -304,8 +304,9 @@ class Source:
         flux_valid = flux[valid_mask]
         flux_err_valid = flux_err[valid_mask] if flux_err is not None else None
 
-        # V metric (coefficient of variation)
-        v = float(np.std(flux_valid) / np.mean(flux_valid)) if np.mean(flux_valid) > 0 else 0.0
+        # V metric (coefficient of variation, canonical ddof=1 convention
+        # from photometry/metrics.py — consolidated in #118)
+        v = calculate_v_metric(flux_valid)
 
         # η metric (weighted variance)
         if flux_err_valid is not None and len(flux_valid) >= 2:
@@ -337,7 +338,7 @@ class Source:
 
         return {
             "v": v,
-            "eta": float(eta),
+            "eta": float(eta) if eta is not None else None,
             "vs_mean": float(np.mean(vs_metrics)) if vs_metrics else None,
             "m_mean": float(np.mean(m_metrics)) if m_metrics else None,
             "n_epochs": len(self.measurements),
@@ -374,10 +375,7 @@ class Source:
         if self.measurements.empty:
             return []
 
-        flux_col = "peak_jyb"
-        has_normalized = "normalized_flux_jy" in self.measurements.columns
-        if has_normalized:
-            flux_col = "normalized_flux_jy"
+        flux_col, _ = self._flux_columns()
         target_flux = self.measurements[flux_col].median()
         if np.isnan(target_flux):
             return []
@@ -454,13 +452,18 @@ class Source:
             ra_degs = df["ra_deg"].to_numpy()
             dec_degs = df["dec_deg"].to_numpy()
 
-            # 1. Vectorized distance check
-            cos_dec = np.cos(np.deg2rad(self.dec_deg))
-            dists_sq = (
-                ((ra_degs - self.ra_deg) * cos_dec) ** 2
-                + (dec_degs - self.dec_deg) ** 2
+            # 1. Vectorized exact angular separation (haversine). The planar
+            # small-angle approximation rejected genuinely-close candidates
+            # across the 0/360 RA boundary and near the poles (issue #118).
+            dec1 = np.deg2rad(self.dec_deg)
+            dec2 = np.deg2rad(dec_degs)
+            d_ra = np.deg2rad(ra_degs - self.ra_deg)
+            hav = (
+                np.sin((dec2 - dec1) / 2.0) ** 2
+                + np.cos(dec1) * np.cos(dec2) * np.sin(d_ra / 2.0) ** 2
             )
-            dist_mask = dists_sq <= radius_deg**2
+            seps_deg = np.rad2deg(2.0 * np.arcsin(np.sqrt(np.clip(hav, 0.0, 1.0))))
+            dist_mask = seps_deg <= radius_deg
 
             # 2. Vectorized flux ratio check
             flux_ratios = df["mean_flux_mjy"].to_numpy() / target_flux_mjy
@@ -531,13 +534,18 @@ class Source:
         if self.measurements.empty:
             return {}
 
+        # Target and neighbors use the same flux/error columns: normalized
+        # when populated, raw peak otherwise (mixing normalizations across
+        # the ensemble would bias the relative flux).
+        flux_col, err_col = self._flux_columns()
+
         # Ensure required columns exist
-        required_cols = ["image_path", "mjd", "normalized_flux_jy"]
+        required_cols = ["image_path", "mjd", flux_col]
         if not all(col in self.measurements.columns for col in required_cols):
             logger.warning(f"Missing required columns for relative photometry: {required_cols}")
             return {}
 
-        target_epochs = self.measurements[["image_path", "mjd", "normalized_flux_jy"]].copy()
+        target_epochs = self.measurements[["image_path", "mjd", flux_col]].copy()
         target_epochs = target_epochs.set_index("image_path")
 
         neighbor_flux_matrix = []
@@ -554,15 +562,13 @@ class Source:
 
                 # Align with target
                 # Join on image_path
-                n_data = n_meas[
-                    ["image_path", "normalized_flux_jy", "normalized_flux_err_jy"]
-                ].set_index("image_path")
+                n_data = n_meas[["image_path", flux_col, err_col]].set_index("image_path")
 
                 # Reindex to target epochs (puts NaNs where missing)
                 aligned = n_data.reindex(target_epochs.index)
 
-                neighbor_flux_matrix.append(aligned["normalized_flux_jy"].values)
-                neighbor_error_matrix.append(aligned["normalized_flux_err_jy"].values)
+                neighbor_flux_matrix.append(aligned[flux_col].values)
+                neighbor_error_matrix.append(aligned[err_col].values)
                 valid_neighbor_ids.append(nid)
 
             except Exception as e:
@@ -583,7 +589,7 @@ class Source:
 
         # 3. Calculate Relative Flux
         rel_flux, mean_val, std_val = calculate_relative_flux(
-            target_fluxes=target_epochs["normalized_flux_jy"].values,
+            target_fluxes=target_epochs[flux_col].values,
             neighbor_fluxes=neighbor_fluxes,
             neighbor_errors=neighbor_errors,
             use_robust_stats=True,

--- a/tests/test_batch_e2_hygiene.py
+++ b/tests/test_batch_e2_hygiene.py
@@ -110,7 +110,14 @@ def test_forced_convolve_works_without_dsa110_contimg():
                 any(name.startswith(p) for p in evict_prefixes)
                 and name not in saved_modules
             ):
-                del sys.modules[name]
+                stale = sys.modules.pop(name)
+                # Also unbind the stale module from its parent package, or a
+                # never-previously-imported subtree would leave the fresh
+                # module reachable by attribute traversal.
+                parent, _, child = name.rpartition(".")
+                parent_mod = sys.modules.get(parent)
+                if parent_mod is not None and getattr(parent_mod, child, None) is stale:
+                    delattr(parent_mod, child)
         for name, mod in saved_modules.items():
             sys.modules[name] = mod
             parent, _, child = name.rpartition(".")

--- a/tests/test_batch_e2_hygiene.py
+++ b/tests/test_batch_e2_hygiene.py
@@ -97,15 +97,25 @@ def test_forced_convolve_works_without_dsa110_contimg():
         flux, flux_err, chisq = forced_mod._weighted_convolution(data, noise, kernel)
         assert np.isfinite(flux) and np.isfinite(flux_err) and np.isfinite(chisq)
     finally:
-        # Restore meta_path exactly + drop the polluted forced module so the
-        # next test that imports it gets the normal (non-fallback) version.
+        # Restore meta_path exactly, drop every module created under the
+        # blocker, and put the ORIGINAL module objects back — including the
+        # parent-package attributes: the fresh import rebinds `photometry` as
+        # an attribute of the (never-evicted) `dsa110_continuum` package, and
+        # string-target monkeypatch resolution in later tests traverses
+        # attributes, so a leaked fresh package would make them patch the
+        # wrong namespace (surfaced by test_relative_photometry's eta test).
         sys.meta_path[:] = saved_meta_path
         for name in list(sys.modules):
-            if (name.startswith("dsa110_contimg")
-                    or name.startswith("dsa110_continuum.photometry.forced")):
+            if (
+                any(name.startswith(p) for p in evict_prefixes)
+                and name not in saved_modules
+            ):
                 del sys.modules[name]
         for name, mod in saved_modules.items():
             sys.modules[name] = mod
+            parent, _, child = name.rpartition(".")
+            if parent and parent in sys.modules:
+                setattr(sys.modules[parent], child, mod)
 
 
 # ─── B1: no double-nesting of date directory ────────────────────────────────

--- a/tests/test_metrics_canonical.py
+++ b/tests/test_metrics_canonical.py
@@ -210,12 +210,17 @@ class TestSourceModuleMetricImports:
 
     def test_import_failure_propagates_instead_of_stubbing(self, monkeypatch):
         monkeypatch.setitem(sys.modules, "dsa110_continuum.catalog.multiwavelength", None)
-        sys.modules.pop("dsa110_continuum.photometry.source", None)
+        # Restore the ORIGINAL module object afterwards: leaving sys.modules
+        # empty makes later imports create a fresh module, so tests that bound
+        # Source at collection time would monkeypatch a stale namespace.
+        original = sys.modules.pop("dsa110_continuum.photometry.source", None)
         try:
             with pytest.raises(ImportError):
                 importlib.import_module("dsa110_continuum.photometry.source")
         finally:
             sys.modules.pop("dsa110_continuum.photometry.source", None)
+            if original is not None:
+                sys.modules["dsa110_continuum.photometry.source"] = original
 
     def test_source_metrics_are_the_variability_implementations(self):
         psource = importlib.import_module("dsa110_continuum.photometry.source")

--- a/tests/test_relative_photometry.py
+++ b/tests/test_relative_photometry.py
@@ -23,12 +23,22 @@ Correctness criteria (hardening-research-code):
    Mooley et al. (2016) closed forms: eta = reduced chi-squared about the
    weighted mean (pinned canonically in tests/test_metrics_canonical.py),
    Vs = (f_a - f_b)/sqrt(e_a^2 + e_b^2), m = 2(f_a - f_b)/(f_a + f_b) over
-   sequential epoch pairs. CAUTION: the v value pins the CURRENT inline
-   computation in source.py (np.std default, ddof=0), which diverges from the
-   repo's canonical ddof=1 convention (test_metrics_canonical.py
-   TestVMetricConvention, aligned to VAST in #110). When source.py is
-   consolidated onto the canonical v, update that one expected value to
-   std(f, ddof=1)/mean(f) — for f=[1,2,3] that is 0.5, not sqrt(2/3)/2.
+   sequential epoch pairs, and v = std(f, ddof=1)/mean(f) via the canonical
+   photometry/metrics.py implementation (test_metrics_canonical.py
+   TestVMetricConvention, aligned to VAST in #110; source.py consolidated
+   onto it in #118 — for f=[1,2,3] that is 0.5). When eta cannot be computed
+   the metric is None, never a float coercion of None (issue #118 item 2).
+5. Flux-column selection — normalized_flux_jy/normalized_flux_err_jy are used
+   when the normalized column carries at least one finite value; otherwise
+   peak_jyb/peak_err_jyb are used. This makes the relative-photometry path
+   reachable from a raw products DB (issue #118 item 1). MJD recovery is
+   analytic: the Unix epoch 1970-01-01T00:00 UTC is MJD 40587.0 exactly and
+   both scales count 86400 s civil days (Unix time excludes leap seconds), so
+   a row with mjd NULL and measured_at = t seconds loads as mjd = 40587 + t/86400.
+6. Neighbor-search geometry — candidate distance uses the exact spherical
+   (haversine) separation, so a neighbor within radius_deg is selected
+   regardless of RA wrap at 0/360 or proximity to the pole; expected
+   separations below are derived from the haversine closed form in each test.
 
 Tolerances: every expected value is exact in a handful of double-precision
 operations, so assert_allclose(rtol=1e-12) covers accumulated rounding (~10 eps)
@@ -345,6 +355,57 @@ class TestCalculateRelativeLightcurveAssembly:
         target = make_source(frames, neighbor_ids=["N1"])
         assert target.calculate_relative_lightcurve() == {}
 
+    def test_max_neighbors_truncates_neighbor_list(self, make_source):
+        """With max_neighbors=2 only the first two ids are used: A over N1, N2
+        is [2, 3, 4.5] -> R = [1, 2, 2] (same derivation as the happy path).
+        If N3 (100x brighter) leaked past the truncation, three valid
+        neighbors would also engage the weighted median and change every
+        epoch's ensemble average."""
+        frames = {
+            "T": _measurements_frame(EPOCHS, MJDS, [2.0, 6.0, 9.0], [0.1, 0.1, 0.1]),
+            "N1": _measurements_frame(EPOCHS, MJDS, [1.0, 2.0, 3.0], [1.0, 1.0, 1.0]),
+            "N2": _measurements_frame(EPOCHS, MJDS, [3.0, 4.0, 6.0], [1.0, 1.0, 1.0]),
+            "N3": _measurements_frame(EPOCHS, MJDS, [100.0, 100.0, 100.0], [1.0, 1.0, 1.0]),
+        }
+        target = make_source(frames, neighbor_ids=["N1", "N2", "N3"])
+
+        result = target.calculate_relative_lightcurve(max_neighbors=2)
+
+        assert result["neighbor_ids"] == ["N1", "N2"]
+        assert result["n_neighbors"] == 2
+        assert_allclose(result["relative_flux"], [1.0, 2.0, 2.0], rtol=1e-12)
+
+
+class TestRawDbEndToEnd:
+    """Issue #118 item 1: the full path DB -> stable neighbors -> relative
+    flux must run on a raw products DB (peak fluxes only, nothing
+    pre-normalized)."""
+
+    def test_relative_lightcurve_from_raw_products_db(self, tmp_path):
+        """T0 peak fluxes [0.4, 0.6] (median 0.5 Jy -> 500 mJy); single
+        neighbor GOOD with constant peak 0.2 at (180.1, 16.15), separation
+        ~0.11 deg, flux ratio 0.4 — passes every filter. One neighbor makes
+        the ensemble average the neighbor itself: R = [2, 3], mean 2.5,
+        std(ddof=0) = 0.5."""
+        rows = [
+            ("T0", 180.0, 16.1, 500.0, 0.4, 0.01, 1.7e9, 60000.0, "e1.fits"),
+            ("T0", 180.0, 16.1, 500.0, 0.6, 0.01, 1.7e9 + 3600, 60000.042, "e2.fits"),
+            ("GOOD", 180.1, 16.15, 200.0, 0.2, 0.02, 1.7e9, 60000.0, "e1.fits"),
+            ("GOOD", 180.1, 16.15, 200.0, 0.2, 0.02, 1.7e9 + 3600, 60000.042, "e2.fits"),
+        ]
+        stats = [("GOOD", 180.1, 16.15, 200.0, 0.5, 20)]
+        db = _make_products_db(tmp_path / "products.sqlite3", rows, stats)
+        src = Source("T0", products_db=db)
+
+        result = src.calculate_relative_lightcurve()
+
+        assert result["neighbor_ids"] == ["GOOD"]
+        assert result["n_neighbors"] == 1
+        assert_allclose(result["relative_flux"], [2.0, 3.0], rtol=1e-12)
+        assert_allclose(result["relative_flux_mean"], 2.5, rtol=1e-12)
+        assert_allclose(result["relative_flux_std"], 0.5, rtol=1e-12)
+        assert_allclose(result["mjds"], [60000.0, 60000.042], rtol=1e-12)
+
 
 class TestCalcVariabilityMetrics:
     """Criterion 4: metric wiring reproduces the Mooley et al. closed forms."""
@@ -352,8 +413,7 @@ class TestCalcVariabilityMetrics:
     def test_metrics_match_hand_derivation(self, make_source):
         """f = [1, 2, 3], e = 0.1 everywhere:
 
-        v  = std(f, ddof=0)/mean(f) = sqrt(2/3)/2 — pins the current inline
-             ddof=0 computation, which DIVERGES from the canonical ddof=1
+        v  = std(f, ddof=1)/mean(f) = 1/2 — the canonical VAST/ddof=1
              convention (see module docstring, criterion 4)
         eta = reduced chi-squared about the weighted mean (= 2):
               ((-1)^2 + 0 + 1^2)/0.01 / (N-1) = 200/2 = 100
@@ -365,7 +425,7 @@ class TestCalcVariabilityMetrics:
 
         metrics = src.calc_variability_metrics()
 
-        assert_allclose(metrics["v"], np.sqrt(2.0 / 3.0) / 2.0, rtol=1e-12)
+        assert_allclose(metrics["v"], 0.5, rtol=1e-12)
         assert_allclose(metrics["eta"], 100.0, rtol=1e-12)
         assert_allclose(metrics["vs_mean"], -1.0 / np.sqrt(0.02), rtol=1e-12)
         assert_allclose(metrics["m_mean"], -8.0 / 15.0, rtol=1e-12)
@@ -382,16 +442,40 @@ class TestCalcVariabilityMetrics:
             "n_epochs": 1,
         }
 
+    def test_eta_is_none_when_eta_calculation_fails(self, make_source, monkeypatch, caplog):
+        """The eta failure branch deliberately reports None (not 0.0) so an
+        uncomputable source is never labeled stable; the other metrics must
+        still come back. Pre-#118 this branch raised TypeError on float(None)."""
+        frames = {"T": _measurements_frame(EPOCHS, MJDS, [1.0, 2.0, 3.0], [0.1, 0.1, 0.1])}
+        src = make_source(frames)
 
-def _make_products_db(path, photometry_rows, stats_rows=()):
+        def boom(*args, **kwargs):
+            raise ValueError("synthetic eta failure")
+
+        monkeypatch.setattr("dsa110_continuum.photometry.source.calculate_eta_metric", boom)
+
+        with caplog.at_level(logging.WARNING):
+            metrics = src.calc_variability_metrics()
+
+        assert metrics["eta"] is None
+        assert_allclose(metrics["v"], 0.5, rtol=1e-12)
+        assert_allclose(metrics["vs_mean"], -1.0 / np.sqrt(0.02), rtol=1e-12)
+        assert "Failed to calculate" in caplog.text
+
+
+def _make_products_db(path, photometry_rows, stats_rows=(), with_normalized=False):
     conn = sqlite3.connect(str(path))
+    normalized_cols = (
+        ", normalized_flux_jy REAL, normalized_flux_err_jy REAL" if with_normalized else ""
+    )
     conn.execute(
-        """CREATE TABLE photometry (
+        f"""CREATE TABLE photometry (
             source_id TEXT, ra_deg REAL, dec_deg REAL, nvss_flux_mjy REAL,
             peak_jyb REAL, peak_err_jyb REAL, measured_at REAL, mjd REAL,
-            image_path TEXT)"""
+            image_path TEXT{normalized_cols})"""
     )
-    conn.executemany("INSERT INTO photometry VALUES (?,?,?,?,?,?,?,?,?)", photometry_rows)
+    placeholders = ",".join("?" * (11 if with_normalized else 9))
+    conn.executemany(f"INSERT INTO photometry VALUES ({placeholders})", photometry_rows)
     if stats_rows:
         conn.execute(
             """CREATE TABLE variability_stats (
@@ -424,9 +508,77 @@ class TestLoadMeasurements:
         assert src.dec_deg == 16.1
         assert list(src.measurements["image_path"]) == ["e1.fits", "e2.fits"]
         assert_allclose(src.measurements["peak_jyb"], [0.5, 0.6], rtol=1e-12)
-        # The loader does not populate normalized fluxes from the photometry
-        # table; the columns exist but are NaN until a caller normalizes.
+        # This table has no normalized columns, so the loader NaN-fills them;
+        # downstream column selection falls back to peak_jyb (criterion 5).
         assert src.measurements["normalized_flux_jy"].isna().all()
+
+    def test_loads_normalized_columns_when_present_in_db(self, tmp_path):
+        """A products DB whose photometry table carries normalized columns
+        must surface their values (pre-#118 the loader NaN-filled them
+        unconditionally, so no DB could ever feed the normalized path)."""
+        db = _make_products_db(
+            tmp_path / "products.sqlite3",
+            [
+                ("SRC1", 180.0, 16.1, 500.0, 0.5, 0.01, 1.7e9, 60000.0, "e1.fits", 0.45, 0.02),
+                (
+                    "SRC1",
+                    180.0,
+                    16.1,
+                    500.0,
+                    0.6,
+                    0.01,
+                    1.7e9 + 3600,
+                    60000.042,
+                    "e2.fits",
+                    0.55,
+                    0.03,
+                ),
+            ],
+            with_normalized=True,
+        )
+        src = Source("SRC1", products_db=db)
+
+        assert_allclose(src.measurements["normalized_flux_jy"], [0.45, 0.55], rtol=1e-12)
+        assert_allclose(src.measurements["normalized_flux_err_jy"], [0.02, 0.03], rtol=1e-12)
+
+    def test_mjd_recomputed_from_measured_at_when_all_null(self, tmp_path):
+        """mjd = 40587 + measured_at/86400 exactly (module docstring,
+        criterion 5: Unix epoch = MJD 40587.0, shared 86400 s civil days)."""
+        t0 = 1.7e9
+        db = _make_products_db(
+            tmp_path / "products.sqlite3",
+            [
+                ("SRC1", 180.0, 16.1, 500.0, 0.5, 0.01, t0, None, "e1.fits"),
+                ("SRC1", 180.0, 16.1, 500.0, 0.6, 0.01, t0 + 3600, None, "e2.fits"),
+            ],
+        )
+        src = Source("SRC1", products_db=db)
+
+        expected = [40587.0 + t0 / 86400.0, 40587.0 + (t0 + 3600.0) / 86400.0]
+        assert_allclose(src.measurements["mjd"].astype(float), expected, rtol=1e-12)
+
+    def test_photometry_table_without_source_id_yields_empty(self, tmp_path):
+        """A schema without source_id cannot be queried per-source; the loader
+        returns no measurements rather than guessing (coords supplied so the
+        constructor does not raise)."""
+        db = tmp_path / "products.sqlite3"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE photometry (ra_deg REAL, dec_deg REAL, peak_jyb REAL)")
+        conn.commit()
+        conn.close()
+
+        src = Source("SRC1", ra_deg=180.0, dec_deg=16.1, products_db=db)
+        assert src.measurements.empty
+
+    def test_missing_photometry_table_yields_empty(self, tmp_path):
+        db = tmp_path / "products.sqlite3"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE unrelated (x REAL)")
+        conn.commit()
+        conn.close()
+
+        src = Source("SRC1", ra_deg=180.0, dec_deg=16.1, products_db=db)
+        assert src.measurements.empty
 
     def test_missing_db_raises(self, tmp_path):
         with pytest.raises(SourceError, match="not found"):
@@ -466,20 +618,61 @@ class TestFindStableNeighbors:
 
     def test_selects_only_stable_similar_flux_neighbors_within_radius(self, tmp_path):
         src = self._target(tmp_path)
-        # The loader leaves normalized_flux_jy NaN; populate it the way the
-        # normalization step would before neighbor selection.
+        # Populate normalized flux the way the normalization step would;
+        # selection then prefers the normalized column (criterion 5).
         src.measurements["normalized_flux_jy"] = src.measurements["peak_jyb"]
         assert src.find_stable_neighbors() == ["GOOD"]
 
-    def test_returns_empty_when_target_flux_unknown(self, tmp_path):
-        """With normalized_flux_jy all-NaN the flux-ratio filter is undefined,
-        so neighbor selection refuses to guess and returns no neighbors.
-
-        Pins CURRENT behavior, not a requirement: the loader NaN-fills
-        normalized_flux_jy unconditionally (source.py, _load_measurements) and
-        find_stable_neighbors prefers that column over the populated peak_jyb,
-        so the DB path can never select neighbors without a caller-side
-        normalization step. A legitimate fall-back-to-peak fix may change this
-        expectation — see the latent-issue notes in PR #113."""
+    def test_falls_back_to_peak_flux_when_normalized_all_nan(self, tmp_path):
+        """A raw products DB has no normalized columns, so the loader NaN-fills
+        them; neighbor selection must fall back to the populated peak_jyb
+        (median 0.5 Jy -> 500 mJy target flux) instead of refusing with an
+        undefined flux-ratio filter. Pre-#118 this returned [] and made
+        relative photometry unreachable from a raw DB (issue #118 item 1)."""
         src = self._target(tmp_path)
-        assert src.find_stable_neighbors() == []
+        assert src.measurements["normalized_flux_jy"].isna().all()
+        assert src.find_stable_neighbors() == ["GOOD"]
+
+    def test_ra_wrap_neighbor_across_zero_meridian(self, tmp_path):
+        """Target at RA 0.2 deg: the RA box (half-width 0.5/cos(16.1) ~ 0.52)
+        wraps below 0, so the SQL clause becomes (ra >= 359.68 OR ra <= 0.72).
+        WRAP at RA 359.9 is dRA = 0.3 deg away — haversine separation
+        0.3*cos(16.1) ~ 0.288 deg < 0.5 — and must be selected. NOWRAP at
+        RA 5.0 (~4.6 deg away) stays excluded by the SQL box. Pre-#118 the
+        planar post-filter computed |359.9 - 0.2| = 359.7 deg and rejected
+        every wrapped candidate the SQL clause had correctly found
+        (criterion 6)."""
+        rows = [
+            ("T0", 0.2, 16.1, 500.0, 0.5, 0.01, 1.7e9, 60000.0, "e1.fits"),
+            ("T0", 0.2, 16.1, 500.0, 0.5, 0.01, 1.7e9 + 3600, 60000.042, "e2.fits"),
+        ]
+        stats = [
+            ("WRAP", 359.9, 16.1, 400.0, 0.5, 20),
+            ("NOWRAP", 5.0, 16.1, 400.0, 0.5, 20),
+        ]
+        db = _make_products_db(tmp_path / "products.sqlite3", rows, stats)
+        src = Source("T0", products_db=db)
+
+        assert src.find_stable_neighbors() == ["WRAP"]
+
+    def test_pole_search_finds_neighbor_across_ra(self, tmp_path):
+        """Target at dec 89.7 (colatitude 0.3 deg) triggers the all-RA pole
+        branch. POLE at the antipodal RA, dec 89.9 (colatitude 0.1) sits on
+        the same great circle through the pole: separation 0.3 + 0.1 = 0.4 deg
+        < 0.5, so it must be selected. POLEFAR at RA+90, dec 89.25 has
+        small-angle separation sqrt(0.3^2 + 0.75^2) ~ 0.808 deg > 0.5 and is
+        excluded by the post-filter even though it passes the all-RA box.
+        Pre-#118 the planar post-filter rejected POLE — its RA term alone,
+        (180*cos 89.7)^2, exceeds radius^2 (criterion 6)."""
+        rows = [
+            ("T0", 180.0, 89.7, 500.0, 0.5, 0.01, 1.7e9, 60000.0, "e1.fits"),
+            ("T0", 180.0, 89.7, 500.0, 0.5, 0.01, 1.7e9 + 3600, 60000.042, "e2.fits"),
+        ]
+        stats = [
+            ("POLE", 0.0, 89.9, 400.0, 0.5, 20),
+            ("POLEFAR", 270.0, 89.25, 400.0, 0.5, 20),
+        ]
+        db = _make_products_db(tmp_path / "products.sqlite3", rows, stats)
+        src = Source("T0", products_db=db)
+
+        assert src.find_stable_neighbors() == ["POLE"]

--- a/tests/test_relative_photometry.py
+++ b/tests/test_relative_photometry.py
@@ -376,6 +376,123 @@ class TestCalculateRelativeLightcurveAssembly:
         assert_allclose(result["relative_flux"], [1.0, 2.0, 2.0], rtol=1e-12)
 
 
+class TestNullColumnRobustness:
+    """All-NULL SQLite REAL columns arrive from pandas as object-dtype None
+    arrays (findings of the #124 adversarial review). The loader must coerce
+    every flux/err column to float, normalized columns are selected only when
+    flux AND error carry finite values, and neighbors with no usable flux or
+    error are skipped instead of crashing or silently producing all-NaN
+    relative fluxes. Partially normalized tables are an expected mid-pipeline
+    state (photometry/normalize.py filters WHERE normalized_flux_jy IS NOT
+    NULL), so these are realistic DB states, not corruption."""
+
+    def test_all_null_columns_load_as_float(self, tmp_path):
+        db = _make_products_db(
+            tmp_path / "products.sqlite3",
+            [
+                ("SRC1", 180.0, 16.1, 500.0, 0.5, None, 1.7e9, 60000.0, "e1.fits", None, None),
+                (
+                    "SRC1",
+                    180.0,
+                    16.1,
+                    500.0,
+                    0.6,
+                    None,
+                    1.7e9 + 3600,
+                    60000.042,
+                    "e2.fits",
+                    None,
+                    None,
+                ),
+            ],
+            with_normalized=True,
+        )
+        src = Source("SRC1", products_db=db)
+        for col in (
+            "peak_jyb",
+            "peak_err_jyb",
+            "normalized_flux_jy",
+            "normalized_flux_err_jy",
+        ):
+            assert src.measurements[col].dtype == np.float64, col
+
+    def test_neighbor_with_all_null_normalized_is_skipped(self, tmp_path):
+        """Target fully normalized; the only selected neighbor has NULL
+        normalized columns. No usable neighbor remains, so the result is {}
+        (pre-fix: TypeError from None**2 on the object-dtype error matrix,
+        uncaught because it fires after the per-neighbor try/except)."""
+        rows = [
+            ("T0", 180.0, 16.1, 500.0, 0.4, 0.01, 1.7e9, 60000.0, "e1.fits", 0.4, 0.01),
+            (
+                "T0",
+                180.0,
+                16.1,
+                500.0,
+                0.6,
+                0.01,
+                1.7e9 + 3600,
+                60000.042,
+                "e2.fits",
+                0.6,
+                0.01,
+            ),
+            ("GOOD", 180.1, 16.15, 200.0, 0.2, 0.02, 1.7e9, 60000.0, "e1.fits", None, None),
+            (
+                "GOOD",
+                180.1,
+                16.15,
+                200.0,
+                0.2,
+                0.02,
+                1.7e9 + 3600,
+                60000.042,
+                "e2.fits",
+                None,
+                None,
+            ),
+        ]
+        stats = [("GOOD", 180.1, 16.15, 200.0, 0.5, 20)]
+        db = _make_products_db(tmp_path / "products.sqlite3", rows, stats, with_normalized=True)
+        src = Source("T0", products_db=db)
+
+        assert src.calculate_relative_lightcurve() == {}
+
+    def test_target_normalized_err_all_null_falls_back_to_peak(self, tmp_path):
+        """normalized_flux_jy populated but normalized_flux_err_jy all NULL:
+        weighted metrics are impossible in the normalized system, so column
+        selection falls back to peak — v = 0.5 and eta = 100 from the peak
+        f=[1,2,3], e=0.1 derivation (criterion 4). Pre-fix: TypeError from
+        np.isfinite on the object-dtype error column."""
+        rows = [
+            ("SRC1", 180.0, 16.1, 500.0, 1.0, 0.1, 1.7e9, 60000.0, "e1.fits", 1.0, None),
+            ("SRC1", 180.0, 16.1, 500.0, 2.0, 0.1, 1.7e9 + 3600, 60000.042, "e2.fits", 2.0, None),
+            ("SRC1", 180.0, 16.1, 500.0, 3.0, 0.1, 1.7e9 + 7200, 60000.083, "e3.fits", 3.0, None),
+        ]
+        db = _make_products_db(tmp_path / "products.sqlite3", rows, with_normalized=True)
+        src = Source("SRC1", products_db=db)
+
+        metrics = src.calc_variability_metrics()
+
+        assert_allclose(metrics["v"], 0.5, rtol=1e-12)
+        assert_allclose(metrics["eta"], 100.0, rtol=1e-12)
+
+    def test_raw_db_neighbor_with_null_errors_is_skipped(self, tmp_path):
+        """Raw DB: the neighbor's peak_err_jyb is all NULL, so inverse-
+        variance weighting cannot use it; the neighbor is skipped and with no
+        usable neighbor left the result is {} (pre-fix: TypeError None**2)."""
+        rows = [
+            ("T0", 180.0, 16.1, 500.0, 0.4, 0.01, 1.7e9, 60000.0, "e1.fits"),
+            ("T0", 180.0, 16.1, 500.0, 0.6, 0.01, 1.7e9 + 3600, 60000.042, "e2.fits"),
+            ("GOOD", 180.1, 16.15, 200.0, 0.2, None, 1.7e9, 60000.0, "e1.fits"),
+            ("GOOD", 180.1, 16.15, 200.0, 0.2, None, 1.7e9 + 3600, 60000.042, "e2.fits"),
+        ]
+        stats = [("GOOD", 180.1, 16.15, 200.0, 0.5, 20)]
+        db = _make_products_db(tmp_path / "products.sqlite3", rows, stats)
+        src = Source("T0", products_db=db)
+
+        assert src.calculate_relative_lightcurve() == {}
+
+
 class TestRawDbEndToEnd:
     """Issue #118 item 1: the full path DB -> stable neighbors -> relative
     flux must run on a raw products DB (peak fluxes only, nothing

--- a/tests/test_relative_photometry.py
+++ b/tests/test_relative_photometry.py
@@ -29,9 +29,12 @@ Correctness criteria (hardening-research-code):
    onto it in #118 — for f=[1,2,3] that is 0.5). When eta cannot be computed
    the metric is None, never a float coercion of None (issue #118 item 2).
 5. Flux-column selection — normalized_flux_jy/normalized_flux_err_jy are used
-   when the normalized column carries at least one finite value; otherwise
-   peak_jyb/peak_err_jyb are used. This makes the relative-photometry path
-   reachable from a raw products DB (issue #118 item 1). MJD recovery is
+   when BOTH carry at least one finite value (weighted metrics need errors);
+   otherwise peak_jyb/peak_err_jyb are used. This makes the relative-photometry
+   path reachable from a raw products DB (issue #118 item 1). All flux/error
+   columns are coerced to float on load (all-NULL SQLite columns otherwise
+   arrive object-dtype) and neighbors with no finite flux or error after
+   alignment are skipped. MJD recovery is
    analytic: the Unix epoch 1970-01-01T00:00 UTC is MJD 40587.0 exactly and
    both scales count 86400 s civil days (Unix time excludes leap seconds), so
    a row with mjd NULL and measured_at = t seconds loads as mjd = 40587 + t/86400.


### PR DESCRIPTION
Closes #118. All four items from the #113 review follow-ups, red-first, plus fixes for every confirmed finding of an independent adversarial review.

## Changes

1. **Relative photometry reachable from a raw products DB** (item 1):
   - `_load_measurements` now selects `normalized_flux_jy`/`normalized_flux_err_jy` when the photometry table has them (previously NaN-filled unconditionally, so no DB could ever feed the normalized path), and coerces every flux/error column to float (all-NULL SQLite columns otherwise arrive object-dtype).
   - New `Source._flux_columns()`: normalized columns only when flux AND error carry ≥1 finite value (weighted metrics are impossible without errors), else `peak_jyb`/`peak_err_jyb`. Wired into `detections`, `calc_variability_metrics`, `find_stable_neighbors`, `calculate_relative_lightcurve`. Target and neighbors use the same columns (mixing normalizations would bias the ensemble); a partially normalized target keeps honest NaN gaps.
   - Neighbors with no finite flux or error after epoch alignment are skipped instead of crashing or contributing an all-NaN column counted as success.
   - Flipped test: `test_returns_empty_when_target_flux_unknown` → `test_falls_back_to_peak_flux_when_normalized_all_nan`; new end-to-end raw-DB test with analytic expectation.
2. **`eta` failure branch** (item 2): returns `None` as the code comment documents instead of `float(None)` TypeError. No production consumer reads this `eta`; the repo's other eta consumers None-guard (verified by the reviewer).
3. **v metric consolidation** (item 3): `calc_variability_metrics` uses `photometry/metrics.py::calculate_v_metric` (ddof=1, VAST convention) via the `variability.py` delegate. Pinned value flips `sqrt(2/3)/2` → `0.5` exactly as the #113 module docstring said it should. Note: the canonical implementation returns a negative v for a negative-mean flux series where the old inline guard returned 0.0 — no repo consumer reads this v; documented here per review NIT.
4. **Untested branches** (item 4): mjd-recompute-from-`measured_at` (analytic: Unix epoch = MJD 40587.0), no-`source_id`-column, missing-`photometry`-table, `max_neighbors` truncation, RA-wrap and pole branches.

## Found while testing item 4

The RA-wrap SQL clause was **dead in practice**: the planar post-filter computed `|359.9 − 0.2| = 359.7 deg` and rejected every wrapped candidate the SQL had correctly found; near-pole cross-RA neighbors were likewise rejected. Replaced the planar distance with the exact haversine separation (vectorized numpy; reviewer-verified to 5.7e-13 deg against `astropy` over 2006 pairs including wrap/pole/antipodes). At the operational Dec ~16° strip with radius 0.5° the numerical difference vs planar is negligible; wrap/pole cases become correct.

## Two test-pollution fixes (f798923, a02bbef)

The new eta-failure test passed alone but failed in full-suite order — twice, with two independent polluters, same mechanism (string-target monkeypatch patching a different `photometry.source` namespace than the one collection-time imports bound):

- `test_metrics_canonical.py::test_import_failure_propagates_instead_of_stubbing` popped `dsa110_continuum.photometry.source` from `sys.modules` without restoring the original module object.
- `test_batch_e2_hygiene.py::test_forced_convolve_works_without_dsa110_contimg` evicts the `photometry` subtree and re-imports it under a blocker; its `finally` restored `sys.modules` but left the fresh package bound as the `photometry` **attribute** of `dsa110_continuum` — and pytest's string-target monkeypatch resolves by attribute traversal. Now re-binds parent-package attributes, drops every blocker-era module, and unbinds stale modules from parent packages (review NIT).

## Adversarial review (independent subagent, all findings verified by execution)

- **MUST-FIX (confirmed, fixed in 69f592f):** the branch's new code paths crashed with `TypeError` on all-NULL flux/error columns — a realistic mid-pipeline state (`normalize.py` filters `WHERE normalized_flux_jy IS NOT NULL`) and a regression vs main's early-bailout behavior. Three reproduced crash cases now covered by `TestNullColumnRobustness` (all four tests seen red pre-fix).
- **SHOULD-FIX (confirmed, fixed in 69f592f):** an all-NaN neighbor was counted in `n_neighbors` and returned an all-NaN relative flux as success — now skipped.
- **NITs:** negative-mean v semantics (documented above); hygiene-test attribute leak for never-imported subtrees (fixed in 69f592f).
- Cleared by execution: haversine vs astropy, SQL interpolation safety, eta=None propagation, ddof-flip blast radius, both pollution fixes' restoration invariants (identity checks, both orderings), all new analytic expectations.

## Verification

- Red-first: 7 behavior-change tests + 4 review-finding tests seen red pre-fix; 4 born-green branch tests each seen red under a targeted mutation (unit s→ms, branch→raise ×2, truncation dropped).
- Full suite on the exact final tree: **1497 passed, 3 skipped, 0 failed** (`--ignore=tests/test_mosaic_ra_wrap.py`, pre-existing collection break).
- Cloud CI (cloud-safe subset): green on every push.
- `ruff check` clean on all touched files; `ruff format --check` clean on `test_relative_photometry.py`/`test_metrics_canonical.py` (`source.py` and `test_batch_e2_hygiene.py` have pre-existing format drift on main, left alone per repo policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016C8W9yKc79hxNmzLn8FvRF
