### PR TITLE
fix(calibration): default to combine=field when solving a gain range without a peak field (fixes #104)

### DIFF
--- a/dsa110_continuum/calibration/solve_gains.py
+++ b/dsa110_continuum/calibration/solve_gains.py
@@ -185,21 +185,19 @@ def solve_prebandpass_phase(
     # - If combining across fields: use the full selection string to maximize SNR
     # - Otherwise: use the peak field (closest to calibrator) if provided, otherwise parse from range
     #   The peak field is the one with maximum PB-weighted flux (closest to calibrator position)
-    if combine_fields:
+    fallback_to_range = peak_field_idx is None and "~" in str(cal_field)
+    use_combine_fields = combine_fields or fallback_to_range
+    if use_combine_fields:
         field_selector = str(cal_field)
+    elif peak_field_idx is not None:
+        field_selector = str(peak_field_idx)
     else:
-        if peak_field_idx is not None:
-            field_selector = str(peak_field_idx)
-        elif "~" in str(cal_field):
-            # Fallback: use first field in range (should be peak when peak_idx=0)
-            field_selector = str(cal_field).split("~")[0]
-        else:
-            field_selector = str(cal_field)
+        field_selector = str(cal_field)
     logger.debug(
         f"Using field selector '{field_selector}' for pre-bandpass phase solve"
         + (
             f" (combined from range {cal_field})"
-            if combine_fields
+            if use_combine_fields
             else f" (peak field: {field_selector})"
         )
     )
@@ -207,7 +205,7 @@ def solve_prebandpass_phase(
     # Combine across scans, fields, and SPWs when requested
     # Combining SPWs improves SNR by using all 16 subbands simultaneously
     comb_parts = ["scan"]
-    if combine_fields:
+    if use_combine_fields:
         comb_parts.append("field")
     if combine_spw:
         comb_parts.append("spw")
@@ -567,21 +565,19 @@ def solve_gains(
     # - If combining across fields: use the full selection string to maximize SNR
     # - Otherwise: use the peak field (closest to calibrator) if provided, otherwise parse from range
     #   The peak field is the one with maximum PB-weighted flux (closest to calibrator position)
-    if combine_fields:
+    fallback_to_range = peak_field_idx is None and "~" in str(cal_field)
+    use_combine_fields = combine_fields or fallback_to_range
+    if use_combine_fields:
         field_selector = str(cal_field)
+    elif peak_field_idx is not None:
+        field_selector = str(peak_field_idx)
     else:
-        if peak_field_idx is not None:
-            field_selector = str(peak_field_idx)
-        elif "~" in str(cal_field):
-            # Fallback: use first field in range (should be peak when peak_idx=0)
-            field_selector = str(cal_field).split("~")[0]
-        else:
-            field_selector = str(cal_field)
+        field_selector = str(cal_field)
     logger.debug(
         f"Using field selector '{field_selector}' for gain calibration"
         + (
             f" (combined from range {cal_field})"
-            if combine_fields
+            if use_combine_fields
             else f" (peak field: {field_selector})"
         )
     )
@@ -593,7 +589,7 @@ def solve_gains(
     gaintable.extend(bptables)
 
     # Combine across scans and fields when requested; otherwise do not combine
-    comb = "scan,field" if combine_fields else ""
+    comb = "scan,field" if use_combine_fields else ""
 
     # CRITICAL FIX: Determine spwmap if tables were created with combine_spw=True
     # When combine_spw is used, the table has solutions only for SPW=0 (aggregate).


### PR DESCRIPTION
## Summary
`solve_prebandpass_phase` and `solve_gains` had a field-range fallback that selected the first field in a range (`0`) when no `peak_field_idx` was supplied. For DSA-110 calibrator MSs with 24 fields, field 0 is ~0.74x the peak primary-beam response, which biases the resulting gain table high by ~1.36x. This caused the daily `.g` fallback in epoch gaincal to produce hot fluxes on the 2026-07-13 hour-11 run (#104).

This PR changes the fallback for a range-without-peak to use the full `cal_field` range with `combine=field`, matching the SNR-maximizing behavior already used when `combine_fields=True`. An explicit `peak_field_idx` still wins; a single field id still resolves to itself.

## Changes
- `dsa110_continuum/calibration/solve_gains.py`: introduce `fallback_to_range` and `use_combine_fields` in both `solve_prebandpass_phase` and `solve_gains`. `comb_parts.append('field')` and the `gaincal` `comb` string now follow `use_combine_fields`, so a range without a peak no longer silently collapses to field `0`.
- Updated the debug/log messaging to reflect the effective combine decision.

## Verification
- `make test-cloud PYTHON=/home/ubuntu/.venv-dsa110-312/bin/python` passes (200 passed).
- `ruff check dsa110_continuum/calibration/solve_gains.py` is clean.
- H17 validation pending: compare flag fraction and residual kurtosis / flux scale on the 2026-07-13T11:18:06 calibrator MS or rerun `batch_pipeline.py` for an affected epoch.

Closes #104.