### PR TITLE
fix(database): migrate valid_start_mjd / valid_end_mjd columns in caltables (fixes #102)

### DIFF
--- a/dsa110_continuum/database/unified.py
+++ b/dsa110_continuum/database/unified.py
@@ -1030,6 +1030,8 @@ def _migrate_caltables_schema(conn: sqlite3.Connection) -> None:
 
     # Add missing provenance columns
     new_columns = [
+        ("valid_start_mjd", "REAL"),
+        ("valid_end_mjd", "REAL"),
         ("source_ms_path", "TEXT"),
         ("solver_command", "TEXT"),
         ("solver_version", "TEXT"),


### PR DESCRIPTION
## Summary
The `caltables` schema in `dsa110_continuum/database/unified.py` has included `valid_start_mjd` / `valid_end_mjd` in the `CREATE TABLE` for new databases, but the migration function `_migrate_caltables_schema` only added the provenance text columns (`source_ms_path`, `solver_command`, etc.). Existing `pipeline.sqlite3` databases created before those columns therefore raised `no such column: valid_start_mjd` when the pipeline tried to register generated calibration tables (#102).

## Changes
- `dsa110_continuum/database/unified.py`: add `valid_start_mjd` and `valid_end_mjd` to the `new_columns` list in `_migrate_caltables_schema`, guarded by the existing `PRAGMA table_info` probe. The `CREATE TABLE` and `idx_caltables_valid` index code are unchanged; the index is still created in `ensure_calibration_database` after the migration.

## Verification
- `make test-cloud PYTHON=/home/ubuntu/.venv-dsa110-312/bin/python` passes (200 passed).
- `ruff check dsa110_continuum/database/unified.py` reports five pre-existing style/name issues in the file that are unrelated to this change (I001, F821 at `query_df`, and W291/W293 on migration SQL strings); I did not bulk-fix them per repo guidance.
- H17 validation pending: confirm that a real `pipeline.sqlite3` with the old `caltables` schema successfully runs `_migrate_caltables_schema` and caltable registration no longer logs `no such column: valid_start_mjd`.

Closes #102.