### PR TITLE
Fix epoch gaincal calibrator tile selection

### DIFF
--- a/dsa110_continuum/calibration/epoch_gaincal.py
+++ b/dsa110_continuum/calibration/epoch_gaincal.py
@@ -3,7 +3,7 @@
 Public API
 ----------
 select_calibration_tile_from_ms(epoch_ms_paths) -> str
-    Return the MS path (from the two central tiles) with the most catalog sources.
+    Return the epoch MS with the strongest catalog calibration target.
 
 calibrate_epoch(epoch_ms_paths, bp_table, work_dir, ...) -> EpochGaincalResult
     Full 5-step catalog-bootstrap + self-cal gain solve. Returns a structured
@@ -25,13 +25,13 @@ from pathlib import Path
 
 import numpy as np
 from dsa110_continuum.calibration.applycal import apply_to_target
+from dsa110_continuum.calibration.field_directions import (
+    extract_field_ra_dec as _extract_field_ra_dec,
+)
 from dsa110_continuum.calibration.model import count_bright_sources_in_tile
 from dsa110_continuum.calibration.mosaic_constants import (
     SKYMODEL_MIN_FLUX_MJY,
     SOURCE_QUERY_RADIUS_DEG,
-)
-from dsa110_continuum.calibration.field_directions import (
-    extract_field_ra_dec as _extract_field_ra_dec,
 )
 from dsa110_continuum.calibration.runner import phaseshift_ms
 from dsa110_continuum.calibration.skymodels import (
@@ -112,18 +112,44 @@ def _read_ms_phase_center(ms_path: str) -> tuple[float, float]:
     return median_ra, median_dec
 
 
+def _find_vla_calibrator_in_ms(
+    ms_path: str,
+    *,
+    search_radius_deg: float,
+) -> tuple[str, float, float]:
+    """Return ``(name, flux_jy, separation_deg)`` for the best VLA calibrator."""
+    from dsa110_continuum.calibration.selection import select_bandpass_from_catalog
+
+    _, _, _, cal_info, _ = select_bandpass_from_catalog(
+        ms_path,
+        search_radius_deg=search_radius_deg,
+    )
+    name, cal_ra_deg, cal_dec_deg, flux_jy = cal_info
+    tile_ra_deg, tile_dec_deg = _read_ms_phase_center(ms_path)
+    tile_ra = np.radians(tile_ra_deg)
+    tile_dec = np.radians(tile_dec_deg)
+    cal_ra = np.radians(cal_ra_deg)
+    cal_dec = np.radians(cal_dec_deg)
+    cos_sep = (
+        np.sin(tile_dec) * np.sin(cal_dec)
+        + np.cos(tile_dec) * np.cos(cal_dec) * np.cos(tile_ra - cal_ra)
+    )
+    separation_deg = float(np.degrees(np.arccos(np.clip(cos_sep, -1.0, 1.0))))
+    return str(name), float(flux_jy), separation_deg
+
+
 def select_calibration_tile_from_ms(
     epoch_ms_paths: list[str],
     *,
     min_flux_mjy: float = SKYMODEL_MIN_FLUX_MJY,
     source_radius_deg: float = SOURCE_QUERY_RADIUS_DEG,
 ) -> str:
-    """Return the central tile MS with the most bright catalog sources.
+    """Return the epoch MS with the strongest catalog calibration target.
 
-    Checks the two tiles nearest the centre of the sorted list and returns
-    the MS path whose pointing has more catalog sources above *min_flux_mjy*
-    within *source_radius_deg*.  Optimised for MOSAIC_TILE_COUNT (12) tiles
-    but gracefully handles any count >= 2.
+    All tiles are checked for VLA calibrators first. The highest-flux match
+    wins, with angular proximity to the tile midpoint as the tiebreaker. If
+    the VLA catalog is unavailable or no calibrator is present, all tiles are
+    ranked by their bright-source counts.
 
     Parameters
     ----------
@@ -148,37 +174,74 @@ def select_calibration_tile_from_ms(
     if n < 2:
         raise ValueError(f"Need at least 2 MS paths for tile selection, got {n}")
 
-    # Pick the two tiles nearest the centre of the list
-    mid = n // 2
-    center_indices = [mid - 1, mid]
+    calibrator_search_radius_deg = max(1.0, source_radius_deg)
+    best_calibrator_ms: str | None = None
+    best_calibrator_score: tuple[float, float] | None = None
+
+    for idx, ms in enumerate(epoch_ms_paths):
+        try:
+            name, flux_jy, separation_deg = _find_vla_calibrator_in_ms(
+                ms,
+                search_radius_deg=calibrator_search_radius_deg,
+            )
+        except (
+            FileNotFoundError,
+            KeyError,
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            log.debug("No VLA calibrator match for tile %d (%s): %s", idx, ms, exc)
+            continue
+
+        score = (flux_jy, -separation_deg)
+        log.info(
+            "Tile %d (%s): VLA calibrator %s, %.2f Jy, %.3f deg from midpoint",
+            idx,
+            Path(ms).stem,
+            name,
+            flux_jy,
+            separation_deg,
+        )
+        if best_calibrator_score is None or score > best_calibrator_score:
+            best_calibrator_score = score
+            best_calibrator_ms = ms
+
+    if best_calibrator_ms is not None:
+        log.info(
+            "Selected calibration tile %s from VLA calibrator ranking",
+            Path(best_calibrator_ms).stem,
+        )
+        return best_calibrator_ms
+
     best_ms: str | None = None
     best_count = -1
 
-    for idx in center_indices:
-        ms = epoch_ms_paths[idx]
+    for idx, ms in enumerate(epoch_ms_paths):
         try:
             ra, dec = _read_ms_phase_center(ms)
-            n = count_bright_sources_in_tile(
+            source_count = count_bright_sources_in_tile(
                 ra,
                 dec,
                 min_flux_mjy=min_flux_mjy,
                 radius_deg=source_radius_deg,
             )
-            log.info("Tile %d (%s): %d catalog sources", idx, Path(ms).stem, n)
-            if n > best_count:
-                best_count = n
+            log.info("Tile %d (%s): %d catalog sources", idx, Path(ms).stem, source_count)
+            if source_count > best_count:
+                best_count = source_count
                 best_ms = ms
         except Exception as exc:
             log.warning("Cannot count sources for tile %d (%s): %s", idx, ms, exc)
 
     if best_ms is None:
-        # Both catalog queries failed (e.g. VLASS/RACS databases absent).
+        # All catalog queries failed (e.g. VLASS/NVSS databases absent).
         # Fall back to the geometrically central tile rather than a hardcoded
         # index that is only correct for MOSAIC_TILE_COUNT=12.
         fallback_idx = len(epoch_ms_paths) // 2
         best_ms = epoch_ms_paths[fallback_idx]
         log.warning(
-            "Source count failed for all candidate tiles — "
+            "Source count failed for all epoch tiles — "
             "defaulting to central tile index %d (%s)",
             fallback_idx,
             Path(best_ms).stem,
@@ -207,7 +270,7 @@ def calibrate_epoch(
 
     Workflow
     --------
-    1.  Select central tile (by catalog source count).
+    1.  Select the strongest calibration tile from the full epoch.
     2.  Phaseshift to median meridian (reuses existing meridian MS if present).
     1b. Pre-calibration RFI flagging (autocorr + AOFlagger/tfcrop+rflag).
     3.  Apply bandpass-only to CORRECTED_DATA.
@@ -261,7 +324,7 @@ def calibrate_epoch(
     work.mkdir(parents=True, exist_ok=True)
 
     try:
-        # ── 0. Select central tile ────────────────────────────────────────────
+        # ── 0. Select calibration tile ────────────────────────────────────────
         central_raw_ms = select_calibration_tile_from_ms(
             epoch_ms_paths,
             min_flux_mjy=min_flux_mjy,

--- a/dsa110_continuum/calibration/model.py
+++ b/dsa110_continuum/calibration/model.py
@@ -1526,7 +1526,7 @@ def count_bright_sources_in_tile(
                     all_sources.extend(sources_df.to_dict("records"))
                     break  # Use first catalog with results
 
-            except (ValueError, KeyError, RuntimeError) as e:
+            except (FileNotFoundError, ValueError, KeyError, RuntimeError) as e:
                 logger.debug(f"Error querying {catalog_type} catalog: {e}")
                 continue
 

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -7,7 +7,7 @@ def test_select_calibration_tile_from_ms_picks_richer_tile():
     """Should return the MS whose central pointing has more catalog sources."""
     from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
 
-    # 12 tiles: centre pair is indices 5 (mid-1) and 6 (mid) where mid = 12//2 = 6
+    # The all-tile fallback should select index 6 because it has more sources.
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
 
     def fake_phase_center(ms_path):
@@ -19,6 +19,9 @@ def test_select_calibration_tile_from_ms_picks_richer_tile():
         return 8 if pointing_ra_deg == 60.0 else 3
 
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=fake_phase_center,
     ), patch(
@@ -31,10 +34,10 @@ def test_select_calibration_tile_from_ms_picks_richer_tile():
 
 
 def test_select_calibration_tile_works_with_11_tiles():
-    """Should work with 11 tiles (centre pair is indices 4 and 5)."""
+    """Should rank every tile when an epoch has an odd tile count."""
     from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
 
-    # 11 tiles: mid = 11//2 = 5, centre pair is indices 4 and 5
+    # The all-tile fallback should select index 5 because it has more sources.
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(11)]
 
     def fake_phase_center(ms_path):
@@ -46,6 +49,9 @@ def test_select_calibration_tile_works_with_11_tiles():
         return 9 if pointing_ra_deg == 50.0 else 2
 
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=fake_phase_center,
     ), patch(
@@ -66,13 +72,89 @@ def test_select_calibration_tile_raises_on_too_few():
         select_calibration_tile_from_ms(["/fake/a.ms"])
 
 
+def test_select_calibration_tile_prefers_bright_vla_calibrator_outside_center():
+    """A bright calibrator transit should beat the geometric center pair."""
+    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
+
+    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
+
+    def fake_calibrator_match(ms_path, **kwargs):
+        idx = int(Path(ms_path).stem.split("_")[1])
+        if idx == 2:
+            return ("2253+161", 12.66, 0.20)
+        if idx == 6:
+            return ("faint-cal", 1.0, 0.05)
+        raise RuntimeError("no calibrator")
+
+    with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=fake_calibrator_match,
+    ), patch(
+        "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
+    ) as source_count:
+        result = select_calibration_tile_from_ms(fake_paths)
+
+    assert result == "/fake/tile_02.ms"
+    source_count.assert_not_called()
+
+
+def test_select_calibration_tile_uses_nearest_tile_for_same_calibrator():
+    """When one calibrator spans tiles, select its closest tile midpoint."""
+    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
+
+    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(4)]
+
+    def fake_calibrator_match(ms_path, **kwargs):
+        idx = int(Path(ms_path).stem.split("_")[1])
+        separations = {1: 0.65, 2: 0.18}
+        if idx in separations:
+            return ("2253+161", 12.66, separations[idx])
+        raise RuntimeError("no calibrator")
+
+    with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=fake_calibrator_match,
+    ):
+        result = select_calibration_tile_from_ms(fake_paths)
+
+    assert result == "/fake/tile_02.ms"
+
+
+def test_select_calibration_tile_counts_all_tiles_without_vla_catalog():
+    """Catalog-count fallback must consider non-central tiles too."""
+    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
+
+    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
+
+    def fake_phase_center(ms_path):
+        idx = int(Path(ms_path).stem.split("_")[1])
+        return (float(idx), 16.1)
+
+    with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=FileNotFoundError("VLA catalog missing"),
+    ), patch(
+        "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+        side_effect=fake_phase_center,
+    ), patch(
+        "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
+        side_effect=lambda ra, dec, **kwargs: 20 if ra == 2.0 else 1,
+    ):
+        result = select_calibration_tile_from_ms(fake_paths)
+
+    assert result == "/fake/tile_02.ms"
+
+
 def test_select_calibration_tile_defaults_to_central_tile_on_failure():
-    """Falls back to n//2 (geometric centre) if source counting raises for both candidates."""
+    """Falls back to n//2 if source counting fails for every tile."""
     from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
 
     # 12 tiles: n//2 = 6
     fake_paths_12 = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=RuntimeError("casacore unavailable"),
     ):
@@ -82,11 +164,37 @@ def test_select_calibration_tile_defaults_to_central_tile_on_failure():
     # 6 tiles: n//2 = 3
     fake_paths_6 = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=RuntimeError("casacore unavailable"),
     ):
         result_6 = select_calibration_tile_from_ms(fake_paths_6)
     assert result_6 == "/fake/tile_03.ms"
+
+
+def test_count_bright_sources_falls_back_to_nvss_when_vlass_missing():
+    """A missing VLASS strip database must not prevent the NVSS query."""
+    import pandas as pd
+    from dsa110_continuum.calibration.model import count_bright_sources_in_tile
+
+    calls = []
+
+    def fake_query(*, catalog_type, **kwargs):
+        calls.append(catalog_type)
+        if catalog_type == "vlass":
+            raise FileNotFoundError("missing VLASS strip database")
+        return pd.DataFrame([{"ra_deg": 343.49, "dec_deg": 16.15}])
+
+    with patch(
+        "dsa110_continuum.calibration.catalogs.query_catalog_sources",
+        side_effect=fake_query,
+    ):
+        result = count_bright_sources_in_tile(343.49, 16.15)
+
+    assert result == 1
+    assert calls[:2] == ["vlass", "nvss"]
 
 
 def _make_exists_fn(meridian_ms: str, *, ap_table: str | None = None) -> object:


### PR DESCRIPTION
## Summary
- rank every hourly-epoch MS by the brightest matched VLA calibrator, using midpoint separation as the same-calibrator tiebreaker
- fall back to bright-source counts across all tiles instead of only the center pair
- continue from a missing VLASS strip database to NVSS source counts

## Validation
- ..........................                                               [100%]
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
<frozen importlib._bootstrap>:488
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
26 passed, 3 warnings in 4.34s — 26 passed
- live probes select , , and 
- no new Ruff findings relative to ; existing file-level findings remain unchanged

## Bounded H17 confirmation
The Jul 15 calibrator tile raises median unflagged p.G SNR to 57.09, but the production preconditioner propagates a 46.15% flag mask, so the 30% gate still fails. A no-preconditioner control improves to 33.33% flagged / SNR 65.70 but also remains above the gate. This PR fixes the confirmed selection/catalog defects without changing  or the gate threshold; full Jul 12/13/15 reruns remain blocked pending the residual antenna/baseline-coherence investigation.