### PR TITLE
Canonical forced-phot CSV contract + photometry sanity gates (#133, #134)

### DIFF
--- a/docs/reference/photometry-and-ese.md
+++ b/docs/reference/photometry-and-ese.md
@@ -174,3 +174,37 @@ Catalog coverage limits:
 Sky model seeding (skymodels.py):
   make_unified_wsclean_list(center_ra, center_dec, radius_deg, min_mjy=2.0, freq_ghz=1.4)
   Source priority: FIRST > RACS > NVSS
+
+## Forced-photometry CSV contract (photometry/phot_csv.py; issues #133, #134)
+
+Canonical columns for `{date}T{HH}00_forced_phot.csv` products, in order:
+
+  source_id, ra_deg, dec_deg, flux_jy, flux_err_jy,
+  nvss_flux_jy, dsa_nvss_ratio, snr
+
+Extra columns (coarse_snr, passed_coarse, spectral_index, injected_flux_jy,
+...) are preserved after the canonical block. `nvss_flux_jy` /
+`dsa_nvss_ratio` are historical names kept for consumer compatibility — the
+reference flux is whatever catalog forced photometry ran against (usually
+master).
+
+Historical schema drift (2026-07 H17 audit) — two legacy schemas exist in
+archived products and are mapped by `normalize_phot_rows` /
+`read_forced_phot_csv` via `COLUMN_ALIASES`:
+
+  source_name       -> source_id
+  measured_flux_jy  -> flux_jy      dsa_peak_jyb      -> flux_jy
+  dsa_peak_err_jyb  -> flux_err_jy  catalog_flux_jy   -> nvss_flux_jy
+  flux_ratio        -> dsa_nvss_ratio                 ratio -> dsa_nvss_ratio
+
+Writers MUST go through `write_forced_phot_csv` (the only sanctioned writer;
+`scripts/forced_photometry.py` does). It applies the per-measurement flux
+sanity gate: rows with non-finite flux or |flux_jy| > MAX_ABS_FLUX_JY
+(5000 Jy — brightest possible field source is Cas A at ~1.7 kJy) are dropped
+and reported. Motivating incident: a 297 kJy artifact row in
+2026-02-15T0000_forced_phot.csv ranked as the top variable source.
+
+Epoch-level gate: an epoch CSV with fewer than MIN_EPOCH_MEASUREMENTS (10;
+operator override `--min-phot-sources`) recovered measurements records a
+`phot_min_measurements` FAIL gate in the run manifest, degrading the pipeline
+verdict (batch_pipeline.py).

--- a/dsa110_continuum/photometry/phot_csv.py
+++ b/dsa110_continuum/photometry/phot_csv.py
@@ -1,0 +1,186 @@
+"""Canonical forced-photometry CSV contract (issues #133, #134).
+
+One column contract, one writer, one normalizing reader for the per-epoch
+``{date}T{HH}00_forced_phot.csv`` products. Three writer schemas exist in the
+wild (2026-07 audit of ``/data/dsa110-proc/products/mosaics`` on H17):
+
+1. ``source_id`` + ``flux_jy``/``flux_err_jy``            (canonical, below)
+2. ``source_id`` + ``dsa_peak_jyb``/``dsa_peak_err_jyb``  (legacy)
+3. ``source_name`` + ``measured_flux_jy``/``flux_err_jy`` (scripts/forced_photometry.py)
+
+``normalize_phot_rows`` maps all of them onto the canonical contract so
+consumers can stop alias-sniffing; ``write_forced_phot_csv`` is the single
+writer and applies the per-measurement flux sanity gate (#134).
+
+See ``docs/reference/photometry-and-ese.md`` (Forced-photometry CSV contract)
+for the rationale and threshold provenance.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+#: Canonical column contract. Extra columns are preserved after these.
+CANONICAL_COLUMNS: list[str] = [
+    "source_id",
+    "ra_deg",
+    "dec_deg",
+    "flux_jy",
+    "flux_err_jy",
+    "nvss_flux_jy",
+    "dsa_nvss_ratio",
+    "snr",
+]
+
+#: Alias -> canonical. Applied only when the canonical column is absent.
+COLUMN_ALIASES: dict[str, str] = {
+    "source_name": "source_id",
+    "measured_flux_jy": "flux_jy",
+    "dsa_peak_jyb": "flux_jy",
+    "dsa_peak_err_jyb": "flux_err_jy",
+    "catalog_flux_jy": "nvss_flux_jy",
+    "flux_ratio": "dsa_nvss_ratio",
+    "ratio": "dsa_nvss_ratio",
+}
+
+#: Columns coerced to numeric during normalization ("" -> NaN).
+_NUMERIC_COLUMNS = (
+    "ra_deg",
+    "dec_deg",
+    "flux_jy",
+    "flux_err_jy",
+    "nvss_flux_jy",
+    "dsa_nvss_ratio",
+    "snr",
+)
+
+#: Per-measurement sanity bound (#134). The brightest source that can appear
+#: in a DSA-110 field is Cas A at ~1.7 kJy; anything beyond this is a
+#: measurement artifact, not astrophysics.
+MAX_ABS_FLUX_JY: float = 5000.0
+
+#: Minimum measurements for an epoch phot CSV to count as a science product
+#: (#134). A near-empty CSV means photometry effectively failed even if the
+#: process exited cleanly.
+MIN_EPOCH_MEASUREMENTS: int = 10
+
+
+def normalize_phot_rows(rows: Any) -> pd.DataFrame:
+    """Return *rows* (records list or DataFrame) under the canonical contract.
+
+    Aliases are renamed only where the canonical column is missing; unknown
+    columns are preserved. Numeric canonical columns are coerced (empty
+    strings become NaN). Raises ``ValueError`` if no flux column can be found.
+    """
+    df = rows.copy() if isinstance(rows, pd.DataFrame) else pd.DataFrame(list(rows))
+    renames = {
+        alias: canon
+        for alias, canon in COLUMN_ALIASES.items()
+        if alias in df.columns and canon not in df.columns
+    }
+    df = df.rename(columns=renames)
+    if "flux_jy" not in df.columns:
+        raise ValueError(
+            f"No flux column found (columns={list(df.columns)}); "
+            f"expected one of: flux_jy, {', '.join(a for a, c in COLUMN_ALIASES.items() if c == 'flux_jy')}"
+        )
+    for col in _NUMERIC_COLUMNS:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+    ordered = [c for c in CANONICAL_COLUMNS if c in df.columns]
+    extras = [c for c in df.columns if c not in ordered]
+    return df[ordered + extras]
+
+
+def apply_flux_sanity_gate(
+    df: pd.DataFrame,
+    max_abs_flux_jy: float = MAX_ABS_FLUX_JY,
+) -> tuple[pd.DataFrame, list[str]]:
+    """Drop physically impossible measurements; return ``(clean, reasons)``.
+
+    Rejects rows whose ``flux_jy`` is non-finite or exceeds
+    *max_abs_flux_jy* in magnitude. One human-readable reason per rejected
+    row (capped at 20) is returned for gate/manifest logging.
+    """
+    flux = df["flux_jy"]
+    finite = np.isfinite(flux)
+    in_bounds = finite & (flux.abs() <= max_abs_flux_jy)
+    reasons: list[str] = []
+    for _, row in df[~in_bounds].head(20).iterrows():
+        sid = row.get("source_id", "?")
+        val = row["flux_jy"]
+        why = (
+            "non-finite flux"
+            if not np.isfinite(val)
+            else (f"|flux| {val:.6g} Jy > {max_abs_flux_jy:.6g} Jy bound")
+        )
+        reasons.append(f"{sid}: {why}")
+    n_dropped = int((~in_bounds).sum())
+    if n_dropped > len(reasons):
+        reasons.append(f"... and {n_dropped - len(reasons)} more")
+    return df[in_bounds].copy(), reasons
+
+
+def check_min_measurements(
+    n_measurements: int,
+    minimum: int = MIN_EPOCH_MEASUREMENTS,
+) -> tuple[bool, str]:
+    """Return ``(ok, reason)`` for the epoch-level minimum-recovery gate."""
+    if n_measurements >= minimum:
+        return True, ""
+    return False, (
+        f"only {n_measurements} forced-photometry measurement(s) "
+        f"(< {minimum} required for a science product)"
+    )
+
+
+def write_forced_phot_csv(
+    rows: Any,
+    path: str | Path,
+    max_abs_flux_jy: float = MAX_ABS_FLUX_JY,
+) -> dict:
+    """Normalize, sanity-gate, and write a forced-photometry CSV.
+
+    The single sanctioned writer for ``*_forced_phot.csv`` products.
+
+    Returns
+    -------
+    dict
+        ``n_written``, ``n_rejected``, ``rejected_reasons`` (list[str]),
+        ``median_ratio`` (float, NaN when no ratios), ``path``.
+    """
+    df = normalize_phot_rows(rows)
+    clean, reasons = apply_flux_sanity_gate(df, max_abs_flux_jy=max_abs_flux_jy)
+    n_rejected = len(df) - len(clean)
+    if n_rejected:
+        log.warning(
+            "Flux sanity gate rejected %d/%d measurement(s) for %s: %s",
+            n_rejected,
+            len(df),
+            path,
+            "; ".join(reasons[:5]),
+        )
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    clean.to_csv(out, index=False)
+    ratios = clean["dsa_nvss_ratio"].dropna() if "dsa_nvss_ratio" in clean.columns else []
+    median_ratio = float(np.median(ratios)) if len(ratios) else float("nan")
+    return {
+        "n_written": int(len(clean)),
+        "n_rejected": int(n_rejected),
+        "rejected_reasons": reasons,
+        "median_ratio": median_ratio,
+        "path": str(out),
+    }
+
+
+def read_forced_phot_csv(path: str | Path) -> pd.DataFrame:
+    """Read any historical or canonical forced-phot CSV, normalized."""
+    return normalize_phot_rows(pd.read_csv(path))

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -60,6 +60,10 @@ from astropy.io import fits
 from astropy.wcs import WCS
 from dsa110_continuum.photometry.epoch_qa import EpochQAResult, measure_epoch_qa
 from dsa110_continuum.photometry.epoch_qa_plot import plot_epoch_qa
+from dsa110_continuum.photometry.phot_csv import (
+    MIN_EPOCH_MEASUREMENTS,
+    check_min_measurements,
+)
 from dsa110_continuum.qa.provenance import RunManifest, try_load_prior_manifest
 
 logging.basicConfig(
@@ -1418,6 +1422,18 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--min-phot-sources",
+        type=int,
+        default=MIN_EPOCH_MEASUREMENTS,
+        metavar="N",
+        help=(
+            "Minimum forced-photometry measurements for an epoch CSV to count "
+            f"as a science product (default: {MIN_EPOCH_MEASUREMENTS}). Below "
+            "this a phot_min_measurements gate is recorded and the run verdict "
+            "degrades (issue #134)."
+        ),
+    )
+    parser.add_argument(
         "--photometry-chunk-size",
         type=int,
         default=0,
@@ -2138,6 +2154,30 @@ def main() -> None:
                 median_ratio = phot_result["median_ratio"]
                 if np.isfinite(median_ratio):
                     log.info("  Median DSA/Cat ratio: %.3f  (%d sources)", median_ratio, n_sources)
+                # ── Photometry product gates (#134) ──────────────────────────
+                n_flux_rejected = phot_result.get("n_flux_rejected", 0)
+                if n_flux_rejected:
+                    manifest.add_gate(
+                        gate="phot_flux_sanity",
+                        verdict="REJECTED_ROWS",
+                        reason=(
+                            f"{n_flux_rejected} unphysical measurement(s) dropped "
+                            f"for epoch {label}: "
+                            + "; ".join(phot_result.get("flux_rejected_reasons", [])[:3])
+                        ),
+                        epoch_label=label,
+                    )
+                min_ok, min_reason = check_min_measurements(
+                    n_sources, minimum=args.min_phot_sources
+                )
+                if not min_ok:
+                    log.warning("  Photometry gate: %s (epoch %s)", min_reason, label)
+                    manifest.add_gate(
+                        gate="phot_min_measurements",
+                        verdict="FAIL",
+                        reason=f"epoch {label}: {min_reason}",
+                        epoch_label=label,
+                    )
             except Exception as e:
                 log.error("  Forced photometry failed for epoch %s: %s", label, e)
                 manifest.add_gate(

--- a/scripts/forced_photometry.py
+++ b/scripts/forced_photometry.py
@@ -121,7 +121,11 @@ def run_forced_photometry(
     Returns
     -------
     dict
-        ``{"n_sources": int, "median_ratio": float, "csv_path": str}``
+        ``n_sources`` (measurements written, post sanity gate),
+        ``n_flux_rejected`` + ``flux_rejected_reasons`` (per-measurement
+        sanity gate, issue #134), ``median_ratio``, ``csv_path``, and the
+        noise-floor QA fields. The CSV follows the canonical contract in
+        ``dsa110_continuum.photometry.phot_csv`` (issue #133).
     """
     if not Path(mosaic_path).exists():
         raise FileNotFoundError(f"Mosaic not found: {mosaic_path}")
@@ -323,12 +327,18 @@ def run_forced_photometry(
     # gate and is the single sanctioned *_forced_phot.csv writer.
     from dsa110_continuum.photometry.phot_csv import write_forced_phot_csv
 
-    write_stats = write_forced_phot_csv(rows, out_csv) if rows else {
-        "n_written": 0, "n_rejected": 0, "rejected_reasons": [],
-        "median_ratio": float("nan"), "path": str(out_csv),
-    }
-    if not rows:
-        Path(out_csv).write_text("")  # sim_mode may legitimately measure nothing
+    if rows:
+        write_stats = write_forced_phot_csv(rows, out_csv)
+    else:
+        # sim_mode may legitimately measure nothing; keep a header-only
+        # canonical CSV so downstream readers see the contract, not EOF.
+        from dsa110_continuum.photometry.phot_csv import CANONICAL_COLUMNS
+
+        Path(out_csv).write_text(",".join(CANONICAL_COLUMNS) + "\n")
+        write_stats = {
+            "n_written": 0, "n_rejected": 0, "rejected_reasons": [],
+            "median_ratio": float("nan"), "path": str(out_csv),
+        }
     n_written = write_stats["n_written"]
     n_flux_rejected = write_stats["n_rejected"]
 

--- a/scripts/forced_photometry.py
+++ b/scripts/forced_photometry.py
@@ -13,7 +13,7 @@ Usage:
     python scripts/forced_photometry.py --mosaic /path/to/mosaic.fits --method simple_peak --sim
     python scripts/forced_photometry.py --mosaic /path/to/mosaic.fits --method two_stage --sim --snr-coarse 0.0
 """
-import csv
+
 import logging
 import sys
 from pathlib import Path
@@ -316,36 +316,21 @@ def run_forced_photometry(
     if not rows and not sim_mode:
         raise RuntimeError("No rows to write — forced photometry failed")
 
-    # ── Write CSV ──────────────────────────────────────────────────────────────
-    if method == "simple_peak":
-        base_fields = ["source_name", "ra_deg", "dec_deg", "measured_flux_jy", "snr"]
-        if sim_mode:
-            base_fields.insert(3, "injected_flux_jy")
-        elif not sim_mode:
-            base_fields.insert(3, "catalog_flux_jy")
-        fieldnames = base_fields
+    # ── Write CSV via the canonical contract (issues #133/#134) ───────────────
+    # normalize_phot_rows maps the legacy row fields (source_name,
+    # measured_flux_jy, catalog_flux_jy, flux_ratio, ...) onto the canonical
+    # schema; write_forced_phot_csv applies the per-measurement flux sanity
+    # gate and is the single sanctioned *_forced_phot.csv writer.
+    from dsa110_continuum.photometry.phot_csv import write_forced_phot_csv
 
-    elif method == "two_stage":
-        ref_field = "injected_flux_jy" if sim_mode else "catalog_flux_jy"
-        fieldnames = [
-            "source_name", "ra_deg", "dec_deg",
-            ref_field, "measured_flux_jy", "flux_err_jy",
-            "flux_ratio", "snr", "coarse_snr", "passed_coarse",
-        ]
-
-    else:  # condon
-        fieldnames = [
-            "source_name", "ra_deg", "dec_deg",
-            "catalog_flux_jy", "measured_flux_jy", "flux_err_jy",
-            "flux_ratio", "snr",
-        ]
-        if actual_catalog == "master":
-            fieldnames.append("spectral_index")
-
-    with open(out_csv, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames, extrasaction="ignore")
-        writer.writeheader()
-        writer.writerows(rows)
+    write_stats = write_forced_phot_csv(rows, out_csv) if rows else {
+        "n_written": 0, "n_rejected": 0, "rejected_reasons": [],
+        "median_ratio": float("nan"), "path": str(out_csv),
+    }
+    if not rows:
+        Path(out_csv).write_text("")  # sim_mode may legitimately measure nothing
+    n_written = write_stats["n_written"]
+    n_flux_rejected = write_stats["n_rejected"]
 
     # ── QA summary ─────────────────────────────────────────────────────────────
     valid_ratios = []
@@ -354,10 +339,15 @@ def run_forced_photometry(
             float(r["flux_ratio"]) for r in rows
             if r.get("flux_ratio", "") != "" and np.isfinite(float(r["flux_ratio"]))
         ]
-    median_ratio = float(np.median(valid_ratios)) if valid_ratios else float("nan")
+    median_ratio = write_stats["median_ratio"]
+    if not np.isfinite(median_ratio) and valid_ratios:
+        median_ratio = float(np.median(valid_ratios))
 
     log.info("\n=== Forced Photometry QA ===")
-    log.info("Catalog: %s | Sources measured: %d", actual_catalog, len(rows))
+    log.info(
+        "Catalog: %s | Sources measured: %d (written: %d, sanity-rejected: %d)",
+        actual_catalog, len(rows), n_written, n_flux_rejected,
+    )
     if method != "simple_peak" and valid_ratios:
         log.info("Flux ratio (DSA/catalog): median=%.3f, std=%.3f", median_ratio, np.std(valid_ratios))
         log.info("Ratio range: %.3f – %.3f", min(valid_ratios), max(valid_ratios))
@@ -429,7 +419,9 @@ def run_forced_photometry(
         log.debug("Epoch QA log skipped: %s", exc)
 
     return {
-        "n_sources": len(rows),
+        "n_sources": n_written,
+        "n_flux_rejected": n_flux_rejected,
+        "flux_rejected_reasons": write_stats["rejected_reasons"],
         "median_ratio": median_ratio,
         "csv_path": out_csv,
         "rms_mjy": round(_rms_mjy, 3) if np.isfinite(_rms_mjy) else float("nan"),

--- a/tests/test_phot_csv.py
+++ b/tests/test_phot_csv.py
@@ -1,0 +1,176 @@
+"""Tests for the canonical forced-photometry CSV contract (issues #133, #134).
+
+Pure numpy/pandas + tmp_path; no FITS, no CASA, no telescope paths.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from dsa110_continuum.photometry.phot_csv import (
+    CANONICAL_COLUMNS,
+    MAX_ABS_FLUX_JY,
+    MIN_EPOCH_MEASUREMENTS,
+    apply_flux_sanity_gate,
+    check_min_measurements,
+    normalize_phot_rows,
+    read_forced_phot_csv,
+    write_forced_phot_csv,
+)
+
+
+def test_normalize_canonical_passthrough():
+    df = normalize_phot_rows(
+        [
+            {
+                "source_id": "S1",
+                "ra_deg": 150.0,
+                "dec_deg": 16.1,
+                "flux_jy": 0.5,
+                "flux_err_jy": 0.01,
+                "nvss_flux_jy": 0.5,
+                "dsa_nvss_ratio": 1.0,
+                "snr": 50.0,
+            }
+        ]
+    )
+    assert list(df.columns) == CANONICAL_COLUMNS
+    assert df.iloc[0]["flux_jy"] == 0.5
+
+
+def test_normalize_two_stage_writer_schema():
+    # schema 3: scripts/forced_photometry.py two_stage rows ("" for missing)
+    df = normalize_phot_rows(
+        [
+            {
+                "source_name": "J150.0+16.1",
+                "ra_deg": 150.0,
+                "dec_deg": 16.1,
+                "catalog_flux_jy": 0.4,
+                "measured_flux_jy": 0.42,
+                "flux_err_jy": "",
+                "flux_ratio": 1.05,
+                "snr": 21.0,
+                "coarse_snr": 5.0,
+                "passed_coarse": True,
+            }
+        ]
+    )
+    assert df.iloc[0]["source_id"] == "J150.0+16.1"
+    assert df.iloc[0]["flux_jy"] == 0.42
+    assert np.isnan(df.iloc[0]["flux_err_jy"])  # "" coerced to NaN
+    assert df.iloc[0]["nvss_flux_jy"] == 0.4
+    assert df.iloc[0]["dsa_nvss_ratio"] == 1.05
+    assert "coarse_snr" in df.columns  # extras preserved
+    assert list(df.columns)[: len(CANONICAL_COLUMNS)] == CANONICAL_COLUMNS
+
+
+def test_normalize_legacy_peak_schema():
+    # schema 2: dsa_peak_jyb + source_id (historical products)
+    df = normalize_phot_rows(
+        pd.DataFrame(
+            {
+                "source_id": ["1"],
+                "ra_deg": [31.2],
+                "dec_deg": [15.2],
+                "nvss_flux_jy": [4.07],
+                "dsa_peak_jyb": [3.9],
+                "dsa_peak_err_jyb": [0.05],
+                "dsa_nvss_ratio": [0.96],
+            }
+        )
+    )
+    assert df.iloc[0]["flux_jy"] == 3.9
+    assert df.iloc[0]["flux_err_jy"] == 0.05
+
+
+def test_normalize_never_clobbers_canonical():
+    # if both flux_jy and an alias exist, canonical wins
+    df = normalize_phot_rows(
+        [
+            {
+                "source_id": "S1",
+                "ra_deg": 1.0,
+                "dec_deg": 2.0,
+                "flux_jy": 0.7,
+                "measured_flux_jy": 99.0,
+            }
+        ]
+    )
+    assert df.iloc[0]["flux_jy"] == 0.7
+    assert df.iloc[0]["measured_flux_jy"] == 99.0  # kept as extra
+
+
+def test_normalize_requires_a_flux_column():
+    with pytest.raises(ValueError, match="No flux column"):
+        normalize_phot_rows([{"source_id": "S1", "ra_deg": 1.0, "dec_deg": 2.0}])
+
+
+def test_flux_sanity_gate_drops_junk_row():
+    # the motivating incident: a 297 kJy artifact (issue #134)
+    df = normalize_phot_rows(
+        [
+            {"source_id": "junk", "ra_deg": 1.0, "dec_deg": 2.0, "flux_jy": 297000.0},
+            {"source_id": "casA-scale", "ra_deg": 1.0, "dec_deg": 2.0, "flux_jy": 1700.0},
+            {"source_id": "nanrow", "ra_deg": 1.0, "dec_deg": 2.0, "flux_jy": float("nan")},
+            {"source_id": "ok", "ra_deg": 1.0, "dec_deg": 2.0, "flux_jy": 0.5},
+        ]
+    )
+    clean, reasons = apply_flux_sanity_gate(df)
+    assert list(clean["source_id"]) == ["casA-scale", "ok"]
+    assert len(reasons) == 2
+    assert any("junk" in r and "bound" in r for r in reasons)
+    assert any("nanrow" in r and "non-finite" in r for r in reasons)
+
+
+def test_min_measurements_gate():
+    ok, reason = check_min_measurements(MIN_EPOCH_MEASUREMENTS)
+    assert ok and reason == ""
+    ok, reason = check_min_measurements(1)
+    assert not ok and "1" in reason
+    ok, reason = check_min_measurements(1, minimum=1)
+    assert ok
+
+
+def test_writer_roundtrip_and_stats(tmp_path):
+    rows = [
+        {
+            "source_name": f"J{i}",
+            "ra_deg": float(i),
+            "dec_deg": 16.0,
+            "catalog_flux_jy": 0.5,
+            "measured_flux_jy": 0.5,
+            "flux_err_jy": 0.01,
+            "flux_ratio": 1.0,
+            "snr": 50.0,
+        }
+        for i in range(12)
+    ]
+    rows.append(
+        {
+            "source_name": "Jjunk",
+            "ra_deg": 0.0,
+            "dec_deg": 16.0,
+            "catalog_flux_jy": 0.5,
+            "measured_flux_jy": 297000.0,
+            "flux_err_jy": 0.01,
+            "flux_ratio": 594000.0,
+            "snr": 9e9,
+        }
+    )
+    out = tmp_path / "e_forced_phot.csv"
+    stats = write_forced_phot_csv(rows, out)
+    assert stats["n_written"] == 12
+    assert stats["n_rejected"] == 1
+    assert stats["median_ratio"] == pytest.approx(1.0)
+    back = read_forced_phot_csv(out)
+    assert len(back) == 12
+    assert list(back.columns)[: len(CANONICAL_COLUMNS)] == CANONICAL_COLUMNS
+    assert "Jjunk" not in set(back["source_id"])
+
+
+def test_writer_respects_custom_bound(tmp_path):
+    rows = [{"source_id": "S", "ra_deg": 0.0, "dec_deg": 0.0, "flux_jy": 10.0}]
+    out = tmp_path / "x_forced_phot.csv"
+    stats = write_forced_phot_csv(rows, out, max_abs_flux_jy=5.0)
+    assert stats["n_written"] == 0 and stats["n_rejected"] == 1
+    assert MAX_ABS_FLUX_JY > 5.0  # default untouched

--- a/tests/test_two_stage_photometry.py
+++ b/tests/test_two_stage_photometry.py
@@ -342,7 +342,9 @@ def test_cli_simple_peak_sim_produces_csv(tmp_path):
     with open(out_csv) as f:
         rows = list(_csv.DictReader(f))
     assert len(rows) > 0
-    assert "measured_flux_jy" in rows[0]
+    # canonical contract (photometry/phot_csv.py, #133): measured_flux_jy is
+    # normalized to flux_jy on write; extras like injected_flux_jy survive.
+    assert "flux_jy" in rows[0]
     assert "snr" in rows[0]
     assert "injected_flux_jy" in rows[0]
 


### PR DESCRIPTION
Closes #133. Closes #134.

## What

**`dsa110_continuum/photometry/phot_csv.py` (new)** — the forced-photometry CSV contract:
- canonical columns `source_id, ra_deg, dec_deg, flux_jy, flux_err_jy, nvss_flux_jy, dsa_nvss_ratio, snr` (extras preserved after; `nvss_*` names kept for consumer compatibility)
- `normalize_phot_rows` / `read_forced_phot_csv` map the two legacy schemas found in archived H17 products (`dsa_peak_jyb`+`source_id`, `measured_flux_jy`+`source_name`) onto the contract — aliases apply only when the canonical column is absent
- `write_forced_phot_csv` — the single sanctioned writer; applies the per-measurement flux sanity gate (drop non-finite or |flux| > 5 kJy; brightest possible field source is Cas A at ~1.7 kJy) and reports what it dropped

**`scripts/forced_photometry.py`** — all three methods (two_stage / simple_peak / condon) now write through the shared writer; returns `n_flux_rejected` + reasons. New CSVs are canonical from now on.

**`scripts/batch_pipeline.py`** — two new manifest gates after per-epoch photometry, both degrading the run verdict via the existing `RunManifest` machinery:
- `phot_flux_sanity` (REJECTED_ROWS) when measurements were dropped
- `phot_min_measurements` (FAIL) when fewer than `--min-phot-sources` (default 10) survive — a 1-row CSV no longer passes silently

**`docs/reference/photometry-and-ese.md`** — contract, alias table, threshold provenance.

## Motivation

A 297,000 Jy artifact row in `2026-02-15T0000_forced_phot.csv` (a single-row CSV) passed every gate and ranked as the top variable source in the pipeline console's eta table. Separately, three writer schemas in the wild force every consumer to alias-sniff and break cross-epoch source joins (#133 audit).

## Testing

- 9 new tests (`tests/test_phot_csv.py`): all three schema normalizations, canonical-wins-over-alias, flux sanity gate (297 kJy + NaN rejected, Cas A-scale kept), min-measurements gate, writer round-trip + custom bound.
- Affected suites (`test_two_stage_photometry`, `test_forced_photometry_parallel`, `test_batch_e1_hygiene`, `test_epoch_log`, `test_variability_metrics`, `test_lightcurves`): 99 passed; the 5 failures are identical on pristine `main` (py3.10-only `datetime.UTC` / `caskade` imports — env artifacts, verified against a baseline worktree).
- ruff: new files clean; touched scripts carry the same pre-existing violation set as `main` (no new violations).
- `batch_pipeline.py --help` exposes `--min-phot-sources`; import chain verified.

## Operational follow-up (not in this PR)

Quarantine/regenerate `2026-02-15T0000_forced_phot.csv` on H17 — after this merges, a re-run rewrites it canonically and the junk row is dropped at write time.
