### PR TITLE
Job-state precision: date-level hits require a pipeline-driver marker

### DIFF
--- a/dsa110_continuum/observability/job_state.py
+++ b/dsa110_continuum/observability/job_state.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 
 PROCESS_KEYWORDS = ("wsclean", "aoflagger", "batch_pipeline.py", "dsa110", "casa")
+BATCH_MARKERS = ("batch_pipeline.py", "auto_pipeline.py", "mosaic_day.py", "dsa110 convert")
 EXCLUDE_MARKERS = ("uvicorn", "pytest", "ps -eo", "job_state")
 TAIL_WINDOW = 4000
 
@@ -70,7 +71,13 @@ def jobs_for_timestamp(ts: str, control_config=None, max_lines: int = 40) -> dic
     date = ts[:10]
     processes = active_processes()
     direct = [proc for proc in processes if ts in proc["command"]]
-    batch = [proc for proc in processes if proc not in direct and date in proc["command"]]
+    batch = [
+        proc
+        for proc in processes
+        if proc not in direct
+        and date in proc["command"]
+        and any(marker in proc["command"] for marker in BATCH_MARKERS)
+    ]
     runs: list[dict] = []
     try:
         for run in _running_runs(control_config):

--- a/tests/test_job_state.py
+++ b/tests/test_job_state.py
@@ -83,6 +83,24 @@ class TestJobsForTimestamp:
         assert len(lines) == 2
         assert all(TS in line for line in lines)
 
+    def test_date_in_unrelated_process_argv_not_matched(self, monkeypatch):
+        """A shell/session process that merely mentions the date is not a batch hit."""
+        monkeypatch.setattr(
+            job_state,
+            "active_processes",
+            lambda: [
+                {
+                    "pid": 444,
+                    "elapsed_seconds": 3,
+                    "command": "/bin/bash -c echo 2026-01-25",
+                }
+            ],
+        )
+        monkeypatch.setattr(job_state, "_running_runs", lambda config: [])
+        job = job_state.jobs_for_timestamp(TS)
+        assert job["batch"] == []
+        assert job["active"] is False
+
     def test_inactive_when_nothing_matches(self, monkeypatch):
         monkeypatch.setattr(job_state, "active_processes", lambda: [])
         monkeypatch.setattr(job_state, "_running_runs", lambda config: [])


### PR DESCRIPTION
Fix rider on #57 (PR #125): live smoke caught the date-level bucket matching an unrelated session shell whose argv contained the date — a false 'active job' badge. Date-level matches now require `batch_pipeline.py` / `auto_pipeline.py` / `mosaic_day.py` / `dsa110 convert` in the command; full-timestamp direct hits unchanged. Regression test added.

10/10 job-state tests green; `make test-cloud` unaffected paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWfuZCVQgwkUZiBP1ByKwE