### PR TITLE
Clarify very bright source labels

### DIFF
--- a/scripts/dashboard_server.py
+++ b/scripts/dashboard_server.py
@@ -2023,7 +2023,6 @@ svg .lbl.big{fill:#dfe6f2;font-size:10.5px}
         <span id="sky-note">—</span><span class="spacer"></span>
         <span class="legend">
           <span><i style="background:var(--sun)"></i>Sun</span>
-          <span><i style="background:var(--bad)"></i>very bright source</span>
           <span><i style="background:var(--acc)"></i>calibrator</span>
           <span><i style="background:#aab6c9"></i>source</span>
           <span><i style="background:#b98760;box-shadow:0 0 6px #b98760"></i>Galactic plane</span>

--- a/scripts/dashboard_server.py
+++ b/scripts/dashboard_server.py
@@ -2023,7 +2023,7 @@ svg .lbl.big{fill:#dfe6f2;font-size:10.5px}
         <span id="sky-note">—</span><span class="spacer"></span>
         <span class="legend">
           <span><i style="background:var(--sun)"></i>Sun</span>
-          <span><i style="background:var(--bad)"></i>A-team</span>
+          <span><i style="background:var(--bad)"></i>very bright source</span>
           <span><i style="background:var(--acc)"></i>calibrator</span>
           <span><i style="background:#aab6c9"></i>source</span>
           <span><i style="background:#b98760;box-shadow:0 0 6px #b98760"></i>Galactic plane</span>
@@ -2195,7 +2195,7 @@ function drawSky(){
     .join('')||'<span class="quiet">Nothing notable in the strip this hour.</span>'}
 
 const skyTip=$('sky-tip'),skyCanvas=document.querySelector('.skycanvas');
-const kindLabel={sun:'solar system',ateam:'A-team source',cal:'calibrator',src:'bright source',catalog:'catalog source'};
+const kindLabel={sun:'solar system',ateam:'very bright radio source',cal:'calibrator',src:'bright source',catalog:'catalog source'};
 const skySource=e=>e.target.closest?e.target.closest('.sky-source'):null;
 function placeSkyTip(source,event){
   const canvas=skyCanvas.getBoundingClientRect(),box=source.getBoundingClientRect();

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -355,7 +355,7 @@ def test_sky_map_has_simulated_context_and_hover_tooltips(console):
     assert 'id="sky-tip" role="tooltip"' in page
     assert 'class="sky-source' in page
     assert "pointerover" in page and "focusin" in page
-    assert "very bright source" in page
+    assert "very bright radio source" in page
 
 
 def test_antennas_json_source_preferred(console, tmp_path, monkeypatch):

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -355,6 +355,7 @@ def test_sky_map_has_simulated_context_and_hover_tooltips(console):
     assert 'id="sky-tip" role="tooltip"' in page
     assert 'class="sky-source' in page
     assert "pointerover" in page and "focusin" in page
+    assert "very bright source" in page
 
 
 def test_antennas_json_source_preferred(console, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- replace the unexplained A-team shorthand in the sky-map legend
- describe the same class as a very bright radio source in tooltips

## Validation
- focused dashboard sky-map test
- ruff check and format check
- verified on the public dashboard