### PR TITLE
fix(calibration): fail safe on ambiguous bad-pol MS coherence

### DIFF
--- a/dsa110_continuum/calibration/flagging_bad_pols.py
+++ b/dsa110_continuum/calibration/flagging_bad_pols.py
@@ -72,6 +72,8 @@ def detect_and_flag_bad_polarizations(
         - 'total_flagged_after': Overall flagged fraction after action
         - 'action_taken': Whether any flags were applied
         - 'detection_method': 'phase_table' or 'ms_coherence'
+        - 'amplitude_imbalanced_antennas': Antennas skipped by the MS fallback
+          because their receptor amplitudes differ by at least 2x
 
     """
     import logging
@@ -87,6 +89,7 @@ def detect_and_flag_bad_polarizations(
         "total_flagged_after": 0.0,
         "action_taken": False,
         "detection_method": "unknown",
+        "amplitude_imbalanced_antennas": [],
     }
 
     # Method 1: Analyze phase calibration table if provided
@@ -298,7 +301,11 @@ def _detect_bad_pols_from_ms_coherence(
     """Detect bad polarizations from MS coherence analysis.
 
     Less reliable than calibration table analysis, but useful when no
-    calibration table is available. Uses coherence ratio between polarizations.
+    calibration table is available. Coherence is computed independently for
+    each baseline before taking the median across baselines. This avoids
+    cancellation between legitimate baseline-dependent sky phases. The fallback
+    only assigns a receptor when amplitudes agree within 2x and at least one
+    receptor has coherence of 0.5 or greater; otherwise a phase table is required.
 
     Parameters
     ----------
@@ -326,6 +333,8 @@ def _detect_bad_pols_from_ms_coherence(
 
     # Use looser coherence ratio threshold - this detection is less reliable
     coherence_ratio_threshold = 2.0  # One pol 2x less coherent
+    amplitude_ratio_threshold = 2.0
+    min_reliable_coherence = 0.5
 
     try:
         with casatables.table(ms_path, readonly=True) as tb:
@@ -336,11 +345,11 @@ def _detect_bad_pols_from_ms_coherence(
 
             ant1 = tb.getcol("ANTENNA1")
             ant2 = tb.getcol("ANTENNA2")
-            data = tb.getcol("DATA")  # shape: (n_rows, n_chan, n_pol)
+            data = tb.getcol("DATA")  # shape: (n_rows, n_pol, n_chan)
             flags = tb.getcol("FLAG")
 
             # Get number of polarizations
-            n_pol = data.shape[2]
+            n_pol = data.shape[1]
             if n_pol < 2:
                 logger.warning("MS has only one polarization, skipping bad pol detection")
                 return bad_polarizations
@@ -357,6 +366,7 @@ def _detect_bad_pols_from_ms_coherence(
                 mask = ((ant1 == ant_id) | (ant2 == ant_id)) & cross_mask
                 ant_data = data[mask]
                 ant_flags = flags[mask]
+                partners = np.where(ant1[mask] == ant_id, ant2[mask], ant1[mask])
 
                 if ant_data.size == 0:
                     continue
@@ -364,25 +374,32 @@ def _detect_bad_pols_from_ms_coherence(
                 # Compute coherence for each polarization
                 pol_stats = []
                 for pol in range(n_pol):
-                    pol_data = ant_data[:, :, pol]
-                    pol_flags = ant_flags[:, :, pol]
+                    baseline_coherences = []
+                    valid_amplitudes = []
+                    n_valid = 0
+                    for partner in np.unique(partners):
+                        baseline_mask = partners == partner
+                        pol_data = ant_data[baseline_mask, pol, :]
+                        valid_data = pol_data[~ant_flags[baseline_mask, pol, :]]
+                        amplitudes = np.abs(valid_data)
+                        nonzero = amplitudes > 0
+                        if not np.any(nonzero):
+                            continue
 
-                    # Use only unflagged data
-                    valid_mask = ~pol_flags
-                    if valid_mask.sum() == 0:
+                        unit_phasors = valid_data[nonzero] / amplitudes[nonzero]
+                        baseline_coherences.append(float(np.abs(np.mean(unit_phasors))))
+                        valid_amplitudes.append(amplitudes[nonzero])
+                        n_valid += int(nonzero.sum())
+
+                    if not baseline_coherences:
                         pol_stats.append({"coherence": 0, "n_valid": 0})
                         continue
 
-                    # Compute phase coherence: ratio of vector average to scalar average
-                    complex_data = pol_data[valid_mask]
-                    vector_avg = np.abs(np.mean(complex_data))
-                    scalar_avg = np.mean(np.abs(complex_data))
-                    coherence = vector_avg / scalar_avg if scalar_avg > 0 else 0
-
                     pol_stats.append(
                         {
-                            "coherence": float(coherence),
-                            "n_valid": int(valid_mask.sum()),
+                            "coherence": float(np.median(baseline_coherences)),
+                            "median_amplitude": float(np.median(np.concatenate(valid_amplitudes))),
+                            "n_valid": n_valid,
                         }
                     )
 
@@ -392,6 +409,32 @@ def _detect_bad_pols_from_ms_coherence(
                 if len(pol_stats) >= 2:
                     coh0 = pol_stats[0].get("coherence", 1.0)
                     coh1 = pol_stats[1].get("coherence", 1.0)
+                    amp0 = pol_stats[0].get("median_amplitude", 0.0)
+                    amp1 = pol_stats[1].get("median_amplitude", 0.0)
+
+                    min_amplitude = min(amp0, amp1)
+                    amplitude_ratio = (
+                        max(amp0, amp1) / min_amplitude if min_amplitude > 0 else np.inf
+                    )
+                    if amplitude_ratio >= amplitude_ratio_threshold:
+                        result.setdefault("amplitude_imbalanced_antennas", []).append(int(ant_id))
+                        logger.warning(
+                            "Antenna %s has %.2fx receptor amplitude imbalance; "
+                            "skipping MS-coherence labeling and requiring a phase table",
+                            ant_id,
+                            amplitude_ratio,
+                        )
+                        continue
+
+                    if max(coh0, coh1) < min_reliable_coherence:
+                        logger.debug(
+                            "Antenna %s has no reliably coherent receptor "
+                            "(XX=%.3f, YY=%.3f); skipping MS-coherence labeling",
+                            ant_id,
+                            coh0,
+                            coh1,
+                        )
+                        continue
 
                     if coh0 > 0 and coh1 > 0:
                         coh_ratio = coh0 / coh1

--- a/tests/test_bad_pol_wiring_smoke.py
+++ b/tests/test_bad_pol_wiring_smoke.py
@@ -3,17 +3,14 @@
 Generates a tiny synthetic UVH5 with a known single-polarization failure on one
 antenna, converts it to a CASA Measurement Set via pyuvdata, runs
 ``run_pre_calibration_flagging`` with ``enable_bad_pol_detection=True``, and
-asserts that detection runs end-to-end against the real CASA path: the
-injected antenna lands in the detected set and CASA ``flagdata`` calls
-persist new flags into the MS.
+asserts that detection runs end-to-end against the real CASA path and abstains
+from labeling the amplitude-imbalanced receptor without a phase table.
 
 This is the integration counterpart to the mock-based unit tests in
 ``test_run_pre_calibration_flagging.py`` and ``test_detect_bad_polarizations.py``.
 The mock tests cover the function's contract under controlled inputs; this
-smoke test proves the wiring works against real CASA tables — without
-overconstraining label conventions, since the MS-coherence detection path
-has a known pol-label ambiguity under amplitude-imbalanced injection (see
-the in-test comment and the tracked GitHub issue for follow-up).
+smoke test proves the fallback fails safe against real CASA tables under
+amplitude-imbalanced injection.
 
 Skipped by default in fast runs — opt in with ``pytest --run-slow`` (project
 ``conftest.py`` gate). Marker selection alone (``-m "slow"``) is not enough
@@ -71,7 +68,7 @@ def _inject_single_pol_failure(
 
 @pytest.mark.slow
 @pytest.mark.integration
-def test_smoke_detects_injected_antenna_and_persists_flags_through_real_ms_path(tmp_path):
+def test_smoke_skips_amplitude_imbalanced_ms_fallback(tmp_path):
     """Synthetic UVH5 with an injected single-pol failure on antenna 2 → MS
     via pyuvdata → ``run_pre_calibration_flagging`` with bad-pol detection
     enabled → real CASA ``flagdata`` calls persist new flags into the MS.
@@ -125,36 +122,16 @@ def test_smoke_detects_injected_antenna_and_persists_flags_through_real_ms_path(
     assert bad_pol_result is not None, (
         "bad-pol detection silently returned None — helper try/except swallowed an error"
     )
-    assert bad_pol_result["action_taken"] is True, (
-        "non-dry-run with detected pols should have applied flags; action_taken=False"
-    )
+    assert bad_pol_result["action_taken"] is False
     assert bad_pol_result["detection_method"] == "ms_coherence", (
         "no phase_table passed → should fall back to ms_coherence path"
     )
 
-    # 5b. The injected antenna IS in the detected set.
-    #
-    # We deliberately do NOT pin the specific pol label here. The MS-coherence
-    # detection path's pol-ratio comparison is asymmetric: when one polarisation
-    # has dramatically higher amplitude than the other (as our injection produces),
-    # the pol-ratio statistic can interpret the high-amplitude noise pol as the
-    # *good* one (high scalar_avg) relative to the truly-clean low-amplitude pol.
-    # That label inversion does not change the science contract — the bad antenna
-    # is still detected — and the per-label semantics are covered exhaustively
-    # by the mock unit tests on idealised synthetic data.
-    detected_ants = {ant_id for ant_id, _pol_idx, _pol_name in bad_pol_result["bad_polarizations"]}
-    assert bad_ant_idx in detected_ants, (
-        f"expected antenna {bad_ant_idx} (the injected one) in detected set, "
-        f"got {bad_pol_result['bad_polarizations']}"
-    )
+    # 5b. The fallback reports the ambiguous antenna without assigning a label.
+    assert bad_pol_result["bad_polarizations"] == []
+    assert bad_pol_result["amplitude_imbalanced_antennas"] == [bad_ant_idx]
 
-    # 5c. Flags STRICTLY grew — CASA flagdata calls actually persisted new
-    #     flags into the MS. With ``action_taken=True`` already asserted, the
-    #     after-fraction must be strictly greater than the before-fraction;
-    #     equality would mean flagdata fired but produced no MS-level effect.
+    # 5c. Failing safe means no receptor flags were persisted.
     before = float(bad_pol_result["total_flagged_before"])
     after = float(bad_pol_result["total_flagged_after"])
-    assert after > before, (
-        f"flag fraction did not grow: before={before:.4f}, after={after:.4f}; "
-        f"action_taken=True but no flags were persisted to the MS"
-    )
+    assert after == before

--- a/tests/test_detect_bad_polarizations.py
+++ b/tests/test_detect_bad_polarizations.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import numpy as np
-
+import pytest
 from dsa110_continuum.calibration.flagging import detect_and_flag_bad_polarizations
 
 
@@ -33,10 +33,10 @@ def _baseline_pairs(n_ant: int) -> tuple[np.ndarray, np.ndarray]:
 
 
 def _coherent_visibilities(
-    n_rows: int, n_chan: int = 4, n_pol: int = 2
+    n_rows: int, n_chan: int = 16, n_pol: int = 2
 ) -> np.ndarray:
     """Phase-aligned unit-amplitude visibilities — both pols perfectly coherent."""
-    return np.ones((n_rows, n_chan, n_pol), dtype=complex)
+    return np.ones((n_rows, n_pol, n_chan), dtype=complex)
 
 
 class _MockMSTable:
@@ -118,7 +118,7 @@ def test_one_antenna_with_decoherent_xx_pol_is_detected(tmp_path):
     ms_path = str(tmp_path / "fake.ms")
     n_ant = 8
     bad_ant = 3
-    n_chan = 4
+    n_chan = 16
 
     ant1, ant2 = _baseline_pairs(n_ant=n_ant)
     n_rows = len(ant1)
@@ -127,7 +127,7 @@ def test_one_antenna_with_decoherent_xx_pol_is_detected(tmp_path):
     rng = np.random.default_rng(seed=42)
     bad_rows_mask = (ant1 == bad_ant) | (ant2 == bad_ant)
     random_phases = rng.uniform(-np.pi, np.pi, size=(int(bad_rows_mask.sum()), n_chan))
-    data[bad_rows_mask, :, 0] = np.exp(1j * random_phases)
+    data[bad_rows_mask, 0, :] = np.exp(1j * random_phases)
 
     flags = np.zeros(data.shape, dtype=bool)
 
@@ -150,7 +150,7 @@ def test_one_antenna_with_decoherent_xx_pol_is_detected(tmp_path):
     assert result["detection_method"] == "ms_coherence"
 
 
-def _bad_xx_dataset(n_ant: int = 8, bad_ant: int = 3, n_chan: int = 4, seed: int = 42):
+def _bad_xx_dataset(n_ant: int = 8, bad_ant: int = 3, n_chan: int = 16, seed: int = 42):
     """Build the canonical 'one decoherent XX pol on bad_ant' fixture used by T2/T3."""
     ant1, ant2 = _baseline_pairs(n_ant=n_ant)
     n_rows = len(ant1)
@@ -158,7 +158,7 @@ def _bad_xx_dataset(n_ant: int = 8, bad_ant: int = 3, n_chan: int = 4, seed: int
     rng = np.random.default_rng(seed=seed)
     bad_rows_mask = (ant1 == bad_ant) | (ant2 == bad_ant)
     random_phases = rng.uniform(-np.pi, np.pi, size=(int(bad_rows_mask.sum()), n_chan))
-    data[bad_rows_mask, :, 0] = np.exp(1j * random_phases)
+    data[bad_rows_mask, 0, :] = np.exp(1j * random_phases)
     flags = np.zeros(data.shape, dtype=bool)
     return ant1, ant2, data, flags, bad_ant
 
@@ -229,7 +229,7 @@ def test_one_antenna_with_decoherent_yy_pol_is_detected(tmp_path):
     ms_path = str(tmp_path / "fake.ms")
     n_ant = 8
     bad_ant = 5
-    n_chan = 4
+    n_chan = 16
 
     ant1, ant2 = _baseline_pairs(n_ant=n_ant)
     n_rows = len(ant1)
@@ -238,7 +238,7 @@ def test_one_antenna_with_decoherent_yy_pol_is_detected(tmp_path):
     rng = np.random.default_rng(seed=7)
     bad_rows_mask = (ant1 == bad_ant) | (ant2 == bad_ant)
     random_phases = rng.uniform(-np.pi, np.pi, size=(int(bad_rows_mask.sum()), n_chan))
-    data[bad_rows_mask, :, 1] = np.exp(1j * random_phases)  # pol 1 = YY
+    data[bad_rows_mask, 1, :] = np.exp(1j * random_phases)  # pol 1 = YY
 
     flags = np.zeros(data.shape, dtype=bool)
 
@@ -256,6 +256,37 @@ def test_one_antenna_with_decoherent_yy_pol_is_detected(tmp_path):
     assert ant_id == bad_ant
     assert pol_idx == 1
     assert pol_name == "YY"
+
+
+@pytest.mark.parametrize("amplitude_ratio", [2.0, 3.0, 10.0])
+def test_baseline_coherence_preserves_bad_pol_label_with_amplitude_imbalance(
+    tmp_path, amplitude_ratio
+):
+    """Amplitude-imbalanced MS fallback must abstain instead of inverting labels."""
+    ms_path = str(tmp_path / "fake.ms")
+    n_ant = 8
+    bad_ant = 3
+    n_chan = 64
+    ant1, ant2 = _baseline_pairs(n_ant=n_ant)
+    bad_rows = (ant1 == bad_ant) | (ant2 == bad_ant)
+
+    rng = np.random.default_rng(seed=28)
+    baseline_phases = rng.uniform(-np.pi, np.pi, size=len(ant1))
+    data = np.exp(1j * baseline_phases[:, None, None]) * np.ones(
+        (len(ant1), 2, n_chan), dtype=complex
+    )
+    random_phases = rng.uniform(-np.pi, np.pi, size=(int(bad_rows.sum()), n_chan))
+    data[bad_rows, 0, :] = amplitude_ratio * np.exp(1j * random_phases)
+    flags = np.zeros(data.shape, dtype=bool)
+
+    with _patch_ms_table(ant1, ant2, data, flags), patch(
+        "dsa110_continuum.calibration.flagging.flag_summary",
+        return_value={"total_fraction_flagged": 0.0},
+    ):
+        result = detect_and_flag_bad_polarizations(ms_path, dry_run=True, phase_table=None)
+
+    assert result["bad_polarizations"] == []
+    assert result["amplitude_imbalanced_antennas"] == [bad_ant]
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The MS-coherence fallback for single-polarization failure detection could assign the clean receptor label under amplitude-imbalanced failures. Real-MS validation showed two contributing problems:

1. `casa_tables` returns visibility cells as `(rows, correlations, channels)`, but the fallback treated them as `(rows, channels, correlations)`, so frequency channels were being analyzed as polarization indices.
2. A raw coherence ratio is not reliable when receptor amplitudes differ substantially or both receptors have very low absolute coherence.

This change corrects the axis handling, computes phase coherence per baseline, and makes the fallback abstain when it cannot safely label a receptor. The phase-table path remains the required method for amplitude-imbalanced antennas.

## Changes

- Read the real MS layout as `(n_rows, n_pol, n_chan)`.
- Compute unit-phasor coherence per baseline and use the median across baselines.
- Record median receptor amplitudes and skip MS labeling at a 2x or greater amplitude ratio.
- Require at least one receptor to reach 0.5 coherence before applying a ratio-based label.
- Return `amplitude_imbalanced_antennas` so callers can identify antennas requiring phase-table analysis.
- Update mocks to use CASA's real axis order and add 2x, 3x, and 10x imbalance regressions.
- Convert the real-MS smoke test from label-agnostic flagging to a fail-safe no-flag assertion.

## Validation

- `tests/test_detect_bad_polarizations.py tests/test_run_pre_calibration_flagging.py`: 17 passed.
- `tests/test_bad_pol_wiring_smoke.py --run-slow`: 1 passed against a generated UVH5 converted to a real CASA MS.
- `ruff check` on the three changed files: passed.
- Targeted `git diff --check`: passed.

Closes #73.
