### PR TITLE
Reduce conditional RFI preflight I/O

### DIFF
--- a/dsa110_continuum/calibration/flagging.py
+++ b/dsa110_continuum/calibration/flagging.py
@@ -106,7 +106,10 @@ def execute_rfi_policy(ms: str, mode: RfiMode, tag: str = "RFI") -> None:
         return
 
     from dsa110_continuum.calibration.flagging_cflag import flag_rfi_cflag
-    from dsa110_continuum.calibration.rfi_preflight import measure_rfi_preflight
+    from dsa110_continuum.calibration.rfi_preflight import (
+        measure_rfi_preflight,
+        required_spws_for_time_metrics,
+    )
 
     logger = logging.getLogger(__name__)
     logger.info("[%s] Running conservative RFI Stage 0", tag)
@@ -123,7 +126,11 @@ def execute_rfi_policy(ms: str, mode: RfiMode, tag: str = "RFI") -> None:
     run_full_chain = mode == "full"
     if mode == "conditional":
         try:
-            preflight = measure_rfi_preflight(ms, datacolumn="DATA")
+            preflight = measure_rfi_preflight(
+                ms,
+                datacolumn="DATA",
+                spw_ids=required_spws_for_time_metrics(),
+            )
             run_full_chain = preflight.decision.triggered
             logger.info(
                 "[%s] Conditional RFI preflight: trigger=%s; %s",

--- a/dsa110_continuum/calibration/rfi_preflight.py
+++ b/dsa110_continuum/calibration/rfi_preflight.py
@@ -170,12 +170,13 @@ def measure_rfi_preflight(
     datacolumn: str = "DATA",
     chunk_rows: int = 65_536,
 ) -> PreflightResult:
-    """Measure chunked per-SPW and per-integration raw-amplitude statistics."""
+    """Measure the SPWs used by the conditional RFI decision."""
     from dsa110_continuum.adapters.casa_tables import table
 
     ms_path = str(ms_path)
     with table(f"{ms_path}/DATA_DESCRIPTION", readonly=True, ack=False) as dd_table:
         dd_to_spw = np.asarray(dd_table.getcol("SPECTRAL_WINDOW_ID"), dtype=int)
+    required_spws = required_spws_for_time_metrics()
 
     histograms: dict[int, np.ndarray] = {}
     counts: dict[int, int] = {}
@@ -187,14 +188,17 @@ def measure_rfi_preflight(
         nrows_total = int(main.nrows())
         for start in range(0, nrows_total, chunk_rows):
             nrows = min(chunk_rows, nrows_total - start)
+            ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
+            spws = dd_to_spw[ddids]
+            required_rows = np.isin(spws, required_spws)
+            if not np.any(required_rows):
+                continue
             data = _rows_first(main.getcol(datacolumn, startrow=start, nrow=nrows), nrows)
             flags = _rows_first(main.getcol("FLAG", startrow=start, nrow=nrows), nrows)
             ant1 = np.asarray(main.getcol("ANTENNA1", startrow=start, nrow=nrows))
             ant2 = np.asarray(main.getcol("ANTENNA2", startrow=start, nrow=nrows))
-            ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
             times = np.asarray(main.getcol("TIME", startrow=start, nrow=nrows), dtype=float)
-            spws = dd_to_spw[ddids]
-            cross = ant1 != ant2
+            cross = (ant1 != ant2) & required_rows
 
             for spw in np.unique(spws[cross]):
                 spw = int(spw)
@@ -211,7 +215,7 @@ def measure_rfi_preflight(
                         np.count_nonzero(amplitudes > 1.0)
                     )
 
-                if spw in required_spws_for_time_metrics():
+                if spw in required_spws:
                     for timestamp in np.unique(times[spw_rows]):
                         rows = spw_rows & (times == timestamp)
                         time_amplitudes = _selected_amplitudes(data, flags, rows)
@@ -232,13 +236,16 @@ def measure_rfi_preflight(
         nrows_total = int(main.nrows())
         for start in range(0, nrows_total, chunk_rows):
             nrows = min(chunk_rows, nrows_total - start)
+            ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
+            spws = dd_to_spw[ddids]
+            required_rows = np.isin(spws, required_spws)
+            if not np.any(required_rows):
+                continue
             data = _rows_first(main.getcol(datacolumn, startrow=start, nrow=nrows), nrows)
             flags = _rows_first(main.getcol("FLAG", startrow=start, nrow=nrows), nrows)
             ant1 = np.asarray(main.getcol("ANTENNA1", startrow=start, nrow=nrows))
             ant2 = np.asarray(main.getcol("ANTENNA2", startrow=start, nrow=nrows))
-            ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
-            spws = dd_to_spw[ddids]
-            cross = ant1 != ant2
+            cross = (ant1 != ant2) & required_rows
             for spw in np.unique(spws[cross]):
                 spw = int(spw)
                 amplitudes = _selected_amplitudes(data, flags, cross & (spws == spw))

--- a/dsa110_continuum/calibration/rfi_preflight.py
+++ b/dsa110_continuum/calibration/rfi_preflight.py
@@ -169,14 +169,16 @@ def measure_rfi_preflight(
     *,
     datacolumn: str = "DATA",
     chunk_rows: int = 65_536,
+    spw_ids: tuple[int, ...] | None = None,
 ) -> PreflightResult:
-    """Measure the SPWs used by the conditional RFI decision."""
+    """Measure chunked per-SPW and per-integration raw-amplitude statistics."""
     from dsa110_continuum.adapters.casa_tables import table
 
     ms_path = str(ms_path)
     with table(f"{ms_path}/DATA_DESCRIPTION", readonly=True, ack=False) as dd_table:
         dd_to_spw = np.asarray(dd_table.getcol("SPECTRAL_WINDOW_ID"), dtype=int)
     required_spws = required_spws_for_time_metrics()
+    measured_spws = tuple(np.unique(dd_to_spw)) if spw_ids is None else spw_ids
 
     histograms: dict[int, np.ndarray] = {}
     counts: dict[int, int] = {}
@@ -190,15 +192,15 @@ def measure_rfi_preflight(
             nrows = min(chunk_rows, nrows_total - start)
             ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
             spws = dd_to_spw[ddids]
-            required_rows = np.isin(spws, required_spws)
-            if not np.any(required_rows):
+            measured_rows = np.isin(spws, measured_spws)
+            if not np.any(measured_rows):
                 continue
             data = _rows_first(main.getcol(datacolumn, startrow=start, nrow=nrows), nrows)
             flags = _rows_first(main.getcol("FLAG", startrow=start, nrow=nrows), nrows)
             ant1 = np.asarray(main.getcol("ANTENNA1", startrow=start, nrow=nrows))
             ant2 = np.asarray(main.getcol("ANTENNA2", startrow=start, nrow=nrows))
             times = np.asarray(main.getcol("TIME", startrow=start, nrow=nrows), dtype=float)
-            cross = (ant1 != ant2) & required_rows
+            cross = (ant1 != ant2) & measured_rows
 
             for spw in np.unique(spws[cross]):
                 spw = int(spw)
@@ -238,14 +240,14 @@ def measure_rfi_preflight(
             nrows = min(chunk_rows, nrows_total - start)
             ddids = np.asarray(main.getcol("DATA_DESC_ID", startrow=start, nrow=nrows), dtype=int)
             spws = dd_to_spw[ddids]
-            required_rows = np.isin(spws, required_spws)
-            if not np.any(required_rows):
+            measured_rows = np.isin(spws, measured_spws)
+            if not np.any(measured_rows):
                 continue
             data = _rows_first(main.getcol(datacolumn, startrow=start, nrow=nrows), nrows)
             flags = _rows_first(main.getcol("FLAG", startrow=start, nrow=nrows), nrows)
             ant1 = np.asarray(main.getcol("ANTENNA1", startrow=start, nrow=nrows))
             ant2 = np.asarray(main.getcol("ANTENNA2", startrow=start, nrow=nrows))
-            cross = (ant1 != ant2) & required_rows
+            cross = (ant1 != ant2) & measured_rows
             for spw in np.unique(spws[cross]):
                 spw = int(spw)
                 amplitudes = _selected_amplitudes(data, flags, cross & (spws == spw))

--- a/tests/test_rfi_preflight.py
+++ b/tests/test_rfi_preflight.py
@@ -1,5 +1,7 @@
 """Synthetic tests for the conditional RFI hard thresholds."""
 
+import dsa110_continuum.adapters.casa_tables as casa_tables
+import dsa110_continuum.calibration.rfi_preflight as rfi_preflight
 import numpy as np
 from dsa110_continuum.calibration.rfi_preflight import (
     SpwStats,
@@ -55,3 +57,47 @@ def test_missing_required_metrics_fail_closed():
 
     assert decision.triggered
     assert not decision.metrics_available
+
+
+def test_measurement_skips_visibility_reads_for_irrelevant_spws(monkeypatch):
+    data_reads = []
+
+    class FakeTable:
+        def __init__(self, path, **_kwargs):
+            self.data_description = str(path).endswith("/DATA_DESCRIPTION")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def nrows(self):
+            return 16
+
+        def getcol(self, name, startrow=0, nrow=-1):
+            if self.data_description:
+                return np.arange(16)
+            stop = 16 if nrow == -1 else startrow + nrow
+            rows = np.arange(16)[startrow:stop]
+            if name == "DATA_DESC_ID":
+                return rows
+            if name == "DATA":
+                data_reads.append(startrow)
+                return np.full((len(rows), 1001, 1), 0.05 + 0j)
+            if name == "FLAG":
+                return np.zeros((len(rows), 1001, 1), dtype=bool)
+            if name == "ANTENNA1":
+                return np.zeros(len(rows), dtype=int)
+            if name == "ANTENNA2":
+                return np.ones(len(rows), dtype=int)
+            if name == "TIME":
+                return np.zeros(len(rows))
+            raise AssertionError(name)
+
+    monkeypatch.setattr(casa_tables, "table", FakeTable)
+
+    result = rfi_preflight.measure_rfi_preflight("fake.ms", chunk_rows=1)
+
+    assert sorted(result.spw_stats) == [6, 7, 8, 9, 14, 15]
+    assert data_reads == [6, 7, 8, 9, 14, 15] * 2

--- a/tests/test_rfi_preflight.py
+++ b/tests/test_rfi_preflight.py
@@ -97,7 +97,17 @@ def test_measurement_skips_visibility_reads_for_irrelevant_spws(monkeypatch):
 
     monkeypatch.setattr(casa_tables, "table", FakeTable)
 
-    result = rfi_preflight.measure_rfi_preflight("fake.ms", chunk_rows=1)
+    result = rfi_preflight.measure_rfi_preflight(
+        "fake.ms",
+        chunk_rows=1,
+        spw_ids=(6, 7, 8, 9, 14, 15),
+    )
 
     assert sorted(result.spw_stats) == [6, 7, 8, 9, 14, 15]
     assert data_reads == [6, 7, 8, 9, 14, 15] * 2
+
+    data_reads.clear()
+    result = rfi_preflight.measure_rfi_preflight("fake.ms", chunk_rows=1)
+
+    assert sorted(result.spw_stats) == list(range(16))
+    assert data_reads == list(range(16)) * 2


### PR DESCRIPTION
## What changed

- read `DATA_DESC_ID` before visibility columns during conditional RFI preflight
- have the production policy request only SPWs 6-9 and 14-15 before reading `DATA`, `FLAG`, antenna, and time columns
- preserve the existing all-SPW default for diagnostic callers
- add regression coverage for both the selective production path and full diagnostic path

## Why

The conditional gate scanned `DATA` and `FLAG` twice for all 16 SPWs even though its hard decision uses only six. That read amplification made the nominally cheap preflight one of the slowest per-tile stages.

On the same 1,787,904-row production MS, the warm-cache control fell from 137.58 seconds to 48.16 seconds (65% faster). The decision, high/mid ratio, integration occupancy, and policy version were identical.

## Validation

- `17 passed` for `tests/test_rfi_preflight.py tests/test_rfi_mode.py`
- `ruff check` passed for all changed files
- `ruff format --check` passed for the two files without known baseline formatting debt
- real-MS decision remained quiet with high/mid ratio `1.0530682914679772` and integration occupancy `0.0`
