### PR TITLE
fix(conversion): isolate malformed groups and trust converter output (fixes #112)

### DIFF
--- a/dsa110_continuum/conversion/calibrator_ms_generator.py
+++ b/dsa110_continuum/conversion/calibrator_ms_generator.py
@@ -439,48 +439,45 @@ class CalibratorMSGenerator:
         ms_paths = []
 
         for group in groups:
-            if isinstance(group, str):
-                # Group representative timestamp from select_groups_by_position
-                timestamp = group
-            else:
-                # SubbandGroup object or raw file list
-                files = group.files if hasattr(group, "files") else group
-                if not files:
-                    continue
-                timestamp = Path(files[0]).stem.rsplit("_sb", 1)[0]
-
-            # Check if already exists
-            ms_path = self.output_dir / f"{timestamp}.ms"
-            if skip_existing and ms_path.exists():
-                logger.info("Skipping existing MS: %s", ms_path)
-                ms_paths.append(ms_path)
-                continue
-
-            # Convert using time-based API
-            end_ts = (Time(timestamp, format="isot") + 2 * u.minute).isot
-
             try:
-                convert_subband_groups_to_ms(
+                if isinstance(group, str):
+                    timestamp = group
+                else:
+                    files = group.files if hasattr(group, "files") else group
+                    if not files:
+                        continue
+                    timestamp = Path(files[0]).stem.rsplit("_sb", 1)[0]
+
+                ms_path = self.output_dir / f"{timestamp}.ms"
+                if skip_existing and ms_path.exists():
+                    logger.info("Skipping existing MS: %s", ms_path)
+                    ms_paths.append(ms_path)
+                    continue
+
+                end_ts = (Time(timestamp, format="isot") + 2 * u.minute).isot
+                result = convert_subband_groups_to_ms(
                     input_dir=str(self.input_dir),
                     output_dir=str(self.output_dir),
                     start_time=timestamp,
                     end_time=end_ts,
-                    skip_existing=False,
+                    skip_existing=skip_existing,
                 )
 
-                # Find the created MS
-                pattern = f"{timestamp}*.ms"
-                created = sorted(
-                    self.output_dir.glob(pattern),
-                    key=lambda p: p.stat().st_mtime,
-                    reverse=True,
-                )
-                if created:
-                    ms_paths.append(created[0])
-                    logger.info("Created MS: %s", created[0])
+                for group_id in result["converted"]:
+                    actual_ms_path = self.output_dir / f"{group_id}.ms"
+                    if actual_ms_path not in ms_paths:
+                        ms_paths.append(actual_ms_path)
+                        logger.info("Conversion result MS: %s", actual_ms_path)
+
+                if skip_existing:
+                    for group_id in result["skipped"]:
+                        actual_ms_path = self.output_dir / f"{group_id}.ms"
+                        if actual_ms_path.exists() and actual_ms_path not in ms_paths:
+                            ms_paths.append(actual_ms_path)
+                            logger.info("Existing conversion result MS: %s", actual_ms_path)
 
             except Exception as exc:
-                logger.error("Failed to convert group %s: %s", timestamp, exc)
+                logger.error("Failed to convert group %r: %s", group, exc)
 
         return ms_paths
 

--- a/tests/test_calibrator_ms_generator.py
+++ b/tests/test_calibrator_ms_generator.py
@@ -143,30 +143,6 @@ class TestGenerateMultiple:
         assert convert.call_args.args[0] == [D1_GROUP]
 
 
-class TestConvertGroupsAcceptsTimestampStrings:
-    """select_groups_by_position returns timestamp strings; convert_groups must
-    treat a string group as the group timestamp, not a file list (regression:
-    it indexed the string, so Time("2", format="isot") raised ValueError and
-    auto-cal table generation always failed)."""
-
-    def test_string_group_uses_full_timestamp_window(self, generator):
-        import astropy.units as u
-
-        def fake_convert(**kwargs):
-            Path(kwargs["output_dir"], f"{kwargs['start_time']}.ms").mkdir(parents=True)
-
-        with patch(
-            "dsa110_continuum.conversion.convert_subband_groups_to_ms",
-            side_effect=fake_convert,
-        ) as conv:
-            ms_paths = generator.convert_groups([D1_GROUP])
-
-        kwargs = conv.call_args.kwargs
-        assert kwargs["start_time"] == D1_GROUP
-        assert kwargs["end_time"] == (Time(D1_GROUP, format="isot") + 2 * u.minute).isot
-        assert ms_paths == [generator.output_dir / f"{D1_GROUP}.ms"]
-
-
 class TestSiderealDayScoping:
     """Correctness criterion (analytic): in drift scan the same RA transits
     once per mean sidereal day (86164.0905 s = 1436.07 min). A positionally
@@ -264,6 +240,16 @@ class TestConvertGroupsBehavior:
 
     CONVERTER = "dsa110_continuum.conversion.convert_subband_groups_to_ms"
 
+    def test_string_group_uses_full_timestamp_window(self, generator):
+        result = {"converted": [D1_GROUP], "skipped": [], "failed": []}
+        with patch(self.CONVERTER, return_value=result) as conv:
+            ms_paths = generator.convert_groups([D1_GROUP])
+
+        kwargs = conv.call_args.kwargs
+        assert kwargs["start_time"] == D1_GROUP
+        assert kwargs["end_time"] == "2026-01-25T22:28:05.000"
+        assert ms_paths == [generator.output_dir / f"{D1_GROUP}.ms"]
+
     def test_subband_group_object_timestamp_from_sb_stem(self, generator):
         class FakeSubbandGroup:
             files = [f"/data/incoming/{D1_GROUP}_sb00.hdf5"]
@@ -293,7 +279,7 @@ class TestConvertGroupsBehavior:
             calls.append(kwargs["start_time"])
             if kwargs["start_time"] == D1_GROUP:
                 raise RuntimeError("conversion blew up")
-            Path(kwargs["output_dir"], f"{kwargs['start_time']}.ms").mkdir(parents=True)
+            return {"converted": [kwargs["start_time"]], "skipped": [], "failed": []}
 
         groups = [
             [f"/data/incoming/{D1_GROUP}_sb00.hdf5"],
@@ -304,6 +290,47 @@ class TestConvertGroupsBehavior:
 
         assert calls == [D1_GROUP, D2_GROUP]
         assert ms_paths == [generator.output_dir / f"{D2_GROUP}.ms"]
+
+    def test_unparseable_group_does_not_abort_remaining(self, generator):
+        def fake_convert(**kwargs):
+            return {"converted": [kwargs["start_time"]], "skipped": [], "failed": []}
+
+        with patch(self.CONVERTER, side_effect=fake_convert) as conv:
+            ms_paths = generator.convert_groups(["not-a-timestamp", D2_GROUP])
+
+        assert conv.call_count == 1
+        assert conv.call_args.kwargs["start_time"] == D2_GROUP
+        assert ms_paths == [generator.output_dir / f"{D2_GROUP}.ms"]
+
+    def test_uses_converter_group_id_for_ms_path(self, generator):
+        actual_group_id = "2026-01-25T22:26:06"
+        result = {"converted": [actual_group_id], "skipped": [], "failed": []}
+
+        with patch(self.CONVERTER, return_value=result):
+            ms_paths = generator.convert_groups([D1_GROUP])
+
+        assert ms_paths == [generator.output_dir / f"{actual_group_id}.ms"]
+
+    def test_uses_existing_converter_group_id_for_ms_path(self, generator):
+        actual_group_id = "2026-01-25T22:26:06"
+        actual_ms = generator.output_dir / f"{actual_group_id}.ms"
+        actual_ms.mkdir(parents=True)
+        result = {"converted": [], "skipped": [actual_group_id], "failed": []}
+
+        with patch(self.CONVERTER, return_value=result):
+            ms_paths = generator.convert_groups([D1_GROUP])
+
+        assert ms_paths == [actual_ms]
+
+    def test_does_not_return_skipped_group_when_reuse_disabled(self, generator):
+        actual_group_id = "2026-01-25T22:26:06"
+        (generator.output_dir / f"{actual_group_id}.ms").mkdir(parents=True)
+        result = {"converted": [], "skipped": [actual_group_id], "failed": []}
+
+        with patch(self.CONVERTER, return_value=result):
+            ms_paths = generator.convert_groups([D1_GROUP], skip_existing=False)
+
+        assert ms_paths == []
 
 
 class TestFailLoudPaths:


### PR DESCRIPTION
## Summary

Fixes both conversion follow-ups reported in #112:

- moves timestamp extraction and ISOT parsing inside the per-group exception boundary, so one malformed group cannot abort later conversions
- uses the authoritative `converted` and `skipped` group IDs returned by `convert_subband_groups_to_ms` instead of reconstructing output names with a selector timestamp glob
- only reuses skipped MS paths when `skip_existing=True` and the returned path exists
- consolidates timestamp-string coverage into the existing conversion behavior tests

## Root cause

`convert_groups` parsed the two-minute conversion window before its per-group `try`, so malformed timestamps escaped the isolation contract. After conversion it searched for `{selector_timestamp}*.ms`, but the core converter derives its output group ID from a separate database query; small timestamp differences could therefore create an MS that the caller silently failed to return.

## Validation

- `PYTHONPATH=/data/dsa110-continuum /opt/miniforge/envs/casa6/bin/python -m pytest tests/test_calibrator_ms_generator.py -q` — 26 passed
- `/opt/miniforge/envs/casa6/bin/python -m ruff check dsa110_continuum/conversion/calibrator_ms_generator.py tests/test_calibrator_ms_generator.py` — passed
- `python -m py_compile dsa110_continuum/conversion/calibrator_ms_generator.py` — passed
- `make test-cloud` import-migration check passed, but the local run was interrupted after `check_contimg_mentions.py` remained blocked in an H17 filesystem request during repository-wide traversal; GitHub CI should run the same gate on the clean checkout

Closes #112.