### PR TITLE
Per-artifact in-flight job state (#57)

### DIFF
--- a/docs/rse/specs/plan-phase-b-job-state-monitor-retirement-2026-07-15.md
+++ b/docs/rse/specs/plan-phase-b-job-state-monitor-retirement-2026-07-15.md
@@ -1,0 +1,134 @@
+# Implementation Plan: Phase B — per-artifact in-flight job state (#57) + monitor_server retirement (#62, closes #49)
+
+---
+**Date:** 2026-07-15
+**Author:** AI Assistant
+**Status:** Draft (authored autonomously; deviations flagged on issues at close-out)
+**Related Documents:**
+- [Campaign roadmap](plan-dashboard-feature-campaign-2026-07-15.md) — gate row B
+- [Phase A record](implement-phase-a-artifact-qa-views.md) — substrate this builds on
+
+---
+
+## Overview
+
+Row B of the ship gate. Two PRs:
+
+- **PR 4 (#57):** an "In-flight job" card on every artifact detail page — which pipeline
+  process (wsclean / batch_pipeline / convert) is touching *this* artifact right now, its PID,
+  and the newest log lines filtered to the artifact's timestamp. Researcher question answered:
+  "why is it slow / is it stuck?" without leaving the page.
+- **PR 5 (#62 + #49):** write the auth-posture ADR (the decision already shipped: pre-shared
+  bearer token, fail-closed, audit log — readiness plan decision 2) → close #49; then delete
+  `scripts/monitor_server.py` (option 2 of #62): every read-only endpoint is superseded
+  (`/disk`,`/processes`,`/logs` → `/api/status` + #57 cards; `/ms`,`/images` →
+  `/artifacts/ms|tile|mosaic`), it has no code callers, is not running (pgrep-verified
+  2026-07-15), and `POST /exec` must not exist anywhere per #62.
+
+**Goal:** #57, #62, #49 closed; no shell-execution endpoint in the repo; job state visible on
+live pages.
+
+## Current State Analysis
+
+- `scripts/qa_server.py:337-363` — `process_status()`: ps scan for
+  `("batch_pipeline.py", "wsclean", "aoflagger")`, returns pid/elapsed/state/command. Generic
+  (dashboard heartbeat), not artifact-scoped.
+- `dsa110_continuum/observability/control.py:229` — `list_runs()`: launcher-owned runs with
+  `status`, `pid`, `log_path`, `request_json`; `running` reconciled against `/proc`.
+- `scripts/qa_server.py:310-317` — `_tail()` helper (unfiltered).
+- `scripts/monitor_server.py` (78 lines) — `/processes` ps-aux keyword grep (`:35-42`),
+  `/logs` newest file from `/tmp` glob patterns (`:52-62`), `POST /exec`
+  `subprocess.run(shell=True)` behind `TIDY_EXEC_SECRET` (`:63-73`). Unmounted, not running,
+  callers = docs only (verified).
+- Artifact pages (Phase A): `scripts/artifact_pages.py` — caltable/tile/ms detail pages with
+  card sections; `observability/artifacts.py::related_artifacts` already derives the
+  timestamp/date for any artifact.
+- `docs/adr/0001-canonical-hourly-epoch-coadd.md` — ADR format (Status + Considered Options).
+- #49 OPEN: the auth decision shipped in the readiness arc but was never recorded as the ADR
+  it promised (`plan-dashboard-production-readiness.md:1324`).
+
+**Process↔artifact ground truth:** wsclean argv embeds the tile imagename
+(`.../{ts}` prefix); conversion argv embeds the MS/HDF5 timestamp; `batch_pipeline.py` argv
+carries `--date {date}` while its per-run log (control registry `log_path`) names specific
+timestamps per tile/MS line. So: full-timestamp substring match on argv → direct process hit;
+date match on a batch argv → date-level hit whose log is then line-filtered by full timestamp.
+
+## Desired End State
+
+- Caltable/tile/MS pages + status JSONs carry a `job` section: matched processes (pid,
+  elapsed, command), date-level batch runs, and ≤40 log lines filtered to the artifact
+  timestamp; "No active job touching this artifact" otherwise.
+- `docs/adr/0002-observability-auth-posture.md` exists; #49 closed.
+- `scripts/monitor_server.py` deleted; CLAUDE.md + `docs/operations/dashboard.md` updated;
+  `check_contimg_mentions`/test-cloud still green; #62 closed.
+
+## What We're NOT Doing
+
+- No mosaic-epoch job card (no mosaic HTML page exists yet — that's Phase C's stage-event
+  work; noted on #57 at close).
+- No new process-spawning, no push updates (polling substrate stands), no `/tmp` log-glob
+  resurrection (control-registry logs are the authority; the ad-hoc `/tmp/convert_*.log`
+  pattern predates the registry).
+- Not moving monitor_server to `tools/` (option 1): nothing left worth moving once `/exec` is
+  out — recorded on #62 for async review.
+
+## Implementation Approach
+
+`observability/job_state.py` (pure stdlib + control registry; no CASA):
+
+- `active_processes()` — one `ps -eo pid=,etimes=,args=` pass filtered by
+  `("wsclean", "aoflagger", "batch_pipeline.py", "dsa110", "casa")`, excluding the scanner.
+- `jobs_for_timestamp(ts, control_config=None, max_lines=40)` →
+  `{"processes": [argv contains ts], "batch": [argv contains ts[:10] date],
+    "runs": running registry runs whose log tail mentions ts (line-filtered),
+    "active": bool}`.
+- Routers call it inside the existing summary/status handlers; pages render a "In-flight job"
+  card between the related-links row and the metrics tables.
+
+Tests monkeypatch `active_processes` and `pipeline_control.list_runs` (fake log file on
+tmp_path) — one in-flight scenario per #57's acceptance criterion, plus the no-job state and
+the ts-filtering unit. Live H17 test asserts the card renders (either state).
+
+PR 5 is mechanical: ADR text (decision already made), `git rm scripts/monitor_server.py`,
+CLAUDE.md service-table + `<important>` block edits, dashboard.md network-posture line,
+close-out comments.
+
+## Implementation Phases
+
+### Phase B1 (PR 4, closes #57)
+
+1. Failing tests `tests/test_job_state.py`: `jobs_for_timestamp` matches ts in fake process
+   argv; date-level batch match; running-run log filtered to ts lines; inactive → empty;
+   route test: MS page shows "In-flight job" card with PID when monkeypatched active, and
+   "No active job" otherwise; status JSON carries `job`.
+2. Implement `dsa110_continuum/observability/job_state.py`; wire into
+   `scripts/artifact_pages.py` (all three status handlers + pages).
+3. `CLOUD_SAFE_TESTS` += `tests/test_job_state.py`; ruff; full suite; live smoke on a page.
+
+### Phase B2 (PR 5, closes #62 and #49)
+
+1. `docs/adr/0002-observability-auth-posture.md` (token/fail-closed/audit/Cloudflare-Access
+   optional hardening; considered: per-user auth, mTLS, Dagster-side auth).
+2. `git rm scripts/monitor_server.py`; update `CLAUDE.md` (services block + command table),
+   `docs/operations/dashboard.md` (posture paragraph); rg confirms no live references remain.
+3. Gates green; PR; merge; close #49 (ADR link), #62 (supersession map per endpoint).
+
+## Success Criteria
+
+**Automated:** `pytest tests/test_job_state.py tests/test_qa_server.py tests/test_caltable_pages.py tests/test_tile_pages.py tests/test_ms_pages.py -q` green on H17;
+`make test-cloud` green; `rg -l "monitor_server" scripts/ dsa110_continuum/ tests/ Makefile ops/` → empty after PR 5;
+live: `curl /artifacts/ms/<name>/status | jq .job` present; no `/exec` route anywhere
+(`rg -n "shell=True" scripts/ dsa110_continuum/` clean).
+
+**Manual (Jakob):** during the next real pipeline run, open an in-progress artifact page and
+confirm the card names the right process and log lines; ratify the delete-vs-move choice on
+#62 and the ADR wording on #49.
+
+## Open Questions
+
+*(none — delete-vs-move recorded as a reviewable deviation on #62)*
+
+---
+
+**References:** issues #57/#62/#49; `plan-dashboard-production-readiness.md` decision 2;
+Phase A record. PRs: #124? (numbers assigned at creation).

--- a/dsa110_continuum/observability/job_state.py
+++ b/dsa110_continuum/observability/job_state.py
@@ -1,0 +1,96 @@
+"""Per-artifact in-flight job state: processes + registry runs + filtered log tails (#57)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+PROCESS_KEYWORDS = ("wsclean", "aoflagger", "batch_pipeline.py", "dsa110", "casa")
+EXCLUDE_MARKERS = ("uvicorn", "pytest", "ps -eo", "job_state")
+TAIL_WINDOW = 4000
+
+
+def active_processes() -> list[dict]:
+    """List pipeline-relevant processes (pid, elapsed seconds, command)."""
+    try:
+        result = subprocess.run(
+            ["ps", "-eo", "pid=,etimes=,args="],
+            capture_output=True,
+            text=True,
+            errors="replace",
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    processes = []
+    for line in result.stdout.splitlines():
+        lowered = line.lower()
+        if not any(keyword in lowered for keyword in PROCESS_KEYWORDS):
+            continue
+        if any(marker in lowered for marker in EXCLUDE_MARKERS):
+            continue
+        parts = line.strip().split(maxsplit=2)
+        if len(parts) == 3:
+            processes.append(
+                {
+                    "pid": int(parts[0]),
+                    "elapsed_seconds": int(parts[1]),
+                    "command": parts[2],
+                }
+            )
+    return processes
+
+
+def _filtered_tail(log_path: Path, needle: str, max_lines: int) -> list[str]:
+    try:
+        with log_path.open(errors="replace") as stream:
+            lines = stream.readlines()[-TAIL_WINDOW:]
+    except OSError:
+        return []
+    matched = [line.rstrip("\n") for line in lines if needle in line]
+    return matched[-max_lines:]
+
+
+def _running_runs(control_config) -> list[dict]:
+    from dsa110_continuum.observability import control as pipeline_control
+
+    config = control_config or pipeline_control.ControlConfig()
+    return [run for run in pipeline_control.list_runs(config) if run.get("status") == "running"]
+
+
+def jobs_for_timestamp(ts: str, control_config=None, max_lines: int = 40) -> dict:
+    """In-flight job state for one artifact timestamp (YYYY-MM-DDTHH:MM:SS).
+
+    A process whose argv contains the full timestamp is a direct hit (wsclean
+    imagename, conversion MS path); a process carrying only the date is a
+    date-level batch hit whose registry log is then line-filtered by the full
+    timestamp.
+    """
+    date = ts[:10]
+    processes = active_processes()
+    direct = [proc for proc in processes if ts in proc["command"]]
+    batch = [proc for proc in processes if proc not in direct and date in proc["command"]]
+    runs: list[dict] = []
+    try:
+        for run in _running_runs(control_config):
+            log_path = run.get("log_path")
+            lines = _filtered_tail(Path(log_path), ts, max_lines) if log_path else []
+            request_blob = str(run.get("request_json") or "") + str(run.get("argv_json") or "")
+            if lines or date in request_blob:
+                runs.append(
+                    {
+                        "run_id": run.get("run_id"),
+                        "pid": run.get("pid"),
+                        "log_path": log_path,
+                        "log_lines": lines,
+                    }
+                )
+    except Exception:
+        runs = []
+    return {
+        "processes": direct,
+        "batch": batch,
+        "runs": runs,
+        "active": bool(direct or batch or runs),
+    }

--- a/scripts/artifact_pages.py
+++ b/scripts/artifact_pages.py
@@ -6,7 +6,7 @@ import html
 import json
 from pathlib import Path
 
-from dsa110_continuum.observability import artifacts, caltable_qa, ms_qa, tile_qa
+from dsa110_continuum.observability import artifacts, caltable_qa, job_state, ms_qa, tile_qa
 from fastapi import APIRouter, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse
 
@@ -24,7 +24,13 @@ border-radius:999px;font-size:.68rem;font-weight:800}
 padding:10px}
 .plot-grid img{width:100%;background:#090b0e;border-radius:4px;min-height:80px}
 .plot-grid figcaption{font-size:.75rem;color:#87919d;margin-top:6px}
-.muted{color:#87919d}</style>"""
+.muted{color:#87919d}
+pre{background:#090b0e;color:#b9c6d0;border-radius:6px;padding:12px;max-height:260px;
+overflow:auto;font-size:.72rem;line-height:1.45;white-space:pre-wrap}
+.process-list{list-style:none;padding:0;margin:0}
+.process-list li{display:flex;gap:10px;padding:6px 0;border-top:1px solid #2a3038;
+font-size:.76rem} .process-list li:first-child{border:0}
+.process-list span{word-break:break-all;color:#bdc6cf}</style>"""
 
 
 def _badge(state: str, label: str) -> str:
@@ -75,6 +81,33 @@ def _related_row(related: dict) -> str:
         )
     links.append(f'<a href="/runs/{related["date"]}">run {related["date"]}</a>')
     return " · ".join(links)
+
+
+def _job_card(job: dict) -> str:
+    """Render the in-flight job section for one artifact (#57)."""
+    if not job.get("active"):
+        return '<h2>In-flight job</h2><p class="muted">No active job touching this artifact</p>'
+    rows = []
+    for proc in job.get("processes", []):
+        rows.append(
+            f"<li><code>PID {proc['pid']}</code> <span>{html.escape(proc['command'])}</span></li>"
+        )
+    for proc in job.get("batch", []):
+        rows.append(
+            f"<li><code>PID {proc['pid']}</code> "
+            f"<span>date-level batch: {html.escape(proc['command'])}</span></li>"
+        )
+    process_html = f'<ul class="process-list">{"".join(rows)}</ul>' if rows else ""
+    runs_html = ""
+    for run in job.get("runs", []):
+        run_id = html.escape(str(run.get("run_id")))
+        tail = html.escape("\n".join(run.get("log_lines") or []) or "no matching log lines yet")
+        runs_html += (
+            f'<p class="muted">run <a href="/control/runs/{run_id}">{run_id}</a>'
+            f" · PID {run.get('pid')} · {html.escape(str(run.get('log_path')))}</p>"
+            f"<pre>{tail}</pre>"
+        )
+    return f"<h2>In-flight job</h2>{process_html}{runs_html}"
 
 
 def _cached_summary(config, category: str, name: str, source: Path, builder) -> dict:
@@ -139,6 +172,7 @@ def caltable_status(name: str, request: Request):
         "summary": summary,
         "related": artifacts.related_artifacts(Path(config.stage), name[:19]),
         "plot_kinds": list(caltable_qa.plot_kinds(name)),
+        "job": job_state.jobs_for_timestamp(name[:19]),
     }
 
 
@@ -209,6 +243,7 @@ def caltable_page(name: str, request: Request):
         or '<tr><td colspan="3" class="muted">—</td></tr>'
     )
     related = artifacts.related_artifacts(Path(config.stage), name[:19])
+    job = job_state.jobs_for_timestamp(name[:19])
     cal_type = caltable_qa.caltable_type(name)
     return _page(
         f"Caltable {name}",
@@ -218,6 +253,7 @@ def caltable_page(name: str, request: Request):
 modified {html.escape(record["modified"][:19])} ·
 <a href="/artifacts/caltable/{html.escape(name)}/status">JSON</a></p>
 <p>{_related_row(related)}</p>{summary_note}
+{_job_card(job)}
 <h2>Provenance</h2>{prov_html}
 <h2>Quality metrics</h2><table><tbody>{quality_rows}</tbody></table>
 <h2>Per-SPW flagging</h2>
@@ -284,6 +320,7 @@ def tile_status(name: str, request: Request):
         "summary": summary,
         "related": artifacts.related_artifacts(Path(config.stage), name),
         "plot_kinds": list(tile_qa.plot_kinds(products, ms_path is not None)),
+        "job": job_state.jobs_for_timestamp(name),
     }
 
 
@@ -345,12 +382,14 @@ def tile_page(name: str, request: Request):
         for key, path in products.items()
     )
     related = artifacts.related_artifacts(Path(config.stage), name)
+    job = job_state.jobs_for_timestamp(name)
     return _page(
         f"Tile {name}",
         f"""
 <h1>Single-tile FITS · {name} {gate_badge}</h1>
 <p class="muted"><a href="/artifacts/tile/{name}/status">JSON</a></p>
 <p>{_related_row(related)}</p>{note}
+{_job_card(job)}
 <h2>QA gate</h2><table><tbody>{gate_rows}</tbody></table>
 <h2>Products</h2><table><tbody>{product_rows}</tbody></table>
 <h2>Diagnostics</h2>{_plot_grid(f"/artifacts/tile/{name}", tile_qa.plot_kinds(products, ms_path is not None))}""",
@@ -374,12 +413,15 @@ def ms_index(request: Request):
     """List the newest Measurement Sets on stage."""
     config = _config(request)
     records = artifacts.list_ms(Path(config.stage) / "ms")
-    rows = "".join(
-        f'<tr><td><a href="/artifacts/ms/{html.escape(record["name"])}">'
-        f"{html.escape(record['name'])}</a></td>"
-        f"<td>{html.escape(record['modified'][:19])}</td></tr>"
-        for record in records
-    ) or '<tr><td colspan="2" class="muted">No Measurement Sets on stage</td></tr>'
+    rows = (
+        "".join(
+            f'<tr><td><a href="/artifacts/ms/{html.escape(record["name"])}">'
+            f"{html.escape(record['name'])}</a></td>"
+            f"<td>{html.escape(record['modified'][:19])}</td></tr>"
+            for record in records
+        )
+        or '<tr><td colspan="2" class="muted">No Measurement Sets on stage</td></tr>'
+    )
     return _page(
         "Measurement Sets",
         f"""<h1>Measurement Sets</h1>
@@ -402,6 +444,7 @@ def ms_status(name: str, request: Request):
         "summary": summary,
         "related": artifacts.related_artifacts(Path(config.stage), name[:19]),
         "plot_kinds": list(ms_qa.plot_kinds(path)),
+        "job": job_state.jobs_for_timestamp(name[:19]),
     }
 
 
@@ -444,6 +487,7 @@ def ms_page(name: str, request: Request):
         summary = {}
         note = f'<p class="muted">metrics unavailable: {html.escape(str(exc))}</p>'
     related = artifacts.related_artifacts(Path(config.stage), name[:19])
+    job = job_state.jobs_for_timestamp(name[:19])
     lifecycle = [
         ("Calibration tables", bool(related["caltables"])),
         ("Tile image", related["tile"] is not None),
@@ -454,10 +498,13 @@ def ms_page(name: str, request: Request):
         f"<td>{_badge('pass' if done else 'warn', 'ready' if done else 'not yet')}</td></tr>"
         for stage_name, done in lifecycle
     )
-    summary_rows = "".join(
-        f"<tr><th>{html.escape(str(key))}</th><td>{html.escape(str(value))}</td></tr>"
-        for key, value in summary.items()
-    ) or '<tr><td colspan="2" class="muted">—</td></tr>'
+    summary_rows = (
+        "".join(
+            f"<tr><th>{html.escape(str(key))}</th><td>{html.escape(str(value))}</td></tr>"
+            for key, value in summary.items()
+        )
+        or '<tr><td colspan="2" class="muted">—</td></tr>'
+    )
     return _page(
         f"MS {name}",
         f"""
@@ -466,6 +513,7 @@ def ms_page(name: str, request: Request):
 modified {html.escape(record["modified"][:19])} ·
 <a href="/artifacts/ms/{html.escape(name)}/status">JSON</a></p>
 <p>{_related_row(related)}</p>{note}
+{_job_card(job)}
 <h2>Lifecycle</h2><table><tbody>{lifecycle_rows}</tbody></table>
 <h2>Summary</h2><table><tbody>{summary_rows}</tbody></table>
 <h2>Diagnostics</h2>{_plot_grid(f"/artifacts/ms/{html.escape(name)}", ms_qa.plot_kinds(path))}""",

--- a/scripts/qa_server.py
+++ b/scripts/qa_server.py
@@ -341,6 +341,7 @@ def process_status() -> list[dict]:
             ["ps", "-eo", "pid=,etimes=,stat=,args="],
             capture_output=True,
             text=True,
+            errors="replace",
             timeout=5,
             check=False,
         )

--- a/scripts/run_cloud_safe_tests.py
+++ b/scripts/run_cloud_safe_tests.py
@@ -40,6 +40,7 @@ CLOUD_SAFE_TESTS = (
     "tests/test_caltable_pages.py",
     "tests/test_tile_pages.py",
     "tests/test_ms_pages.py",
+    "tests/test_job_state.py",
 )
 
 

--- a/tests/test_job_state.py
+++ b/tests/test_job_state.py
@@ -1,0 +1,195 @@
+"""Per-artifact in-flight job state (#57): unit + routed-card tests (cloud-safe)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from dsa110_continuum.observability import job_state
+from fastapi.testclient import TestClient
+from scripts.qa_server import DashboardConfig, create_app
+
+TS = "2026-01-25T22:26:05"
+MS = f"{TS}.ms"
+
+
+def _make_config(tmp_path: Path) -> DashboardConfig:
+    return DashboardConfig(
+        stage=tmp_path / "stage",
+        products=tmp_path / "products",
+        incoming=tmp_path / "incoming",
+        thumb_dir=tmp_path / "thumbs",
+        campaign_outputs=tmp_path / "campaign",
+        campaign_date="2026-07-13",
+        campaign_hour=11,
+    )
+
+
+def _make_ms(config: DashboardConfig, name: str = MS) -> Path:
+    path = config.stage / "ms" / name
+    path.mkdir(parents=True)
+    (path / "table.dat").write_bytes(b"x")
+    return path
+
+
+class TestJobsForTimestamp:
+    def test_direct_process_match_on_timestamp(self, monkeypatch):
+        monkeypatch.setattr(
+            job_state,
+            "active_processes",
+            lambda: [
+                {"pid": 111, "elapsed_seconds": 5, "command": f"wsclean -name /x/{TS} ..."},
+                {"pid": 222, "elapsed_seconds": 9, "command": "wsclean -name /x/other ..."},
+            ],
+        )
+        monkeypatch.setattr(job_state, "_running_runs", lambda config: [])
+        job = job_state.jobs_for_timestamp(TS)
+        assert [proc["pid"] for proc in job["processes"]] == [111]
+        assert job["active"] is True
+
+    def test_date_level_batch_match(self, monkeypatch):
+        monkeypatch.setattr(
+            job_state,
+            "active_processes",
+            lambda: [
+                {
+                    "pid": 333,
+                    "elapsed_seconds": 60,
+                    "command": "python scripts/batch_pipeline.py --date 2026-01-25",
+                }
+            ],
+        )
+        monkeypatch.setattr(job_state, "_running_runs", lambda config: [])
+        job = job_state.jobs_for_timestamp(TS)
+        assert job["processes"] == []
+        assert [proc["pid"] for proc in job["batch"]] == [333]
+        assert job["active"] is True
+
+    def test_running_run_log_filtered_to_timestamp(self, tmp_path, monkeypatch):
+        log = tmp_path / "run_x.log"
+        log.write_text(
+            f"start\nprocessing {TS}.ms stage=applycal\nother 2026-01-25T23:00:00 line\n"
+            f"{TS} wsclean iteration 12\n"
+        )
+        monkeypatch.setattr(job_state, "active_processes", lambda: [])
+        monkeypatch.setattr(
+            job_state,
+            "_running_runs",
+            lambda config: [{"run_id": "r1", "pid": 999, "log_path": str(log), "request_json": ""}],
+        )
+        job = job_state.jobs_for_timestamp(TS)
+        assert len(job["runs"]) == 1
+        lines = job["runs"][0]["log_lines"]
+        assert len(lines) == 2
+        assert all(TS in line for line in lines)
+
+    def test_inactive_when_nothing_matches(self, monkeypatch):
+        monkeypatch.setattr(job_state, "active_processes", lambda: [])
+        monkeypatch.setattr(job_state, "_running_runs", lambda config: [])
+        job = job_state.jobs_for_timestamp(TS)
+        assert job == {"processes": [], "batch": [], "runs": [], "active": False}
+
+    def test_registry_errors_degrade_to_no_runs(self, monkeypatch):
+        monkeypatch.setattr(job_state, "active_processes", lambda: [])
+
+        def boom(config):
+            raise RuntimeError("registry unavailable")
+
+        monkeypatch.setattr(job_state, "_running_runs", boom)
+        job = job_state.jobs_for_timestamp(TS)
+        assert job["runs"] == []
+        assert job["active"] is False
+
+
+class TestJobCardOnPages:
+    def test_ms_page_shows_active_job(self, tmp_path, monkeypatch):
+        config = _make_config(tmp_path)
+        _make_ms(config)
+        monkeypatch.setattr(
+            job_state,
+            "jobs_for_timestamp",
+            lambda ts, control_config=None, max_lines=40: {
+                "processes": [{"pid": 12345, "elapsed_seconds": 30, "command": f"wsclean {ts}"}],
+                "batch": [],
+                "runs": [
+                    {
+                        "run_id": "r9",
+                        "pid": 12345,
+                        "log_path": "/tmp/run.log",
+                        "log_lines": [f"{ts} cleaning <b>bold</b>"],
+                    }
+                ],
+                "active": True,
+            },
+        )
+        with TestClient(create_app(config)) as client:
+            page = client.get(f"/artifacts/ms/{MS}")
+            status = client.get(f"/artifacts/ms/{MS}/status").json()
+        assert "In-flight job" in page.text
+        assert "12345" in page.text
+        assert "&lt;b&gt;bold&lt;/b&gt;" in page.text  # log lines escaped
+        assert status["job"]["active"] is True
+
+    def test_ms_page_shows_no_active_job(self, tmp_path, monkeypatch):
+        config = _make_config(tmp_path)
+        _make_ms(config)
+        monkeypatch.setattr(
+            job_state,
+            "jobs_for_timestamp",
+            lambda ts, control_config=None, max_lines=40: {
+                "processes": [],
+                "batch": [],
+                "runs": [],
+                "active": False,
+            },
+        )
+        with TestClient(create_app(config)) as client:
+            page = client.get(f"/artifacts/ms/{MS}")
+        assert "No active job touching this artifact" in page.text
+
+    def test_caltable_and_tile_status_carry_job(self, tmp_path, monkeypatch):
+        import numpy as np
+        from astropy.io import fits
+        from dsa110_continuum.observability import caltable_qa, tile_qa
+
+        config = _make_config(tmp_path)
+        table = config.stage / "ms" / f"{TS}_0~23.g"
+        table.mkdir(parents=True)
+        tile_ts = "2026-01-25T02:01:43"
+        tile_dir = config.stage / "images" / "mosaic_2026-01-25"
+        tile_dir.mkdir(parents=True)
+        fits.writeto(tile_dir / f"{tile_ts}-image.fits", np.zeros((4, 4), dtype=np.float32))
+        monkeypatch.setattr(caltable_qa, "summary", lambda path: {"name": table.name})
+        monkeypatch.setattr(tile_qa, "summary", lambda products, ms_path: {"gate": None})
+        monkeypatch.setattr(
+            job_state,
+            "jobs_for_timestamp",
+            lambda ts, control_config=None, max_lines=40: {
+                "processes": [],
+                "batch": [],
+                "runs": [],
+                "active": False,
+            },
+        )
+        with TestClient(create_app(config)) as client:
+            cal = client.get(f"/artifacts/caltable/{table.name}/status").json()
+            tile = client.get(f"/artifacts/tile/{tile_ts}/status").json()
+        assert cal["job"]["active"] is False
+        assert tile["job"]["active"] is False
+
+
+STAGE_MS = Path("/stage/dsa110-contimg/ms")
+requires_stage = pytest.mark.skipif(not STAGE_MS.is_dir(), reason="H17 stage volume not present")
+
+
+@requires_stage
+class TestLiveJobCard:
+    def test_real_ms_page_renders_job_section(self, tmp_path):
+        from dsa110_continuum.observability import artifacts
+
+        records = artifacts.list_ms(STAGE_MS, limit=1)
+        config = DashboardConfig(thumb_dir=tmp_path / "thumbs")
+        with TestClient(create_app(config)) as client:
+            page = client.get(f"/artifacts/ms/{records[0]['name']}")
+        assert page.status_code == 200
+        assert "In-flight job" in page.text


### PR DESCRIPTION
Phase B / PR 4 of the dashboard feature campaign (plan: `docs/rse/specs/plan-phase-b-job-state-monitor-retirement-2026-07-15.md`, committed here). Closes #57.

## What
- `dsa110_continuum/observability/job_state.py` — `jobs_for_timestamp(ts)`: direct process hits (full timestamp in argv — wsclean imagename / conversion MS path), date-level batch hits, and running control-registry runs with log tails **line-filtered to the artifact timestamp** (not a generic process dump — the #57 acceptance criterion).
- In-flight job card + `job` status field on all three artifact detail pages; explicit "No active job touching this artifact" empty state; log lines HTML-escaped.
- Hardening: `ps` output decoded with `errors=replace` in both job_state and `qa_server.process_status` — a live H17 process with non-UTF8 argv bytes crashed strict decoding (caught by the live-integration test).
- `CLOUD_SAFE_TESTS` += `test_job_state.py`.

## Verification
- 109 passed on H17 (job-state suite incl. live page render + all Phase A files); `make test-cloud` green (340).
- In-flight scenario covered synthetically per the issue (fake wsclean argv + fake running run with a real filtered log file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWfuZCVQgwkUZiBP1ByKwE