### PR TITLE
Recover epoch calibration and harden rolling campaigns

### DIFF
--- a/docs/validation/promotion-log.md
+++ b/docs/validation/promotion-log.md
@@ -5,3 +5,4 @@ Auto-appended by `dsa110_continuum.qa.promotion.append_promotion_ledger`. One ro
 | date       | hour | class                          | tier | epoch_gc                          | anchor                                                | side-car (relative to products root)               | git_sha  |
 |------------|------|--------------------------------|------|------------------------------------|--------------------------------------------------------|----------------------------------------------------|----------|
 | 2026-01-25 | 22   | auto_emitted_pending_review    | A    | skipped_or_failed_low_snr          | —                                                      | mosaics/2026-01-25/promotion_2026-01-25T2200.json  | 2bd3e4c  |
+| 2026-07-15 | 11   | auto_emitted_pending_review    | C    | solved                             | —                                                      | products/2026-07-15/promotion_2026-07-15T1100.json | cbe629e4 |

--- a/dsa110_continuum/calibration/catalogs.py
+++ b/dsa110_continuum/calibration/catalogs.py
@@ -1844,11 +1844,11 @@ def _resolve_vlass_catalog_path(
     dec_rounded = round(float(dec_deg), 1)
     strip_name = f"vlass_dec{dec_rounded:+.1f}.sqlite3"
     catalog_dirs = [
+        get_env_path("CONTIMG_BASE_DIR", default="/data/dsa110-contimg")
+        / "state/catalogs",
         Path("/data/dsa110-contimg/state/catalogs"),
         Path("/app/state/catalogs"),
         Path.cwd() / "state/catalogs",
-        get_env_path("CONTIMG_BASE_DIR", default="/data/dsa110-contimg")
-        / "state/catalogs",
     ]
 
     for catalog_dir in catalog_dirs:

--- a/dsa110_continuum/calibration/catalogs.py
+++ b/dsa110_continuum/calibration/catalogs.py
@@ -1832,6 +1832,38 @@ def query_rax_sources(
         raise FileNotFoundError(error_msg)
 
 
+def _resolve_vlass_catalog_path(
+    dec_deg: float,
+    catalog_path: str | os.PathLike[str] | None = None,
+) -> Path | None:
+    if catalog_path:
+        explicit_path = Path(catalog_path)
+        if explicit_path.exists():
+            return explicit_path
+
+    dec_rounded = round(float(dec_deg), 1)
+    strip_name = f"vlass_dec{dec_rounded:+.1f}.sqlite3"
+    catalog_dirs = [
+        Path("/data/dsa110-contimg/state/catalogs"),
+        Path("/app/state/catalogs"),
+        Path.cwd() / "state/catalogs",
+        get_env_path("CONTIMG_BASE_DIR", default="/data/dsa110-contimg")
+        / "state/catalogs",
+    ]
+
+    for catalog_dir in catalog_dirs:
+        strip_path = catalog_dir / strip_name
+        if strip_path.exists():
+            return strip_path
+
+    for catalog_dir in catalog_dirs:
+        full_path = catalog_dir / "vlass_full.sqlite3"
+        if full_path.exists():
+            return full_path
+
+    return None
+
+
 def query_vlass_sources(
     ra_deg: float,
     dec_deg: float,
@@ -1871,39 +1903,7 @@ def query_vlass_sources(
     """
     import sqlite3
 
-    # Try SQLite first (much faster)
-    db_path = None
-
-    # 1. Explicit path provided
-    if catalog_path:
-        db_path = Path(catalog_path)
-        if not db_path.exists():
-            db_path = None
-
-    # 2. Auto-resolve based on declination strip
-    if db_path is None:
-        dec_rounded = round(float(dec_deg), 1)
-        db_name = f"vlass_dec{dec_rounded:+.1f}.sqlite3"
-
-        # Try standard locations
-        candidates = []
-
-        for root_str in ["/data/dsa110-contimg", "/app"]:
-            root_path = Path(root_str)
-            if root_path.exists():
-                candidates.append(root_path / "state" / "catalogs" / db_name)
-
-        candidates.append(Path.cwd() / "state" / "catalogs" / db_name)
-        candidates.append(
-            get_env_path("CONTIMG_BASE_DIR", default="/data/dsa110-contimg")
-            / "state/catalogs"
-            / db_name
-        )
-
-        for candidate in candidates:
-            if candidate.exists():
-                db_path = candidate
-                break
+    db_path = _resolve_vlass_catalog_path(dec_deg, catalog_path)
 
     # Query SQLite if available
     if db_path is not None:

--- a/dsa110_continuum/calibration/epoch_gaincal.py
+++ b/dsa110_continuum/calibration/epoch_gaincal.py
@@ -672,6 +672,7 @@ def calibrate_epoch(
         else:
             cmd = [
                 wsclean_exec,
+                "-reorder",
                 "-niter", str(wsclean_niter),
                 "-auto-threshold", str(wsclean_threshold_sigma),
                 "-model-column", "MODEL_DATA",
@@ -681,17 +682,19 @@ def calibrate_epoch(
                 "-size", "1024", "1024",
                 "-scale", "6arcsec",
                 "-weight", "briggs", "0.5",
+                "-mgain", "0.8",
                 meridian_ms,
             ]
             log.info("Epoch gaincal [%s]: WSClean self-cal imaging", stem)
             wsclean_result = subprocess.run(cmd, capture_output=True, timeout=600)
             if wsclean_result.returncode != 0:
+                diagnostic = (wsclean_result.stdout or b"") + (wsclean_result.stderr or b"")
                 log.warning(
                     "Epoch gaincal [%s]: WSClean exited %d — "
                     "falling back to catalog MODEL_DATA for ap solve\n%s",
                     stem,
                     wsclean_result.returncode,
-                    wsclean_result.stderr.decode("utf-8", errors="replace")[-500:],
+                    diagnostic.decode("utf-8", errors="replace")[-500:],
                 )
                 predict_from_skymodel_wsclean(meridian_ms, sky, field="all")
 

--- a/dsa110_continuum/calibration/epoch_gaincal.py
+++ b/dsa110_continuum/calibration/epoch_gaincal.py
@@ -674,13 +674,13 @@ def calibrate_epoch(
                 wsclean_exec,
                 "-niter", str(wsclean_niter),
                 "-auto-threshold", str(wsclean_threshold_sigma),
-                "-save-model-column", "MODEL_DATA",
+                "-model-column", "MODEL_DATA",
+                "-update-model-required",
                 "-field", "all",
                 "-name", wsclean_prefix,
                 "-size", "1024", "1024",
                 "-scale", "6arcsec",
                 "-weight", "briggs", "0.5",
-                "-no-update-model-required",
                 meridian_ms,
             ]
             log.info("Epoch gaincal [%s]: WSClean self-cal imaging", stem)

--- a/dsa110_continuum/calibration/epoch_gaincal.py
+++ b/dsa110_continuum/calibration/epoch_gaincal.py
@@ -358,7 +358,7 @@ def calibrate_epoch(
         BP receptor mask. If direct solving fails and multiple fields contain
         MODEL_DATA, try the 60s pre-conditioner once as a rescue.
     7.  Apply the selected chain, then WSClean quick image (-save-model).
-    8.  Amplitude+phase gaincal using the selected chain → ap.G.
+    8.  BP-referenced amplitude+phase gaincal → self-contained ap.G.
 
     Any exception causes an early return of None so callers can fall back to
     the static daily G table.
@@ -511,7 +511,13 @@ def calibrate_epoch(
                 "catalog sky model is empty (no bright sources within search radius)",
             )
         log.info("Epoch gaincal [%s]: sky model has %d components", stem, sky.Ncomponents)
-        predict_from_skymodel_wsclean(meridian_ms, sky)
+        predict_from_skymodel_wsclean(meridian_ms, sky, field="all")
+        modeled_fields, total_fields = _modeled_field_count(meridian_ms)
+        if modeled_fields != total_fields:
+            raise RuntimeError(
+                f"MODEL_DATA populated for {modeled_fields}/{total_fields} fields; "
+                "refusing partial epoch gain calibration"
+            )
 
         # ── 6. Direct phase-only gaincal ──────────────────────────────────────
         service = CASAService()
@@ -545,7 +551,6 @@ def calibrate_epoch(
             }
         log.info("Epoch gaincal [%s]: direct p.G %s", stem, _format_gain_flag_stats(direct_stats))
         if float(direct_stats["effective_fraction"]) > GAINCAL_FLAG_FRACTION_LIMIT:
-            modeled_fields, total_fields = _modeled_field_count(meridian_ms)
             if modeled_fields < 2:
                 reason = (
                     f"direct p.G {_format_gain_flag_stats(direct_stats)} exceeds "
@@ -656,20 +661,21 @@ def calibrate_epoch(
                 "skipping WSClean self-cal, re-predicting catalog model for ap solve",
                 stem, 100 * _flag_frac, 100 * _WSCLEAN_FLAG_FRACTION_LIMIT,
             )
-            predict_from_skymodel_wsclean(meridian_ms, sky)
+            predict_from_skymodel_wsclean(meridian_ms, sky, field="all")
         elif not wsclean_exec:
             log.warning(
                 "Epoch gaincal [%s]: wsclean not on PATH — "
                 "re-predicting catalog model for ap solve",
                 stem,
             )
-            predict_from_skymodel_wsclean(meridian_ms, sky)
+            predict_from_skymodel_wsclean(meridian_ms, sky, field="all")
         else:
             cmd = [
                 wsclean_exec,
                 "-niter", str(wsclean_niter),
                 "-auto-threshold", str(wsclean_threshold_sigma),
                 "-save-model-column", "MODEL_DATA",
+                "-field", "all",
                 "-name", wsclean_prefix,
                 "-size", "1024", "1024",
                 "-scale", "6arcsec",
@@ -687,7 +693,7 @@ def calibrate_epoch(
                     wsclean_result.returncode,
                     wsclean_result.stderr.decode("utf-8", errors="replace")[-500:],
                 )
-                predict_from_skymodel_wsclean(meridian_ms, sky)
+                predict_from_skymodel_wsclean(meridian_ms, sky, field="all")
 
         # ── 8. Amplitude+phase gaincal ────────────────────────────────────────
         log.info("Epoch gaincal [%s]: ap gaincal → %s", stem, Path(ap_table).name)
@@ -700,9 +706,8 @@ def calibrate_epoch(
             solint="inf",
             minsnr=3.0,
             gaintype="G",
-            gaintable=[bp_table, *_precond, p_table],
-            interp=["nearest", *_precond_interp, "linear"],
-            **( {"spwmap": [[], *_precond_spwmap, []]} if _precond_spwmap else {} ),
+            gaintable=[bp_table],
+            interp=["nearest"],
         )
         if not os.path.exists(ap_table):
             log.error("Epoch gaincal [%s]: ap solve produced no table", stem)

--- a/dsa110_continuum/calibration/epoch_gaincal.py
+++ b/dsa110_continuum/calibration/epoch_gaincal.py
@@ -3,7 +3,7 @@
 Public API
 ----------
 select_calibration_tile_from_ms(epoch_ms_paths) -> str
-    Return the MS path (from the two central tiles) with the most catalog sources.
+    Return the epoch MS with the strongest catalog calibration target.
 
 calibrate_epoch(epoch_ms_paths, bp_table, work_dir, ...) -> EpochGaincalResult
     Full 5-step catalog-bootstrap + self-cal gain solve. Returns a structured
@@ -116,18 +116,44 @@ def _read_ms_phase_center(ms_path: str) -> tuple[float, float]:
     return median_ra, median_dec
 
 
+def _find_vla_calibrator_in_ms(
+    ms_path: str,
+    *,
+    search_radius_deg: float,
+) -> tuple[str, float, float]:
+    """Return ``(name, flux_jy, separation_deg)`` for the best VLA calibrator."""
+    from dsa110_continuum.calibration.selection import select_bandpass_from_catalog
+
+    _, _, _, cal_info, _ = select_bandpass_from_catalog(
+        ms_path,
+        search_radius_deg=search_radius_deg,
+    )
+    name, cal_ra_deg, cal_dec_deg, flux_jy = cal_info
+    tile_ra_deg, tile_dec_deg = _read_ms_phase_center(ms_path)
+    tile_ra = np.radians(tile_ra_deg)
+    tile_dec = np.radians(tile_dec_deg)
+    cal_ra = np.radians(cal_ra_deg)
+    cal_dec = np.radians(cal_dec_deg)
+    cos_sep = (
+        np.sin(tile_dec) * np.sin(cal_dec)
+        + np.cos(tile_dec) * np.cos(cal_dec) * np.cos(tile_ra - cal_ra)
+    )
+    separation_deg = float(np.degrees(np.arccos(np.clip(cos_sep, -1.0, 1.0))))
+    return str(name), float(flux_jy), separation_deg
+
+
 def select_calibration_tile_from_ms(
     epoch_ms_paths: list[str],
     *,
     min_flux_mjy: float = SKYMODEL_MIN_FLUX_MJY,
     source_radius_deg: float = SOURCE_QUERY_RADIUS_DEG,
 ) -> str:
-    """Return the central tile MS with the most bright catalog sources.
+    """Return the epoch MS with the strongest catalog calibration target.
 
-    Checks the two tiles nearest the centre of the sorted list and returns
-    the MS path whose pointing has more catalog sources above *min_flux_mjy*
-    within *source_radius_deg*.  Optimised for MOSAIC_TILE_COUNT (12) tiles
-    but gracefully handles any count >= 2.
+    All tiles are checked for VLA calibrators first. The highest-flux match
+    wins, with angular proximity to the tile midpoint as the tiebreaker. If
+    the VLA catalog is unavailable or no calibrator is present, all tiles are
+    ranked by their bright-source counts.
 
     Parameters
     ----------
@@ -152,37 +178,74 @@ def select_calibration_tile_from_ms(
     if n < 2:
         raise ValueError(f"Need at least 2 MS paths for tile selection, got {n}")
 
-    # Pick the two tiles nearest the centre of the list
-    mid = n // 2
-    center_indices = [mid - 1, mid]
+    calibrator_search_radius_deg = max(1.0, source_radius_deg)
+    best_calibrator_ms: str | None = None
+    best_calibrator_score: tuple[float, float] | None = None
+
+    for idx, ms in enumerate(epoch_ms_paths):
+        try:
+            name, flux_jy, separation_deg = _find_vla_calibrator_in_ms(
+                ms,
+                search_radius_deg=calibrator_search_radius_deg,
+            )
+        except (
+            FileNotFoundError,
+            KeyError,
+            OSError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            log.debug("No VLA calibrator match for tile %d (%s): %s", idx, ms, exc)
+            continue
+
+        score = (flux_jy, -separation_deg)
+        log.info(
+            "Tile %d (%s): VLA calibrator %s, %.2f Jy, %.3f deg from midpoint",
+            idx,
+            Path(ms).stem,
+            name,
+            flux_jy,
+            separation_deg,
+        )
+        if best_calibrator_score is None or score > best_calibrator_score:
+            best_calibrator_score = score
+            best_calibrator_ms = ms
+
+    if best_calibrator_ms is not None:
+        log.info(
+            "Selected calibration tile %s from VLA calibrator ranking",
+            Path(best_calibrator_ms).stem,
+        )
+        return best_calibrator_ms
+
     best_ms: str | None = None
     best_count = -1
 
-    for idx in center_indices:
-        ms = epoch_ms_paths[idx]
+    for idx, ms in enumerate(epoch_ms_paths):
         try:
             ra, dec = _read_ms_phase_center(ms)
-            n = count_bright_sources_in_tile(
+            source_count = count_bright_sources_in_tile(
                 ra,
                 dec,
                 min_flux_mjy=min_flux_mjy,
                 radius_deg=source_radius_deg,
             )
-            log.info("Tile %d (%s): %d catalog sources", idx, Path(ms).stem, n)
-            if n > best_count:
-                best_count = n
+            log.info("Tile %d (%s): %d catalog sources", idx, Path(ms).stem, source_count)
+            if source_count > best_count:
+                best_count = source_count
                 best_ms = ms
         except Exception as exc:
             log.warning("Cannot count sources for tile %d (%s): %s", idx, ms, exc)
 
     if best_ms is None:
-        # Both catalog queries failed (e.g. VLASS/RACS databases absent).
+        # All catalog queries failed (e.g. VLASS/NVSS databases absent).
         # Fall back to the geometrically central tile rather than a hardcoded
         # index that is only correct for MOSAIC_TILE_COUNT=12.
         fallback_idx = len(epoch_ms_paths) // 2
         best_ms = epoch_ms_paths[fallback_idx]
         log.warning(
-            "Source count failed for all candidate tiles — "
+            "Source count failed for all epoch tiles — "
             "defaulting to central tile index %d (%s)",
             fallback_idx,
             Path(best_ms).stem,
@@ -212,7 +275,7 @@ def calibrate_epoch(
 
     Workflow
     --------
-    1.  Select central tile (by catalog source count).
+    1.  Select the strongest calibration tile from the full epoch.
     2.  Phaseshift to median meridian (reuses existing meridian MS if present).
     1b. Pre-calibration RFI flagging (autocorr + AOFlagger/tfcrop+rflag).
     3.  Apply bandpass-only to CORRECTED_DATA.
@@ -268,7 +331,7 @@ def calibrate_epoch(
     work.mkdir(parents=True, exist_ok=True)
 
     try:
-        # ── 0. Select central tile ────────────────────────────────────────────
+        # ── 0. Select calibration tile ────────────────────────────────────────
         central_raw_ms = select_calibration_tile_from_ms(
             epoch_ms_paths,
             min_flux_mjy=min_flux_mjy,

--- a/dsa110_continuum/calibration/epoch_gaincal.py
+++ b/dsa110_continuum/calibration/epoch_gaincal.py
@@ -87,7 +87,7 @@ class EpochGaincalResult:
 
 
 _WSCLEAN_FLAG_FRACTION_LIMIT = 0.60  # skip WSClean self-cal if MS is more flagged than this
-GAINCAL_FLAG_FRACTION_LIMIT  = 0.30  # abort epoch gaincal if p.G table is more flagged than this
+GAINCAL_FLAG_FRACTION_LIMIT = 0.30  # abort epoch gaincal if p.G table is more flagged than this
 
 
 def _ms_flag_fraction(ms_path: str) -> float:
@@ -97,6 +97,79 @@ def _ms_flag_fraction(ms_path: str) -> float:
     with ct.table(ms_path, readonly=True, ack=False) as t:
         flags = t.getcol("FLAG")
     return float(flags.sum()) / flags.size
+
+
+def _gain_flag_fractions(candidate_table: str, bp_table: str) -> dict[str, object]:
+    """Return raw and BP-relative flag fractions for a candidate gain table."""
+    from dsa110_continuum.adapters import casa_tables as ct
+    from dsa110_continuum.calibration.solve_bandpass import (
+        _flag_fraction_excluding_dead_receptors,
+    )
+
+    with ct.table(candidate_table, readonly=True, ack=False) as table:
+        candidate_flags = table.getcol("FLAG")
+        candidate_antennas = table.getcol("ANTENNA1")
+    if np.asarray(candidate_flags).size == 0:
+        raise ValueError(f"Candidate gain table has no FLAG values: {candidate_table}")
+
+    raw_fraction = float(np.mean(candidate_flags))
+    try:
+        with ct.table(bp_table, readonly=True, ack=False) as table:
+            bp_flags = table.getcol("FLAG")
+            bp_antennas = table.getcol("ANTENNA1")
+        if np.asarray(bp_flags).size == 0:
+            raise ValueError(f"Bandpass table has no FLAG values: {bp_table}")
+        baseline = _flag_fraction_excluding_dead_receptors(bp_flags, bp_antennas)
+        effective = _flag_fraction_excluding_dead_receptors(
+            candidate_flags,
+            candidate_antennas,
+            excluded_receptors=set(baseline["dead_receptors"]),
+        )
+    except Exception as exc:
+        log.warning(
+            "Could not validate BP receptor baseline for %s (%s); using raw flag fraction",
+            candidate_table,
+            exc,
+        )
+        return {
+            "raw_fraction": raw_fraction,
+            "effective_fraction": raw_fraction,
+            "baseline_valid": False,
+            "baseline_dead_receptors": 0,
+        }
+
+    return {
+        "raw_fraction": raw_fraction,
+        "effective_fraction": effective["effective_flag_fraction"],
+        "baseline_valid": True,
+        "baseline_dead_receptors": baseline["dead_receptor_count"],
+        "working_flagged": effective["working_flagged"],
+        "working_total": effective["working_total"],
+    }
+
+
+def _modeled_field_count(ms_path: str) -> tuple[int, int]:
+    """Return modeled and total field counts using bounded MODEL_DATA samples."""
+    from dsa110_continuum.adapters import casa_tables as ct
+
+    with ct.table(ms_path, readonly=True, ack=False) as table:
+        field_ids = np.asarray(table.getcol("FIELD_ID"))
+        unique_fields = np.unique(field_ids)
+        modeled = 0
+        for field_id in unique_fields:
+            field_rows = np.flatnonzero(field_ids == field_id)
+            rows = field_rows[np.linspace(0, len(field_rows) - 1, min(8, len(field_rows))).astype(int)]
+            if any(np.any(np.abs(table.getcell("MODEL_DATA", int(row))) > 0) for row in rows):
+                modeled += 1
+    return modeled, len(unique_fields)
+
+
+def _format_gain_flag_stats(stats: dict[str, object]) -> str:
+    baseline = "BP-relative" if stats["baseline_valid"] else "raw fallback"
+    return (
+        f"raw {float(stats['raw_fraction']) * 100:.1f}%, "
+        f"{baseline} {float(stats['effective_fraction']) * 100:.1f}%"
+    )
 
 
 def _read_ms_phase_center(ms_path: str) -> tuple[float, float]:
@@ -280,13 +353,12 @@ def calibrate_epoch(
     1b. Pre-calibration RFI flagging (autocorr + AOFlagger/tfcrop+rflag).
     3.  Apply bandpass-only to CORRECTED_DATA.
     4.  Populate MODEL_DATA from unified catalog (FIRST+RACS+NVSS+VLASS).
-    5b. Pre-conditioner phase solve: calmode='p', solint='60s', combine='spw'
-        → precond.G.  Tracks short-term phase drift across the full bandwidth
-        to prevent vector decorrelation in the long inf-interval solves below.
-    6.  Phase-only gaincal (solint='inf', gaintable=[bp, precond]) → epoch_p.G.
-    7.  Apply BP + precond + p.G, then WSClean quick image (-save-model).
-    8.  Amplitude+phase gaincal (solint='inf', gaintable=[bp, precond, p.G])
-        → epoch_ap.G  ← returned.
+    6.  Direct phase-only gaincal (solint='inf', gaintable=[bp]) → direct.p.G.
+    6b. Gate on newly failed receptors relative to the independently measured
+        BP receptor mask. If direct solving fails and multiple fields contain
+        MODEL_DATA, try the 60s pre-conditioner once as a rescue.
+    7.  Apply the selected chain, then WSClean quick image (-save-model).
+    8.  Amplitude+phase gaincal using the selected chain → ap.G.
 
     Any exception causes an early return of None so callers can fall back to
     the static daily G table.
@@ -339,15 +411,40 @@ def calibrate_epoch(
         )
         stem = Path(central_raw_ms).stem
         meridian_ms   = str(work / f"{stem}_meridian.ms")
-        precond_table = str(work / f"{stem}.precond.G")
-        p_table       = str(work / f"{stem}.p.G")
-        ap_table      = str(work / f"{stem}.ap.G")
+        precond_table = str(work / f"{stem}.direct_first.precond.G")
+        direct_p_table = str(work / f"{stem}.direct.p.G")
+        rescue_p_table = str(work / f"{stem}.precond_rescue.p.G")
+        ap_table = str(work / f"{stem}.direct_first.ap.G")
         wsclean_prefix = str(work / f"{stem}_model")
 
         # Return cached result if the ap.G table already exists
         if os.path.exists(ap_table):
-            log.info("Epoch gaincal [%s]: cached ap.G found — reusing %s", stem, ap_table)
-            return EpochGaincalResult(ap_table, EpochGaincalStatus.SOLVED, "cached ap.G reused")
+            try:
+                cached_stats = _gain_flag_fractions(ap_table, bp_table)
+                if float(cached_stats["effective_fraction"]) <= GAINCAL_FLAG_FRACTION_LIMIT:
+                    log.info(
+                        "Epoch gaincal [%s]: validated cached ap.G — reusing %s",
+                        stem,
+                        ap_table,
+                    )
+                    return EpochGaincalResult(
+                        ap_table, EpochGaincalStatus.SOLVED, "validated cached ap.G reused"
+                    )
+                log.warning(
+                    "Epoch gaincal [%s]: cached ap.G fails gate (%s) — recomputing",
+                    stem,
+                    _format_gain_flag_stats(cached_stats),
+                )
+            except Exception as exc:
+                log.warning(
+                    "Epoch gaincal [%s]: cached ap.G is unreadable (%s) — recomputing",
+                    stem,
+                    exc,
+                )
+            if os.path.isdir(ap_table):
+                shutil.rmtree(ap_table)
+            else:
+                os.remove(ap_table)
 
         # ── 1. Phaseshift to median meridian ──────────────────────────────────
         if not os.path.exists(meridian_ms):
@@ -416,85 +513,13 @@ def calibrate_epoch(
         log.info("Epoch gaincal [%s]: sky model has %d components", stem, sky.Ncomponents)
         predict_from_skymodel_wsclean(meridian_ms, sky)
 
-        # ── 5b. Short-timescale pre-conditioner phase solve ───────────────────
-        # Problem: the main solint='inf' gaincal integrates the full ~4-5 minute
-        # drift-scan window into a single solution. When the ionosphere or instrument
-        # phase drifts within that window, the vector sum of visibilities decorrelates
-        # — amplitudes shrink and the solver flags the solution (SNR < 3.0). This is
-        # the dominant failure mode observed on Feb 15 (faint distributed sky model).
-        #
-        # Fix: solve a frequency-independent phase per antenna at 60s intervals
-        # (combine='spw' averages all 16 subbands, boosting per-interval SNR ~4×).
-        # The resulting table is passed as a prior into the main gaincal so it only
-        # needs to account for slow residual amplitude drifts rather than fast phases.
-        #
-        # This is the "narrow scope" adaptation of the NRAO-recommended pre-bandpass
-        # phase solve (see dsa110-contimg runner.py STEP 3.5). If an automated script
-        # is ever added to re-derive the daily bandpass table, this SPW-combined
-        # pre-solve should also be inserted before that bandpass solve.
+        # ── 6. Direct phase-only gaincal ──────────────────────────────────────
         service = CASAService()
-        log.info("Epoch gaincal [%s]: pre-conditioner phase solve (60s, combine='spw')", stem)
-        try:
-            service.gaincal(
-                vis=meridian_ms,
-                caltable=precond_table,
-                field="",
-                refant=refant,
-                calmode="p",
-                solint="60s",
-                combine="spw",
-                minsnr=3.0,
-                gaintype="G",
-                gaintable=[bp_table],
-                interp=["nearest"],
-            )
-            if os.path.exists(precond_table):
-                log.info(
-                    "Epoch gaincal [%s]: pre-conditioner solve SUCCESS → %s",
-                    stem, Path(precond_table).name,
-                )
-            else:
-                log.warning(
-                    "Epoch gaincal [%s]: pre-conditioner produced no table — "
-                    "proceeding without it (expect lower epoch gaincal SNR)",
-                    stem,
-                )
-        except Exception as _precond_err:
-            log.warning(
-                "Epoch gaincal [%s]: pre-conditioner solve failed (%s) — continuing",
-                stem, _precond_err,
-            )
-
-        # Build the optional precond chain used in all downstream gaintable lists.
-        # If the step above failed or produced no table, these lists are empty and
-        # the remaining solves behave exactly as before the pre-conditioner was added.
-        #
-        # spwmap note: combine='spw' produces a table with only SPW 0.  Without an
-        # explicit spwmap, CASA flags SPWs 1-15 in every subsequent gaincal and
-        # applycal that includes the precond table.  We derive the SPW count from the
-        # MS and provide spwmap=[0,0,...,0] so CASA re-uses the SPW-0 solution for
-        # all 16 subbands instead of flagging them.
-        _precond = [precond_table] if os.path.exists(precond_table) else []
-        _precond_interp = ["linear"] * len(_precond)
-        if _precond:
-            try:
-                from dsa110_continuum.adapters import casa_tables as _ct2
-                with _ct2.table(f"{meridian_ms}::SPECTRAL_WINDOW",
-                                readonly=True, ack=False) as _tspw:
-                    _n_spw = _tspw.nrows()
-                _precond_spwmap: list[list[int]] = [[0] * _n_spw]
-            except Exception as _spw_err:
-                log.warning(
-                    "Epoch gaincal [%s]: could not determine SPW count for precond "
-                    "spwmap (%s) — SPWs 1+ may be flagged in downstream solves",
-                    stem, _spw_err,
-                )
-                _precond_spwmap = []
-        else:
-            _precond_spwmap = []
-
-        # ── 6. Phase-only gaincal ─────────────────────────────────────────────
-        log.info("Epoch gaincal [%s]: phase-only gaincal → %s", stem, Path(p_table).name)
+        p_table = direct_p_table
+        _precond: list[str] = []
+        _precond_interp: list[str] = []
+        _precond_spwmap: list[list[int]] = []
+        log.info("Epoch gaincal [%s]: direct phase-only gaincal → %s", stem, Path(p_table).name)
         service.gaincal(
             vis=meridian_ms,
             caltable=p_table,
@@ -504,54 +529,107 @@ def calibrate_epoch(
             solint="inf",
             minsnr=3.0,
             gaintype="G",
-            gaintable=[bp_table, *_precond],
-            interp=["nearest", *_precond_interp],
-            **( {"spwmap": [[], *_precond_spwmap]} if _precond_spwmap else {} ),
+            gaintable=[bp_table],
+            interp=["nearest"],
         )
-        if not os.path.exists(p_table):
-            log.error("Epoch gaincal [%s]: phase-only solve produced no table", stem)
-            return EpochGaincalResult(
-                None,
-                EpochGaincalStatus.SOLVER_NO_TABLE,
-                "phase-only gaincal produced no table (likely all solutions flagged at minsnr=3.0)",
-            )
+        # ── 6b. Independent receptor gate and bounded rescue ──────────────────
+        if os.path.exists(p_table):
+            direct_stats = _gain_flag_fractions(p_table, bp_table)
+        else:
+            log.warning("Epoch gaincal [%s]: direct phase-only solve produced no table", stem)
+            direct_stats = {
+                "raw_fraction": 1.0,
+                "effective_fraction": 1.0,
+                "baseline_valid": False,
+                "baseline_dead_receptors": 0,
+            }
+        log.info("Epoch gaincal [%s]: direct p.G %s", stem, _format_gain_flag_stats(direct_stats))
+        if float(direct_stats["effective_fraction"]) > GAINCAL_FLAG_FRACTION_LIMIT:
+            modeled_fields, total_fields = _modeled_field_count(meridian_ms)
+            if modeled_fields < 2:
+                reason = (
+                    f"direct p.G {_format_gain_flag_stats(direct_stats)} exceeds "
+                    f"{GAINCAL_FLAG_FRACTION_LIMIT * 100:.0f}% limit; MODEL_DATA present in "
+                    f"{modeled_fields}/{total_fields} fields, so 60s rescue cannot span fields"
+                )
+                return EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, reason)
 
-        # ── 6b. Flag-fraction monitor on p.G table ────────────────────────────
-        # Read the CASA FLAG column from the cal table directly.  CASA often
-        # pre-allocates rows but sets FLAG=True for solutions that failed the
-        # SNR gate (minsnr=3.0).  A high flagged fraction means the sky model
-        # was too faint to support reliable gain solutions; applying a noisy
-        # ap.G table would actively worsen the bandpass calibration already
-        # applied in Step 3.  Return None so the batch pipeline falls back to
-        # BP-only, which is the correct survey-pipeline behaviour for faint fields.
-        try:
-            import casatools as _cto
-            _tb = _cto.table()
-            _tb.open(p_table)
-            _p_flags = _tb.getcol("FLAG")   # shape: (n_pol, n_spw, n_rows) — booleans
-            _tb.close()
-            _p_flag_frac = float(_p_flags.sum()) / float(_p_flags.size)
             log.info(
-                "Epoch gaincal [%s]: p.G flagged fraction = %.1f%%",
-                stem, _p_flag_frac * 100,
+                "Epoch gaincal [%s]: direct gate failed; trying 60s pre-conditioner rescue",
+                stem,
             )
-            if _p_flag_frac > GAINCAL_FLAG_FRACTION_LIMIT:
-                _reason = (
-                    f"p.G flagged {_p_flag_frac * 100:.1f}% of solutions "
-                    f"(limit {GAINCAL_FLAG_FRACTION_LIMIT * 100:.0f}%) — "
-                    f"SNR too low for reliable gain cal"
+            try:
+                service.gaincal(
+                    vis=meridian_ms,
+                    caltable=precond_table,
+                    field="",
+                    refant=refant,
+                    calmode="p",
+                    solint="60s",
+                    combine="spw",
+                    minsnr=3.0,
+                    gaintype="G",
+                    gaintable=[bp_table],
+                    interp=["nearest"],
                 )
-                log.warning(
-                    "Epoch gaincal [%s]: %s. Returning None; pipeline will apply bandpass-only.",
-                    stem, _reason,
+            except Exception as exc:
+                reason = (
+                    f"direct p.G {_format_gain_flag_stats(direct_stats)} exceeds "
+                    f"{GAINCAL_FLAG_FRACTION_LIMIT * 100:.0f}% limit; rescue failed: {exc}"
                 )
-                return EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, _reason)
-        except Exception as _frac_err:
-            log.warning(
-                "Epoch gaincal [%s]: could not read p.G flag fraction (%s) — "
-                "proceeding with ap solve",
-                stem, _frac_err,
+                return EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, reason)
+            if not os.path.exists(precond_table):
+                reason = (
+                    f"direct p.G {_format_gain_flag_stats(direct_stats)} exceeds "
+                    f"{GAINCAL_FLAG_FRACTION_LIMIT * 100:.0f}% limit; rescue produced no table"
+                )
+                return EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, reason)
+
+            from dsa110_continuum.adapters import casa_tables as _ct2
+
+            with _ct2.table(
+                f"{meridian_ms}::SPECTRAL_WINDOW", readonly=True, ack=False
+            ) as _tspw:
+                _n_spw = _tspw.nrows()
+            _precond = [precond_table]
+            _precond_interp = ["linear"]
+            _precond_spwmap = [[0] * _n_spw]
+            service.gaincal(
+                vis=meridian_ms,
+                caltable=rescue_p_table,
+                field="",
+                refant=refant,
+                calmode="p",
+                solint="inf",
+                minsnr=3.0,
+                gaintype="G",
+                gaintable=[bp_table, precond_table],
+                interp=["nearest", "linear"],
+                spwmap=[[], *_precond_spwmap],
             )
+            if not os.path.exists(rescue_p_table):
+                return EpochGaincalResult(
+                    None,
+                    EpochGaincalStatus.LOW_SNR,
+                    "pre-conditioner rescue phase solve produced no table",
+                )
+            rescue_stats = _gain_flag_fractions(rescue_p_table, bp_table)
+            log.info(
+                "Epoch gaincal [%s]: rescue p.G %s",
+                stem,
+                _format_gain_flag_stats(rescue_stats),
+            )
+            rescue_fraction = float(rescue_stats["effective_fraction"])
+            if (
+                rescue_fraction > GAINCAL_FLAG_FRACTION_LIMIT
+                or rescue_fraction >= float(direct_stats["effective_fraction"])
+            ):
+                reason = (
+                    f"rescue p.G {_format_gain_flag_stats(rescue_stats)} did not strictly improve "
+                    f"and pass the {GAINCAL_FLAG_FRACTION_LIMIT * 100:.0f}% limit"
+                )
+                return EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, reason)
+            p_table = rescue_p_table
 
         # Apply BP + precond (if present) + p.G before WSClean imaging
         apply_to_target(
@@ -633,6 +711,15 @@ def calibrate_epoch(
                 EpochGaincalStatus.SOLVER_NO_TABLE,
                 "amplitude+phase gaincal produced no table (likely all solutions flagged at minsnr=3.0)",
             )
+
+        ap_stats = _gain_flag_fractions(ap_table, bp_table)
+        log.info("Epoch gaincal [%s]: ap.G %s", stem, _format_gain_flag_stats(ap_stats))
+        if float(ap_stats["effective_fraction"]) > GAINCAL_FLAG_FRACTION_LIMIT:
+            reason = (
+                f"ap.G {_format_gain_flag_stats(ap_stats)} exceeds "
+                f"{GAINCAL_FLAG_FRACTION_LIMIT * 100:.0f}% limit"
+            )
+            return EpochGaincalResult(None, EpochGaincalStatus.LOW_SNR, reason)
 
         log.info("Epoch gaincal [%s]: SUCCESS → %s", stem, ap_table)
         return EpochGaincalResult(ap_table, EpochGaincalStatus.SOLVED, None)

--- a/dsa110_continuum/calibration/model.py
+++ b/dsa110_continuum/calibration/model.py
@@ -1526,7 +1526,7 @@ def count_bright_sources_in_tile(
                     all_sources.extend(sources_df.to_dict("records"))
                     break  # Use first catalog with results
 
-            except (ValueError, KeyError, RuntimeError) as e:
+            except (FileNotFoundError, ValueError, KeyError, RuntimeError) as e:
                 logger.debug(f"Error querying {catalog_type} catalog: {e}")
                 continue
 

--- a/dsa110_continuum/calibration/skymodels.py
+++ b/dsa110_continuum/calibration/skymodels.py
@@ -632,9 +632,8 @@ def predict_from_skymodel_wsclean(
         pyradiosky SkyModel with multiple sources
     field : str or None
         Field selection string. If None or empty, defaults to all fields in the MS
-        (e.g., "0~23" for a 24-field MS). Used to determine which field's phase
-        center to use for the WSClean model image. For a range like "0~23", the
-        midpoint field's phase center is used.
+        (e.g., "0~23" for a 24-field MS). The selection is passed to WSClean, and
+        its midpoint field supplies the model-image phase center.
     wsclean_path : str, optional
         Path to wsclean executable. If None, uses Docker or searches PATH
     temp_dir : str, optional
@@ -664,6 +663,17 @@ def predict_from_skymodel_wsclean(
 
     if sky_model.Ncomponents == 0:
         raise ValueError("SkyModel is empty - cannot predict visibilities")
+
+    field_str = str(field).strip() if field is not None else ""
+    if not field_str:
+        wsclean_field = "all"
+    elif "~" in field_str:
+        start, end = (int(part) for part in field_str.split("~", maxsplit=1))
+        if end < start:
+            raise ValueError(f"Invalid field range: {field_str}")
+        wsclean_field = ",".join(str(field_id) for field_id in range(start, end + 1))
+    else:
+        wsclean_field = field_str
 
     # Ensure MODEL_DATA column exists
     try:
@@ -943,6 +953,8 @@ def predict_from_skymodel_wsclean(
                 [
                     "-predict",
                     "-reorder",  # Required for multi-SPW MS
+                    "-field",
+                    wsclean_field,
                     "-name",
                     model_prefix,
                     ms_path,
@@ -998,6 +1010,8 @@ def predict_from_skymodel_wsclean(
                 wsclean_exec,
                 "-predict",
                 "-reorder",  # Required for multi-SPW MS
+                "-field",
+                wsclean_field,
                 "-name",
                 model_prefix,
                 ms_path,

--- a/dsa110_continuum/calibration/solve_bandpass.py
+++ b/dsa110_continuum/calibration/solve_bandpass.py
@@ -125,8 +125,9 @@ def _flag_fraction_excluding_dead_receptors(
     antenna_ids: Any,
     *,
     dead_threshold: float = 0.99,
+    excluded_receptors: set[tuple[int, int]] | None = None,
 ) -> dict[str, Any]:
-    """Compute caltable flag fraction after removing dead antenna receptors."""
+    """Compute flag fraction after removing independently known dead receptors."""
     import numpy as np
 
     flags = np.asarray(flags, dtype=bool)
@@ -139,18 +140,18 @@ def _flag_fraction_excluding_dead_receptors(
             f"antenna IDs for {flags.shape[0]} rows"
         )
 
-    # CASA polarization/receptor axes are always small (≤4); channel axes are
-    # always >4. Pick the cell axis whose size is ≤4 as the receptor axis.
-    cell_axes = flags.shape[1:]
-    receptor_axis_in_cell = min(
-        range(len(cell_axes)),
-        key=lambda idx: (cell_axes[idx] > 4, cell_axes[idx]),
-    )
-    receptor_axis = receptor_axis_in_cell + 1
+    receptor_axis = 1
     receptor_count = flags.shape[receptor_axis]
+    if receptor_count > 4:
+        raise ValueError(f"Expected receptor axis at index 1, found shape {flags.shape}")
 
     unique_antennas = sorted(set(antenna_ids.tolist()))
-    dead_receptors: list[tuple[int, int]] = []
+    candidate_receptors = {
+        (int(antenna_id), receptor_idx)
+        for antenna_id in unique_antennas
+        for receptor_idx in range(receptor_count)
+    }
+    dead_receptors = set(excluded_receptors or ()) & candidate_receptors
     working_flagged = 0
     working_total = 0
 
@@ -162,9 +163,10 @@ def _flag_fraction_excluding_dead_receptors(
             receptor_total = int(receptor_flags.size)
             receptor_flagged = int(np.sum(receptor_flags))
             receptor_fraction = receptor_flagged / receptor_total if receptor_total else 0.0
-            if receptor_fraction >= dead_threshold:
-                dead_receptors.append((int(antenna_id), receptor_idx))
-            else:
+            receptor = (int(antenna_id), receptor_idx)
+            if excluded_receptors is None and receptor_fraction >= dead_threshold:
+                dead_receptors.add(receptor)
+            if receptor not in dead_receptors:
                 working_flagged += receptor_flagged
                 working_total += receptor_total
 
@@ -176,6 +178,7 @@ def _flag_fraction_excluding_dead_receptors(
         "effective_flag_fraction": float(effective_flag_fraction),
         "dead_receptor_count": len(dead_receptors),
         "dead_antenna_count": len(dead_antennas),
+        "dead_receptors": sorted(dead_receptors),
         "working_receptor_count": len(unique_antennas) * receptor_count - len(dead_receptors),
         "working_flagged": int(working_flagged),
         "working_total": int(working_total),

--- a/dsa110_continuum/conversion/ms_utils.py
+++ b/dsa110_continuum/conversion/ms_utils.py
@@ -702,7 +702,7 @@ def _ensure_state_table_valid(ms_path: str) -> None:
 
 
 def normalize_phaseshifted_ms_to_single_field(ms_path: str, ra_deg: float, dec_deg: float) -> None:
-    """Normalize a phaseshift+concat MS so calibration can treat it as one field.
+    """Normalize an aligned phaseshift+concat MS to one field for imaging.
 
     CASA's multi-field workaround (phaseshift each field then concat) can produce
     an MS where concat offsets/renumbers FIELD_ID values (e.g., 0, 25..47). The
@@ -711,13 +711,14 @@ def normalize_phaseshifted_ms_to_single_field(ms_path: str, ra_deg: float, dec_d
     - Setting FIELD_ID=0 in the MAIN table (and key subtables when present)
     - Ensuring FIELD row 0 has the requested phase center
 
-    This is safe for calibration because the data have already been phaseshifted
-    to the target phase center; we are only normalizing metadata/IDs.
+    Call this only after per-field calibration: the data must already be
+    phaseshifted and calibrated at the common target phase center.
 
     Parameters
     ----------
     """
     import numpy as _np
+    from dsa110_continuum.calibration.field_directions import set_field_ra_dec
 
     _tb = None
     _use_casatools = False
@@ -741,8 +742,6 @@ def normalize_phaseshifted_ms_to_single_field(ms_path: str, ra_deg: float, dec_d
     try:
         ra_rad = float(_np.radians(ra_deg))
         dec_rad = float(_np.radians(dec_deg))
-        phase_dir_cell = _np.array([[ra_rad, dec_rad]], dtype=_np.float64)  # shape (1, 2)
-
         if _use_casatools:
             main = _tb()
             main.open(ms_path, nomodify=False)
@@ -757,8 +756,8 @@ def normalize_phaseshifted_ms_to_single_field(ms_path: str, ra_deg: float, dec_d
                 return
             for col in ("PHASE_DIR", "DELAY_DIR", "REFERENCE_DIR"):
                 if col in field_tb.colnames():
-                    cell = phase_dir_cell.reshape((1, 2))
-                    field_tb.putcell(col, 0, cell)
+                    directions = field_tb.getcol(col)
+                    field_tb.putcol(col, set_field_ra_dec(directions, ra_rad, dec_rad))
             field_tb.close()
         else:
             with _tb(ms_path, readonly=False) as main:
@@ -770,7 +769,8 @@ def normalize_phaseshifted_ms_to_single_field(ms_path: str, ra_deg: float, dec_d
                     return
                 for col in ("PHASE_DIR", "DELAY_DIR", "REFERENCE_DIR"):
                     if col in field_tb.colnames():
-                        field_tb.putcell(col, 0, phase_dir_cell)
+                        directions = field_tb.getcol(col)
+                        field_tb.putcol(col, set_field_ra_dec(directions, ra_rad, dec_rad))
 
         # Keep other common FIELD_ID-bearing subtables consistent when present.
         for subtable_name in ("POINTING", "SOURCE", "FLAG_CMD"):

--- a/dsa110_continuum/imaging/cli_imaging.py
+++ b/dsa110_continuum/imaging/cli_imaging.py
@@ -983,13 +983,15 @@ def image_ms(
     radius_deg = 0.5 * float(math.hypot(fov_x, fov_y))
 
     # Get phase center from MS (needed for mask generation and unified catalog seeding)
+    from dsa110_continuum.calibration.field_directions import extract_field_ra_dec
+
     ra0_deg = dec0_deg = None
     with casatables.table(f"{ms_path}::FIELD", readonly=True) as fld:
         try:
-            ph = fld.getcol("PHASE_DIR")[0]
-            ra0_deg = float(ph[0][0]) * (180.0 / np.pi)
-            dec0_deg = float(ph[0][1]) * (180.0 / np.pi)
-        except (KeyError, IndexError, TypeError):
+            field_ra_rad, field_dec_rad = extract_field_ra_dec(fld.getcol("PHASE_DIR"))
+            ra0_deg = float(np.degrees(field_ra_rad[0]))
+            dec0_deg = float(np.degrees(field_dec_rad[0]))
+        except (KeyError, IndexError, TypeError, ValueError):
             pass
     if ra0_deg is None or dec0_deg is None:
         LOG.warning("Could not determine phase center from MS FIELD table")
@@ -1003,10 +1005,6 @@ def image_ms(
         and calib_flux_jy > 0
     ):
         try:
-            with casatables.table(f"{ms_path}::FIELD", readonly=True) as fld:
-                ph = fld.getcol("PHASE_DIR")[0]
-                ra0_deg = float(ph[0][0]) * (180.0 / np.pi)
-                dec0_deg = float(ph[0][1]) * (180.0 / np.pi)
             # crude small-angle separation in deg
             d_ra = (float(calib_ra_deg) - ra0_deg) * np.cos(np.deg2rad(dec0_deg))
             d_dec = float(calib_dec_deg) - dec0_deg

--- a/dsa110_continuum/qa/image_metrics.py
+++ b/dsa110_continuum/qa/image_metrics.py
@@ -16,7 +16,12 @@ def _maybe_to_gpu(array: np.ndarray, *, min_elements: int = 1_000_000):
         min_elements=settings.gpu.min_array_size,
     )
     if is_gpu and array.size >= min_elements:
-        return xp.asarray(array), xp, True
+        try:
+            backend_array = xp.asarray(array)
+            xp.asnumpy(xp.abs(backend_array.ravel()[:1]))
+            return backend_array, xp, True
+        except Exception:
+            return array, np, False
     return array, np, False
 
 

--- a/scripts/batch_pipeline.py
+++ b/scripts/batch_pipeline.py
@@ -1126,9 +1126,9 @@ def process_tile_safe(
     import mosaic_day as _md
     tag = Path(ms_path).stem
 
-    def _attempt() -> _md.TileResult:
+    def _attempt(attempt_force_recal: bool) -> _md.TileResult:
         with ProcessPoolExecutor(max_workers=1) as pool:
-            fut = pool.submit(_run_process_ms, ms_path, cfg_dict, keep, force_recal)
+            fut = pool.submit(_run_process_ms, ms_path, cfg_dict, keep, attempt_force_recal)
             try:
                 result_dict = fut.result(timeout=timeout_sec)
                 return _md.TileResult.from_dict(result_dict)
@@ -1139,11 +1139,11 @@ def process_tile_safe(
                 return _md.TileResult("failed", failed_stage="timeout",
                                       error=f"exceeded {timeout_sec}s")
 
-    result = _attempt()
+    result = _attempt(force_recal)
     if not result.ok and retry:
         log.warning("[%s] First attempt failed — waiting 60s then retrying once", tag)
         time.sleep(60)
-        result = _attempt()
+        result = _attempt(False)
         if not result.ok:
             log.error("[%s] Retry also failed — skipping tile", tag)
     return result

--- a/scripts/mosaic_day.py
+++ b/scripts/mosaic_day.py
@@ -566,6 +566,7 @@ def process_ms(
         image_ms(
             ms_path=meridian_ms,
             imagename=imagename,
+            field="all",
             imsize=IMSIZE,
             cell_arcsec=CELL_ARCSEC,
             weighting=WEIGHTING,

--- a/scripts/mosaic_day.py
+++ b/scripts/mosaic_day.py
@@ -426,6 +426,46 @@ def validate_window_params(window_tiles: int, stride_tiles: int) -> list[str]:
     return errors
 
 
+def _normalize_meridian_for_imaging(ms_path: str) -> None:
+    """Collapse an aligned, calibrated meridian MS to FIELD_ID 0."""
+    from astropy.coordinates import angular_separation
+
+    from dsa110_continuum.adapters.casa_tables import table
+    from dsa110_continuum.calibration.field_directions import extract_field_ra_dec
+    from dsa110_continuum.conversion.ms_utils import normalize_phaseshifted_ms_to_single_field
+
+    with table(f"{ms_path}::FIELD", readonly=True, ack=False) as field_table:
+        ra_rad, dec_rad = extract_field_ra_dec(field_table.getcol("PHASE_DIR"))
+
+    if len(ra_rad) == 0 or not np.all(np.isfinite(ra_rad)) or not np.all(np.isfinite(dec_rad)):
+        raise RuntimeError("FIELD::PHASE_DIR is empty or non-finite after phaseshift")
+
+    max_offset_arcsec = float(
+        np.degrees(np.max(angular_separation(ra_rad[0], dec_rad[0], ra_rad, dec_rad)))
+        * 3600.0
+    )
+    if max_offset_arcsec > 1.0:
+        raise RuntimeError(
+            f"FIELD phase centres differ by up to {max_offset_arcsec:.3f} arcsec after phaseshift"
+        )
+
+    normalize_phaseshifted_ms_to_single_field(
+        ms_path,
+        ra_deg=float(np.degrees(ra_rad[0])),
+        dec_deg=float(np.degrees(dec_rad[0])),
+    )
+    with table(ms_path, readonly=True, ack=False) as main_table:
+        field_ids = np.unique(main_table.getcol("FIELD_ID"))
+    if not np.array_equal(field_ids, np.array([0])):
+        raise RuntimeError(f"FIELD_ID normalization failed; found {field_ids.tolist()}")
+
+    log.info(
+        "Collapsed calibrated meridian MS to FIELD_ID=0 for PB imaging "
+        "(maximum pre-collapse offset %.3f arcsec)",
+        max_offset_arcsec,
+    )
+
+
 def process_ms(
     ms_path: str,
     cfg: TileConfig,
@@ -439,6 +479,14 @@ def process_ms(
     # With pbcor=True, WSClean produces {imagename}-image-pb.fits (primary-beam corrected)
     pbcor_fits = imagename + "-image-pb.fits"
     image_fits = imagename + "-image.fits"
+    sentinel = _applycal_sentinel_path(meridian_ms)
+
+    if force_recal and os.path.isdir(meridian_ms):
+        log.info("[%s] Removing derived meridian MS for forced recalibration", tag)
+        shutil.rmtree(meridian_ms)
+        for stale_sentinel in [sentinel, *glob.glob(f"{meridian_ms}.rfi_*_done")]:
+            if os.path.isfile(stale_sentinel):
+                os.remove(stale_sentinel)
 
     # Skip if already fully processed — unless force_recal requests a fresh run
     if not force_recal:
@@ -466,7 +514,6 @@ def process_ms(
                     log.warning("[%s] Could not remove %s: %s", tag, partial, e)
 
     # ── Step 1: Phaseshift ────────────────────────────────────────────────
-    sentinel = _applycal_sentinel_path(meridian_ms)
     if _ms_is_valid(meridian_ms):
         log.info("[%s] Meridian MS already exists", tag)
     else:
@@ -560,13 +607,19 @@ def process_ms(
     else:
         log.info("[%s] Calibration already applied (sentinel exists)", tag)
 
+    try:
+        _normalize_meridian_for_imaging(meridian_ms)
+    except Exception as e:
+        log.error("[%s] Field normalization failed: %s", tag, e)
+        return TileResult("failed", failed_stage="field_normalization", error=str(e))
+
     # ── Step 3: Image ──────────────────────────────────────────────────────
     log.info("[%s] Imaging with WSClean ...", tag)
     try:
         image_ms(
             ms_path=meridian_ms,
             imagename=imagename,
-            field="all",
+            field="0",
             imsize=IMSIZE,
             cell_arcsec=CELL_ARCSEC,
             weighting=WEIGHTING,

--- a/scripts/run_rolling_mosaic_campaign.py
+++ b/scripts/run_rolling_mosaic_campaign.py
@@ -514,13 +514,13 @@ def prune_hour(date: str, hour: int, retain_stems: set[str] | None = None) -> No
 
 
 def run_campaign(plan_only: bool) -> None:
+    os.environ.setdefault("CONTIMG_TMPFS_DIR", "/dev/shm/dsa110-continuum")
+    os.environ.setdefault("CONTIMG_SCRATCH_DIR", "/dev/shm/dsa110-continuum")
     os.environ.update(
         PYTHONPATH=str(REPO),
         PIPELINE_DB=str(DB_PATH),
         CONTIMG_BASE_DIR=str(REPO),
         CONTIMG_STATE_DIR=str(REPO / "state"),
-        CONTIMG_TMPFS_DIR="/dev/shm/dsa110-continuum",
-        CONTIMG_SCRATCH_DIR="/dev/shm/dsa110-continuum",
         DSA110_CATALOG_DIR=str(REPO / "state/catalogs"),
         DSA110_MS_DIR=str(MS_DIR),
         DSA110_STAGE_IMAGE_BASE=str(IMAGE_DIR),

--- a/scripts/run_rolling_mosaic_campaign.py
+++ b/scripts/run_rolling_mosaic_campaign.py
@@ -18,13 +18,23 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
-INPUT_DIR = Path("/data/incoming")
-MS_DIR = Path("/stage/dsa110-continuum/ms")
-PROC_MS_DIR = Path("/data/dsa110-proc/ms")
-PRODUCTS_DIR = Path("/data/dsa110-proc/products")
-IMAGE_DIR = Path("/stage/dsa110-continuum/images")
-DB_PATH = REPO / "state/db/pipeline.sqlite3"
-CAMPAIGN_DIR = REPO / "outputs/jan-apr-mosaic-campaign-2026-07-21"
+INPUT_DIR = Path(os.environ.get("DSA110_INPUT_DIR", "/data/incoming"))
+MS_DIR = Path(os.environ.get("DSA110_MS_DIR", "/stage/dsa110-continuum/ms"))
+PROC_MS_DIR = Path(os.environ.get("DSA110_PROC_MS_DIR", "/data/dsa110-proc/ms"))
+PRODUCTS_MOSAIC_DIR = Path(
+    os.environ.get("DSA110_PRODUCTS_BASE", "/data/dsa110-proc/products/mosaics")
+)
+PRODUCTS_DIR = PRODUCTS_MOSAIC_DIR.parent
+IMAGE_DIR = Path(
+    os.environ.get("DSA110_STAGE_IMAGE_BASE", "/stage/dsa110-continuum/images")
+)
+DB_PATH = Path(os.environ.get("PIPELINE_DB", REPO / "state/db/pipeline.sqlite3"))
+CAMPAIGN_DIR = Path(
+    os.environ.get(
+        "DSA110_CAMPAIGN_DIR",
+        REPO / "outputs/jan-apr-mosaic-campaign-2026-07-21",
+    )
+)
 STATUS_PATH = CAMPAIGN_DIR / "status.json"
 FILE_RE = re.compile(r"^(2026-(?:01|02|03|04)-\d{2})T.*_sb\d+\.hdf5$")
 NVME_RESERVE_BYTES = 20 * 1024**3
@@ -99,14 +109,50 @@ def run(command: list[str]) -> None:
     subprocess.run(command, cwd=REPO, check=True)
 
 
+def _select_ms_for_mosaic_hour(ms_paths: list[str], target_hour: int) -> list[str]:
+    """Keep one hourly core plus two tiles from each adjacent available hour."""
+    by_hour: dict[int, list[str]] = defaultdict(list)
+    for path in sorted(ms_paths):
+        try:
+            hour = datetime.strptime(Path(path).stem, "%Y-%m-%dT%H:%M:%S").hour
+        except ValueError:
+            continue
+        by_hour[hour].append(path)
+    if target_hour not in by_hour:
+        return []
+    hours = sorted(by_hour)
+    index = hours.index(target_hour)
+    selected = list(by_hour[target_hour])
+    if index:
+        selected = by_hour[hours[index - 1]][-2:] + selected
+    if index + 1 < len(hours):
+        selected.extend(by_hour[hours[index + 1]][:2])
+    return selected
+
+
+def _measurement_set_is_readable(ms_path: str) -> bool:
+    """Return whether the main table and essential subtables can be read."""
+    from dsa110_continuum.adapters import casa_tables as ct
+
+    try:
+        with ct.table(ms_path, readonly=True, ack=False) as table:
+            if table.nrows() == 0 or not {"DATA", "FLAG"}.issubset(table.colnames()):
+                return False
+        for subtable in ("FIELD", "SPECTRAL_WINDOW"):
+            with ct.table(f"{ms_path}::{subtable}", readonly=True, ack=False) as table:
+                if table.nrows() == 0:
+                    return False
+    except Exception:
+        return False
+    return True
+
+
 def _working_set_group_ids(
     date: str,
     target_hour: int,
     start_hour: int,
     end_hour: int,
 ) -> set[str]:
-    from batch_pipeline import select_ms_for_mosaic_hour
-
     query = """
         SELECT group_id
         FROM hdf5_files
@@ -126,7 +172,7 @@ def _working_set_group_ids(
     inventory_paths = [f"/inventory/{group_id}.ms" for group_id in group_ids]
     return {
         Path(path).stem
-        for path in select_ms_for_mosaic_hour(inventory_paths, target_hour)
+        for path in _select_ms_for_mosaic_hour(inventory_paths, target_hour)
     }
 
 
@@ -139,8 +185,6 @@ def _is_base_ms(path: Path) -> bool:
 
 
 def demote_inactive_nvme_ms(date: str, active_stems: set[str]) -> None:
-    from dsa110_continuum.calibration.epoch_gaincal import _measurement_set_is_readable
-
     for path in sorted(MS_DIR.glob(f"{date}T*.ms")):
         if not _is_base_ms(path) or path.stem in active_stems or path.is_symlink():
             continue
@@ -216,8 +260,6 @@ def _active_ms_paths(
     start_hour: int,
     end_hour: int,
 ) -> list[Path]:
-    from batch_pipeline import select_ms_for_mosaic_hour
-
     candidates = []
     for path in MS_DIR.glob(f"{date}T*.ms"):
         try:
@@ -226,7 +268,7 @@ def _active_ms_paths(
             continue
         if start_hour <= hour < end_hour:
             candidates.append(str(path))
-    return [Path(path) for path in select_ms_for_mosaic_hour(candidates, target_hour)]
+    return [Path(path) for path in _select_ms_for_mosaic_hour(candidates, target_hour)]
 
 
 def _allocated_bytes(path: Path) -> int:
@@ -243,8 +285,6 @@ def promote_working_set_to_nvme(
     start_hour: int,
     end_hour: int,
 ) -> None:
-    from dsa110_continuum.calibration.epoch_gaincal import _measurement_set_is_readable
-
     paths = _active_ms_paths(date, target_hour, start_hour, end_hour)
     slow_links: list[tuple[Path, Path, int]] = []
     for path in paths:
@@ -327,7 +367,7 @@ def mosaic_paths(date: str, hour: int) -> tuple[Path, Path]:
 
 def _manifest_paths(date: str, hour: int) -> tuple[Path, Path]:
     preserved = CAMPAIGN_DIR / f"{date}T{hour:02d}_{date}_manifest.json"
-    current = Path("/data/dsa110-proc/products/mosaics") / date / f"{date}_manifest.json"
+    current = PRODUCTS_MOSAIC_DIR / date / f"{date}_manifest.json"
     return preserved, current
 
 
@@ -353,11 +393,72 @@ def mosaic_is_valid(date: str, hour: int) -> bool:
 
 
 def preserve_run_metadata(date: str, hour: int) -> None:
-    products = Path("/data/dsa110-proc/products/mosaics") / date
-    for name in (f"{date}_manifest.json", f"{date}_run_summary.json", "run_report.md"):
+    products = PRODUCTS_MOSAIC_DIR / date
+    names = (f"{date}_manifest.json", f"{date}_run_summary.json", "run_report.md")
+    missing = [name for name in names if not (products / name).is_file()]
+    if missing:
+        raise FileNotFoundError(f"missing run metadata for {date}T{hour:02d}: {missing}")
+    for name in names:
         source = products / name
-        if source.exists():
-            shutil.copy2(source, CAMPAIGN_DIR / f"{date}T{hour:02d}_{name}")
+        shutil.copy2(source, CAMPAIGN_DIR / f"{date}T{hour:02d}_{name}")
+
+
+def preserved_run_metadata_complete(date: str, hour: int) -> bool:
+    prefix = CAMPAIGN_DIR / f"{date}T{hour:02d}_"
+    manifest_path = Path(f"{prefix}{date}_manifest.json")
+    summary_path = Path(f"{prefix}{date}_run_summary.json")
+    report_path = Path(f"{prefix}run_report.md")
+    if not all(path.is_file() for path in (manifest_path, summary_path, report_path)):
+        return False
+    try:
+        summary = json.loads(summary_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    label = f"{date}T{hour:02d}00"
+    summary_matches = any(
+        epoch.get("label") == label
+        and epoch.get("status") == "ok"
+        and epoch.get("qa_result") == "PASS"
+        for epoch in summary.get("epochs", [])
+    )
+    report_matches = f"| {hour:02d} | ok | PASS |" in report_path.read_text()
+    return strict_qa_passed(date, hour) and summary_matches and report_matches
+
+
+def photometry_path(date: str, hour: int) -> Path:
+    return PRODUCTS_MOSAIC_DIR / date / f"{date}T{hour:02d}00_forced_phot.csv"
+
+
+def accepted_artifacts_complete(date: str, hour: int) -> bool:
+    forced_phot = photometry_path(date, hour)
+    stacked = PRODUCTS_DIR / "lightcurves/lightcurves.parquet"
+    return (
+        mosaic_is_valid(date, hour)
+        and preserved_run_metadata_complete(date, hour)
+        and forced_phot.is_file()
+        and forced_phot.stat().st_size > 0
+        and stacked.is_file()
+        and stacked.stat().st_mtime_ns >= forced_phot.stat().st_mtime_ns
+    )
+
+
+def accepted_products_ready(date: str, hour: int) -> tuple[bool, str | None]:
+    try:
+        if not preserved_run_metadata_complete(date, hour):
+            preserve_run_metadata(date, hour)
+        if not preserved_run_metadata_complete(date, hour):
+            return False, "preserved run metadata does not match the accepted epoch"
+    except (OSError, ValueError) as exc:
+        return False, f"run metadata preservation failed: {exc}"
+    forced_phot = photometry_path(date, hour)
+    if not forced_phot.is_file() or forced_phot.stat().st_size == 0:
+        return False, "forced-photometry product is missing or empty"
+    if not refresh_lightcurves():
+        return False, "light-curve stack was not produced"
+    stacked = PRODUCTS_DIR / "lightcurves/lightcurves.parquet"
+    if not stacked.is_file() or stacked.stat().st_mtime_ns < forced_phot.stat().st_mtime_ns:
+        return False, "light-curve stack is older than forced photometry"
+    return True, None
 
 
 def refresh_lightcurves() -> bool:
@@ -371,7 +472,7 @@ def refresh_lightcurves() -> bool:
             str(PRODUCTS_DIR),
         ]
     )
-    return True
+    return (PRODUCTS_DIR / "lightcurves/lightcurves.parquet").is_file()
 
 
 def _last_base_ms_stems(date: str, hour: int, count: int = 2) -> list[str]:
@@ -423,6 +524,7 @@ def run_campaign(plan_only: bool) -> None:
         DSA110_CATALOG_DIR=str(REPO / "state/catalogs"),
         DSA110_MS_DIR=str(MS_DIR),
         DSA110_STAGE_IMAGE_BASE=str(IMAGE_DIR),
+        DSA110_PRODUCTS_BASE=str(PRODUCTS_MOSAIC_DIR),
     )
     write_status(state="indexing", error=None)
     index_inventory()
@@ -431,9 +533,10 @@ def run_campaign(plan_only: bool) -> None:
         f"{date}T{hour:02d}00"
         for date, hours in inventory.items()
         for hour in hours
-        if mosaic_is_valid(date, hour)
+        if accepted_artifacts_complete(date, hour)
     ]
     status = write_status(state="planned", dates=inventory, completed=accepted_existing)
+    completed_epochs = set(accepted_existing)
     failed_epochs = {
         str(item["epoch"]): item
         for item in status.get("failed_epochs", [])
@@ -463,7 +566,6 @@ def run_campaign(plan_only: bool) -> None:
                 run([*command, "--dry-run"])
                 write_status(state="imaging", date=date, target_hour=target_hour)
                 run(command)
-                preserve_run_metadata(date, target_hour)
                 if not mosaic_is_valid(date, target_hour):
                     accepted = False
                     failed_epochs[epoch] = {
@@ -478,16 +580,28 @@ def run_campaign(plan_only: bool) -> None:
                     )
 
             if accepted:
+                accepted, reason = accepted_products_ready(date, target_hour)
+                if not accepted:
+                    failed_epochs[epoch] = {"epoch": epoch, "reason": reason}
+                    completed_epochs.discard(epoch)
+                    write_status(
+                        state="epoch_rejected",
+                        date=date,
+                        target_hour=target_hour,
+                        completed=sorted(completed_epochs),
+                        failed_epochs=list(failed_epochs.values()),
+                    )
+
+            if accepted:
                 failed_epochs.pop(epoch, None)
-                completed = write_status(
+                completed_epochs.add(epoch)
+                write_status(
                     state="validated",
                     date=date,
                     target_hour=target_hour,
+                    completed=sorted(completed_epochs),
                     failed_epochs=list(failed_epochs.values()),
-                ).setdefault("completed", [])
-                if epoch not in completed:
-                    completed.append(epoch)
-                    write_status(completed=completed)
+                )
             if index:
                 previous_epoch = f"{date}T{hours[index - 1]:02d}00"
                 if previous_epoch not in failed_epochs:
@@ -499,9 +613,6 @@ def run_campaign(plan_only: bool) -> None:
                     else set()
                 )
                 prune_hour(date, target_hour, retain_stems)
-
-        refresh_lightcurves()
-
     write_status(
         state="complete_with_failures" if failed_epochs else "complete",
         failed_epochs=list(failed_epochs.values()),

--- a/scripts/run_rolling_mosaic_campaign.py
+++ b/scripts/run_rolling_mosaic_campaign.py
@@ -1,0 +1,524 @@
+#!/usr/bin/env python3
+# ruff: noqa: D103
+"""Resumable Jan-Apr 2026 rolling mosaic campaign for H17."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import sqlite3
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from datetime import datetime, timedelta
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+INPUT_DIR = Path("/data/incoming")
+MS_DIR = Path("/stage/dsa110-continuum/ms")
+PROC_MS_DIR = Path("/data/dsa110-proc/ms")
+PRODUCTS_DIR = Path("/data/dsa110-proc/products")
+IMAGE_DIR = Path("/stage/dsa110-continuum/images")
+DB_PATH = REPO / "state/db/pipeline.sqlite3"
+CAMPAIGN_DIR = REPO / "outputs/jan-apr-mosaic-campaign-2026-07-21"
+STATUS_PATH = CAMPAIGN_DIR / "status.json"
+FILE_RE = re.compile(r"^(2026-(?:01|02|03|04)-\d{2})T.*_sb\d+\.hdf5$")
+NVME_RESERVE_BYTES = 20 * 1024**3
+
+
+def write_status(**updates: object) -> dict:
+    CAMPAIGN_DIR.mkdir(parents=True, exist_ok=True)
+    status = json.loads(STATUS_PATH.read_text()) if STATUS_PATH.exists() else {}
+    status.update(updates, updated_at=datetime.now().astimezone().isoformat())
+    temp = STATUS_PATH.with_suffix(".tmp")
+    temp.write_text(json.dumps(status, indent=2, sort_keys=True) + "\n")
+    temp.replace(STATUS_PATH)
+    return status
+
+
+def index_inventory() -> None:
+    from dsa110_continuum.database.hdf5_index import index_subband_files
+    from dsa110_continuum.database.unified import init_unified_db
+
+    files_by_date: dict[str, list[Path]] = defaultdict(list)
+    with os.scandir(INPUT_DIR) as entries:
+        for entry in entries:
+            match = FILE_RE.match(entry.name)
+            if match and entry.is_file(follow_symlinks=False):
+                files_by_date[match.group(1)].append(Path(entry.path))
+
+    database = init_unified_db(DB_PATH)
+    try:
+        for date, files in sorted(files_by_date.items()):
+            added = index_subband_files(database.conn, sorted(files))
+            print(f"indexed {date}: {added} new rows", flush=True)
+    finally:
+        database.close()
+
+
+def complete_hours() -> dict[str, list[int]]:
+    query = """
+        WITH groups_by_hour AS (
+            SELECT obs_date, CAST(substr(timestamp_iso, 12, 2) AS INTEGER) AS hour,
+                   group_id, COUNT(DISTINCT subband_num) AS subbands
+            FROM hdf5_files
+            WHERE obs_date BETWEEN '2026-01-01' AND '2026-04-30'
+            GROUP BY obs_date, hour, group_id
+        )
+        SELECT obs_date, hour
+        FROM groups_by_hour
+        WHERE subbands = 16
+        GROUP BY obs_date, hour
+        ORDER BY obs_date, hour
+    """
+    result: dict[str, list[int]] = defaultdict(list)
+    with sqlite3.connect(DB_PATH) as connection:
+        for date, hour in connection.execute(query):
+            result[str(date)].append(int(hour))
+    return dict(result)
+
+
+def rolling_window(hours: list[int], index: int) -> tuple[int, int]:
+    start = hours[index - 1] if index else hours[index]
+    end = hours[index + 1] + 1 if index + 1 < len(hours) else hours[index] + 1
+    return start, end
+
+
+def iso_bound(date: str, hour: int) -> str:
+    return (datetime.strptime(date, "%Y-%m-%d") + timedelta(hours=hour)).strftime(
+        "%Y-%m-%dT%H:%M:%S"
+    )
+
+
+def run(command: list[str]) -> None:
+    print("+", " ".join(command), flush=True)
+    subprocess.run(command, cwd=REPO, check=True)
+
+
+def _working_set_group_ids(
+    date: str,
+    target_hour: int,
+    start_hour: int,
+    end_hour: int,
+) -> set[str]:
+    from batch_pipeline import select_ms_for_mosaic_hour
+
+    query = """
+        SELECT group_id
+        FROM hdf5_files
+        WHERE timestamp_iso >= ? AND timestamp_iso < ?
+        GROUP BY group_id
+        HAVING COUNT(DISTINCT subband_num) = 16
+        ORDER BY MIN(timestamp_iso)
+    """
+    with sqlite3.connect(DB_PATH) as connection:
+        group_ids = [
+            str(row[0])
+            for row in connection.execute(
+                query,
+                (iso_bound(date, start_hour), iso_bound(date, end_hour)),
+            )
+        ]
+    inventory_paths = [f"/inventory/{group_id}.ms" for group_id in group_ids]
+    return {
+        Path(path).stem
+        for path in select_ms_for_mosaic_hour(inventory_paths, target_hour)
+    }
+
+
+def _is_base_ms(path: Path) -> bool:
+    try:
+        datetime.strptime(path.stem, "%Y-%m-%dT%H:%M:%S")
+    except ValueError:
+        return False
+    return path.suffix == ".ms"
+
+
+def demote_inactive_nvme_ms(date: str, active_stems: set[str]) -> None:
+    from dsa110_continuum.calibration.epoch_gaincal import _measurement_set_is_readable
+
+    for path in sorted(MS_DIR.glob(f"{date}T*.ms")):
+        if not _is_base_ms(path) or path.stem in active_stems or path.is_symlink():
+            continue
+        target = PROC_MS_DIR / path.name
+        if not target.is_dir() or not _measurement_set_is_readable(str(target)):
+            continue
+        temp_link = path.with_name(f".{path.name}.slow-link-{os.getpid()}")
+        backup = path.with_name(f".{path.name}.nvme-backup-{os.getpid()}")
+        if (
+            temp_link.exists()
+            or temp_link.is_symlink()
+            or backup.exists()
+            or backup.is_symlink()
+        ):
+            raise RuntimeError(f"refusing stale NVMe demotion path for {path.name}")
+        temp_link.symlink_to(target)
+        path.rename(backup)
+        try:
+            temp_link.rename(path)
+        except Exception:
+            backup.rename(path)
+            temp_link.unlink(missing_ok=True)
+            raise
+        shutil.rmtree(backup)
+        print(f"demoted inactive {path.name} to slow-storage symlink", flush=True)
+
+
+def ensure_conversion_capacity(group_ids: set[str]) -> None:
+    missing = [group_id for group_id in group_ids if not (MS_DIR / f"{group_id}.ms").exists()]
+    if not missing:
+        return
+    samples = []
+    for path in sorted(PROC_MS_DIR.glob("*.ms")):
+        if _is_base_ms(path) and path.is_dir():
+            samples.append(_allocated_bytes(path))
+            if len(samples) == 3:
+                break
+    per_group = sorted(samples)[len(samples) // 2] if samples else 3 * 1024**3
+    required = len(missing) * per_group
+    free = shutil.disk_usage(MS_DIR).free
+    if required + NVME_RESERVE_BYTES > free:
+        raise RuntimeError(
+            f"conversion working set estimates {required / 1024**3:.1f} GiB plus "
+            f"{NVME_RESERVE_BYTES / 1024**3:.1f} GiB reserve; "
+            f"only {free / 1024**3:.1f} GiB is free"
+        )
+
+
+def convert_window(date: str, target_hour: int, start_hour: int, end_hour: int) -> None:
+    from dsa110_continuum.conversion.conversion_orchestrator import (
+        convert_subband_groups_to_ms,
+    )
+
+    group_ids = _working_set_group_ids(date, target_hour, start_hour, end_hour)
+    demote_inactive_nvme_ms(date, group_ids)
+    ensure_conversion_capacity(group_ids)
+    result = convert_subband_groups_to_ms(
+        str(INPUT_DIR),
+        str(MS_DIR),
+        iso_bound(date, start_hour),
+        iso_bound(date, end_hour),
+        skip_incomplete=True,
+        skip_existing=True,
+        group_ids=group_ids,
+    )
+    if result["failed"]:
+        raise RuntimeError(f"conversion failures: {result['failed']}")
+
+
+def _active_ms_paths(
+    date: str,
+    target_hour: int,
+    start_hour: int,
+    end_hour: int,
+) -> list[Path]:
+    from batch_pipeline import select_ms_for_mosaic_hour
+
+    candidates = []
+    for path in MS_DIR.glob(f"{date}T*.ms"):
+        try:
+            hour = datetime.strptime(path.stem, "%Y-%m-%dT%H:%M:%S").hour
+        except ValueError:
+            continue
+        if start_hour <= hour < end_hour:
+            candidates.append(str(path))
+    return [Path(path) for path in select_ms_for_mosaic_hour(candidates, target_hour)]
+
+
+def _allocated_bytes(path: Path) -> int:
+    total = 0
+    for root, dirs, files in os.walk(path):
+        for name in [*dirs, *files]:
+            total += (Path(root) / name).lstat().st_blocks * 512
+    return total
+
+
+def promote_working_set_to_nvme(
+    date: str,
+    target_hour: int,
+    start_hour: int,
+    end_hour: int,
+) -> None:
+    from dsa110_continuum.calibration.epoch_gaincal import _measurement_set_is_readable
+
+    paths = _active_ms_paths(date, target_hour, start_hour, end_hour)
+    slow_links: list[tuple[Path, Path, int]] = []
+    for path in paths:
+        if not path.is_symlink():
+            continue
+        target = path.resolve(strict=True)
+        if target.parent != PROC_MS_DIR:
+            raise RuntimeError(f"refusing unexpected MS source target: {target}")
+        slow_links.append((path, target, _allocated_bytes(target)))
+
+    required = sum(size for _path, _target, size in slow_links)
+    free = shutil.disk_usage(MS_DIR).free
+    if required + NVME_RESERVE_BYTES > free:
+        raise RuntimeError(
+            f"NVMe working set needs {required / 1024**3:.1f} GiB plus "
+            f"{NVME_RESERVE_BYTES / 1024**3:.1f} GiB reserve; "
+            f"only {free / 1024**3:.1f} GiB is free"
+        )
+
+    for path, target, _size in slow_links:
+        started = time.perf_counter()
+        print(f"promoting {path.name} to NVMe", flush=True)
+        temp = path.with_name(f".{path.name}.nvme-copy-{os.getpid()}")
+        backup = path.with_name(f".{path.name}.slow-link-{os.getpid()}")
+        if temp.exists() or temp.is_symlink() or backup.exists() or backup.is_symlink():
+            raise RuntimeError(f"refusing stale NVMe promotion path for {path.name}")
+        try:
+            shutil.copytree(target, temp, symlinks=True)
+            if not _measurement_set_is_readable(str(temp)):
+                raise RuntimeError(f"copied Measurement Set is unreadable: {temp}")
+            path.rename(backup)
+            try:
+                temp.rename(path)
+            except Exception:
+                backup.rename(path)
+                raise
+            backup.unlink()
+            print(
+                f"promoted {path.name} in {time.perf_counter() - started:.1f}s",
+                flush=True,
+            )
+        finally:
+            if temp.exists():
+                shutil.rmtree(temp)
+
+
+def batch_command(date: str, target_hour: int, start_hour: int, end_hour: int) -> list[str]:
+    command = [
+        "/opt/miniforge/envs/casa6/bin/python",
+        "scripts/batch_pipeline.py",
+        "--date",
+        date,
+        "--start-hour",
+        str(start_hour),
+        "--mosaic-hour",
+        str(target_hour),
+        "--rfi-mode",
+        "conditional",
+        "--quarantine-after-failures",
+        "3",
+        "--tile-timeout",
+        "1800",
+        "--retry-failed",
+        "--tile-workers",
+        "2",
+        "--photometry-workers",
+        "4",
+        "--photometry-chunk-size",
+        "0",
+    ]
+    if end_hour < 24:
+        command.extend(["--end-hour", str(end_hour)])
+    return command
+
+
+def mosaic_paths(date: str, hour: int) -> tuple[Path, Path]:
+    mosaic = IMAGE_DIR / f"mosaic_{date}" / f"{date}T{hour:02d}00_mosaic.fits"
+    return mosaic, mosaic.with_suffix(".weights.fits")
+
+
+def _manifest_paths(date: str, hour: int) -> tuple[Path, Path]:
+    preserved = CAMPAIGN_DIR / f"{date}T{hour:02d}_{date}_manifest.json"
+    current = Path("/data/dsa110-proc/products/mosaics") / date / f"{date}_manifest.json"
+    return preserved, current
+
+
+def strict_qa_passed(date: str, hour: int) -> bool:
+    for manifest_path in _manifest_paths(date, hour):
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        for epoch in manifest.get("epochs", []):
+            if int(epoch.get("hour", -1)) == hour:
+                return epoch.get("status") == "ok" and epoch.get("qa_result") == "PASS"
+    return False
+
+
+def mosaic_is_valid(date: str, hour: int) -> bool:
+    from dsa110_continuum.mosaic.production import weight_map_is_valid
+
+    mosaic, weight = mosaic_paths(date, hour)
+    return weight_map_is_valid(weight, mosaic) and strict_qa_passed(date, hour)
+
+
+def preserve_run_metadata(date: str, hour: int) -> None:
+    products = Path("/data/dsa110-proc/products/mosaics") / date
+    for name in (f"{date}_manifest.json", f"{date}_run_summary.json", "run_report.md"):
+        source = products / name
+        if source.exists():
+            shutil.copy2(source, CAMPAIGN_DIR / f"{date}T{hour:02d}_{name}")
+
+
+def refresh_lightcurves() -> bool:
+    if not any((PRODUCTS_DIR / "mosaics").glob("*/*_forced_phot.csv")):
+        return False
+    run(
+        [
+            "/opt/miniforge/envs/casa6/bin/python",
+            "scripts/stack_lightcurves.py",
+            "--products-dir",
+            str(PRODUCTS_DIR),
+        ]
+    )
+    return True
+
+
+def _last_base_ms_stems(date: str, hour: int, count: int = 2) -> list[str]:
+    stems = []
+    for path in sorted(MS_DIR.glob(f"{date}T{hour:02d}:*.ms")):
+        try:
+            datetime.strptime(path.stem, "%Y-%m-%dT%H:%M:%S")
+        except ValueError:
+            continue
+        stems.append(path.stem)
+    return stems[-count:]
+
+
+def prune_hour(date: str, hour: int, retain_stems: set[str] | None = None) -> None:
+    retain_stems = retain_stems or set()
+    for path in MS_DIR.glob(f"{date}T{hour:02d}:*"):
+        if any(path.name.startswith(stem) for stem in retain_stems):
+            continue
+        if path.name.endswith((".ms", ".ms.flagversions")):
+            if path.is_symlink():
+                target = path.resolve(strict=False)
+                if target.parent != PROC_MS_DIR:
+                    raise RuntimeError(f"refusing to prune unexpected MS target: {target}")
+                if target.exists():
+                    shutil.rmtree(target) if target.is_dir() else target.unlink()
+                path.unlink()
+            else:
+                shutil.rmtree(path) if path.is_dir() else path.unlink()
+
+            proc_copy = PROC_MS_DIR / path.name
+            if proc_copy.exists():
+                shutil.rmtree(proc_copy) if proc_copy.is_dir() else proc_copy.unlink()
+
+    stage = IMAGE_DIR / f"mosaic_{date}"
+    for path in stage.glob(f"{date}T{hour:02d}:*"):
+        if any(path.name.startswith(stem) for stem in retain_stems):
+            continue
+        shutil.rmtree(path) if path.is_dir() else path.unlink()
+
+
+def run_campaign(plan_only: bool) -> None:
+    os.environ.update(
+        PYTHONPATH=str(REPO),
+        PIPELINE_DB=str(DB_PATH),
+        CONTIMG_BASE_DIR=str(REPO),
+        CONTIMG_STATE_DIR=str(REPO / "state"),
+        CONTIMG_TMPFS_DIR="/dev/shm/dsa110-continuum",
+        CONTIMG_SCRATCH_DIR="/dev/shm/dsa110-continuum",
+        DSA110_CATALOG_DIR=str(REPO / "state/catalogs"),
+        DSA110_MS_DIR=str(MS_DIR),
+        DSA110_STAGE_IMAGE_BASE=str(IMAGE_DIR),
+    )
+    write_status(state="indexing", error=None)
+    index_inventory()
+    inventory = complete_hours()
+    accepted_existing = [
+        f"{date}T{hour:02d}00"
+        for date, hours in inventory.items()
+        for hour in hours
+        if mosaic_is_valid(date, hour)
+    ]
+    status = write_status(state="planned", dates=inventory, completed=accepted_existing)
+    failed_epochs = {
+        str(item["epoch"]): item
+        for item in status.get("failed_epochs", [])
+        if isinstance(item, dict) and item.get("epoch")
+    }
+    if plan_only:
+        return
+
+    for date, hours in inventory.items():
+        for index, target_hour in enumerate(hours):
+            start_hour, end_hour = rolling_window(hours, index)
+            epoch = f"{date}T{target_hour:02d}00"
+            accepted = True
+            if mosaic_is_valid(date, target_hour):
+                print(f"validated existing mosaic {epoch}", flush=True)
+            else:
+                write_status(
+                    state="converting",
+                    date=date,
+                    target_hour=target_hour,
+                    window=[start_hour, end_hour],
+                )
+                convert_window(date, target_hour, start_hour, end_hour)
+                promote_working_set_to_nvme(date, target_hour, start_hour, end_hour)
+                command = batch_command(date, target_hour, start_hour, end_hour)
+                write_status(state="dry_run", date=date, target_hour=target_hour)
+                run([*command, "--dry-run"])
+                write_status(state="imaging", date=date, target_hour=target_hour)
+                run(command)
+                preserve_run_metadata(date, target_hour)
+                if not mosaic_is_valid(date, target_hour):
+                    accepted = False
+                    failed_epochs[epoch] = {
+                        "epoch": epoch,
+                        "reason": "mosaic failed product integrity or strict QA",
+                    }
+                    write_status(
+                        state="epoch_rejected",
+                        date=date,
+                        target_hour=target_hour,
+                        failed_epochs=list(failed_epochs.values()),
+                    )
+
+            if accepted:
+                failed_epochs.pop(epoch, None)
+                completed = write_status(
+                    state="validated",
+                    date=date,
+                    target_hour=target_hour,
+                    failed_epochs=list(failed_epochs.values()),
+                ).setdefault("completed", [])
+                if epoch not in completed:
+                    completed.append(epoch)
+                    write_status(completed=completed)
+            if index:
+                previous_epoch = f"{date}T{hours[index - 1]:02d}00"
+                if previous_epoch not in failed_epochs:
+                    prune_hour(date, hours[index - 1])
+            if accepted:
+                retain_stems = (
+                    set(_last_base_ms_stems(date, target_hour))
+                    if index + 1 < len(hours)
+                    else set()
+                )
+                prune_hour(date, target_hour, retain_stems)
+
+        refresh_lightcurves()
+
+    write_status(
+        state="complete_with_failures" if failed_epochs else "complete",
+        failed_epochs=list(failed_epochs.values()),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--plan-only", action="store_true")
+    args = parser.parse_args()
+    try:
+        run_campaign(args.plan_only)
+    except Exception as error:
+        write_status(state="failed", error=str(error))
+        raise
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(REPO))
+    main()

--- a/scripts/run_rolling_mosaic_campaign.py
+++ b/scripts/run_rolling_mosaic_campaign.py
@@ -25,9 +25,7 @@ PRODUCTS_MOSAIC_DIR = Path(
     os.environ.get("DSA110_PRODUCTS_BASE", "/data/dsa110-proc/products/mosaics")
 )
 PRODUCTS_DIR = PRODUCTS_MOSAIC_DIR.parent
-IMAGE_DIR = Path(
-    os.environ.get("DSA110_STAGE_IMAGE_BASE", "/stage/dsa110-continuum/images")
-)
+IMAGE_DIR = Path(os.environ.get("DSA110_STAGE_IMAGE_BASE", "/stage/dsa110-continuum/images"))
 DB_PATH = Path(os.environ.get("PIPELINE_DB", REPO / "state/db/pipeline.sqlite3"))
 CAMPAIGN_DIR = Path(
     os.environ.get(
@@ -170,10 +168,7 @@ def _working_set_group_ids(
             )
         ]
     inventory_paths = [f"/inventory/{group_id}.ms" for group_id in group_ids]
-    return {
-        Path(path).stem
-        for path in _select_ms_for_mosaic_hour(inventory_paths, target_hour)
-    }
+    return {Path(path).stem for path in _select_ms_for_mosaic_hour(inventory_paths, target_hour)}
 
 
 def _is_base_ms(path: Path) -> bool:
@@ -193,12 +188,7 @@ def demote_inactive_nvme_ms(date: str, active_stems: set[str]) -> None:
             continue
         temp_link = path.with_name(f".{path.name}.slow-link-{os.getpid()}")
         backup = path.with_name(f".{path.name}.nvme-backup-{os.getpid()}")
-        if (
-            temp_link.exists()
-            or temp_link.is_symlink()
-            or backup.exists()
-            or backup.is_symlink()
-        ):
+        if temp_link.exists() or temp_link.is_symlink() or backup.exists() or backup.is_symlink():
             raise RuntimeError(f"refusing stale NVMe demotion path for {path.name}")
         temp_link.symlink_to(target)
         path.rename(backup)
@@ -373,16 +363,23 @@ def _manifest_paths(date: str, hour: int) -> tuple[Path, Path]:
 
 def strict_qa_passed(date: str, hour: int) -> bool:
     for manifest_path in _manifest_paths(date, hour):
-        if not manifest_path.exists():
-            continue
-        try:
-            manifest = json.loads(manifest_path.read_text())
-        except (OSError, json.JSONDecodeError):
-            continue
-        for epoch in manifest.get("epochs", []):
-            if int(epoch.get("hour", -1)) == hour:
-                return epoch.get("status") == "ok" and epoch.get("qa_result") == "PASS"
+        verdict = _manifest_epoch_passed(manifest_path, hour)
+        if verdict is not None:
+            return verdict
     return False
+
+
+def _manifest_epoch_passed(manifest_path: Path, hour: int) -> bool | None:
+    if not manifest_path.exists():
+        return None
+    try:
+        manifest = json.loads(manifest_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    for epoch in manifest.get("epochs", []):
+        if int(epoch.get("hour", -1)) == hour:
+            return epoch.get("status") == "ok" and epoch.get("qa_result") == "PASS"
+    return None
 
 
 def mosaic_is_valid(date: str, hour: int) -> bool:
@@ -422,7 +419,9 @@ def preserved_run_metadata_complete(date: str, hour: int) -> bool:
         for epoch in summary.get("epochs", [])
     )
     report_matches = f"| {hour:02d} | ok | PASS |" in report_path.read_text()
-    return strict_qa_passed(date, hour) and summary_matches and report_matches
+    return (
+        _manifest_epoch_passed(manifest_path, hour) is True and summary_matches and report_matches
+    )
 
 
 def photometry_path(date: str, hour: int) -> Path:
@@ -608,9 +607,7 @@ def run_campaign(plan_only: bool) -> None:
                     prune_hour(date, hours[index - 1])
             if accepted:
                 retain_stems = (
-                    set(_last_base_ms_stems(date, target_hour))
-                    if index + 1 < len(hours)
-                    else set()
+                    set(_last_base_ms_stems(date, target_hour)) if index + 1 < len(hours) else set()
                 )
                 prune_hour(date, target_hour, retain_stems)
     write_status(

--- a/tests/test_batch_pipeline_dry_run_quarantine.py
+++ b/tests/test_batch_pipeline_dry_run_quarantine.py
@@ -15,10 +15,44 @@ import json
 import sqlite3
 import sys
 from pathlib import Path
+from unittest import mock
 
 # scripts/ on sys.path so we can import batch_pipeline helpers
 _REPO_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+
+def test_tile_retry_does_not_force_recalibrate_collapsed_ms(monkeypatch):
+    import batch_pipeline as bp
+
+    submitted_force_flags = []
+    results = [
+        {"status": "failed", "failed_stage": "imaging", "error": "first failure"},
+        {"status": "imaged"},
+    ]
+
+    class FakeFuture:
+        def result(self, timeout):
+            return results.pop(0)
+
+    class FakePool:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def submit(self, function, *args):
+            submitted_force_flags.append(args[-1])
+            return FakeFuture()
+
+    monkeypatch.setattr(bp, "ProcessPoolExecutor", lambda max_workers: FakePool())
+    monkeypatch.setattr(bp.time, "sleep", mock.Mock())
+
+    result = bp.process_tile_safe({}, "/ms/tile.ms", True, 30, True, force_recal=True)
+
+    assert result.ok
+    assert submitted_force_flags == [True, False]
 
 
 # ─── _compute_quarantine_set ────────────────────────────────────────────────

--- a/tests/test_calibration_catalog_resolution.py
+++ b/tests/test_calibration_catalog_resolution.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+def test_vlass_resolver_falls_back_to_full_catalog(monkeypatch):
+    from dsa110_continuum.calibration.catalogs import _resolve_vlass_catalog_path
+
+    full_path = Path("/data/dsa110-contimg/state/catalogs/vlass_full.sqlite3")
+    monkeypatch.setattr(Path, "exists", lambda path: path == full_path)
+
+    assert _resolve_vlass_catalog_path(16.1) == full_path
+
+
+def test_vlass_resolver_prefers_strip_catalog(monkeypatch):
+    from dsa110_continuum.calibration.catalogs import _resolve_vlass_catalog_path
+
+    strip_path = Path("/data/dsa110-contimg/state/catalogs/vlass_dec+16.1.sqlite3")
+    full_path = Path("/data/dsa110-contimg/state/catalogs/vlass_full.sqlite3")
+    monkeypatch.setattr(Path, "exists", lambda path: path in {strip_path, full_path})
+
+    assert _resolve_vlass_catalog_path(16.1) == strip_path

--- a/tests/test_calibration_flag_fraction.py
+++ b/tests/test_calibration_flag_fraction.py
@@ -95,3 +95,30 @@ class TestFlagFractionExcludingDeadReceptors:
         assert result["effective_flag_fraction"] == pytest.approx(expected_fraction)
         assert result["working_flagged"] == flagged_per_partial_receptor
         assert result["working_total"] == N_ANTENNAS * N_RECEPTORS * total_per_receptor
+
+    def test_gain_table_singleton_channel_keeps_receptor_axis(self):
+        antenna_ids = np.arange(4)
+        flags = np.zeros((4, 2, 1), dtype=bool)
+        flags[1, 0, 0] = True
+
+        result = _flag_fraction_excluding_dead_receptors(flags, antenna_ids)
+
+        assert result["dead_receptors"] == [(1, 0)]
+        assert result["working_receptor_count"] == 7
+
+    def test_independent_exclusions_do_not_hide_new_candidate_failure(self):
+        antenna_ids = np.arange(4)
+        flags = np.zeros((4, 2, 1), dtype=bool)
+        flags[0, 0, 0] = True
+        flags[1, 1, 0] = True
+
+        result = _flag_fraction_excluding_dead_receptors(
+            flags,
+            antenna_ids,
+            excluded_receptors={(0, 0)},
+        )
+
+        assert result["dead_receptors"] == [(0, 0)]
+        assert result["working_flagged"] == 1
+        assert result["working_total"] == 7
+        assert result["effective_flag_fraction"] == pytest.approx(1 / 7)

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -7,7 +7,7 @@ def test_select_calibration_tile_from_ms_picks_richer_tile():
     """Should return the MS whose central pointing has more catalog sources."""
     from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
 
-    # 12 tiles: centre pair is indices 5 (mid-1) and 6 (mid) where mid = 12//2 = 6
+    # The all-tile fallback should select index 6 because it has more sources.
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
 
     def fake_phase_center(ms_path):
@@ -19,6 +19,9 @@ def test_select_calibration_tile_from_ms_picks_richer_tile():
         return 8 if pointing_ra_deg == 60.0 else 3
 
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=fake_phase_center,
     ), patch(
@@ -31,10 +34,10 @@ def test_select_calibration_tile_from_ms_picks_richer_tile():
 
 
 def test_select_calibration_tile_works_with_11_tiles():
-    """Should work with 11 tiles (centre pair is indices 4 and 5)."""
+    """Should rank every tile when an epoch has an odd tile count."""
     from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
 
-    # 11 tiles: mid = 11//2 = 5, centre pair is indices 4 and 5
+    # The all-tile fallback should select index 5 because it has more sources.
     fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(11)]
 
     def fake_phase_center(ms_path):
@@ -46,6 +49,9 @@ def test_select_calibration_tile_works_with_11_tiles():
         return 9 if pointing_ra_deg == 50.0 else 2
 
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=fake_phase_center,
     ), patch(
@@ -66,13 +72,89 @@ def test_select_calibration_tile_raises_on_too_few():
         select_calibration_tile_from_ms(["/fake/a.ms"])
 
 
+def test_select_calibration_tile_prefers_bright_vla_calibrator_outside_center():
+    """A bright calibrator transit should beat the geometric center pair."""
+    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
+
+    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
+
+    def fake_calibrator_match(ms_path, **kwargs):
+        idx = int(Path(ms_path).stem.split("_")[1])
+        if idx == 2:
+            return ("2253+161", 12.66, 0.20)
+        if idx == 6:
+            return ("faint-cal", 1.0, 0.05)
+        raise RuntimeError("no calibrator")
+
+    with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=fake_calibrator_match,
+    ), patch(
+        "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
+    ) as source_count:
+        result = select_calibration_tile_from_ms(fake_paths)
+
+    assert result == "/fake/tile_02.ms"
+    source_count.assert_not_called()
+
+
+def test_select_calibration_tile_uses_nearest_tile_for_same_calibrator():
+    """When one calibrator spans tiles, select its closest tile midpoint."""
+    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
+
+    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(4)]
+
+    def fake_calibrator_match(ms_path, **kwargs):
+        idx = int(Path(ms_path).stem.split("_")[1])
+        separations = {1: 0.65, 2: 0.18}
+        if idx in separations:
+            return ("2253+161", 12.66, separations[idx])
+        raise RuntimeError("no calibrator")
+
+    with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=fake_calibrator_match,
+    ):
+        result = select_calibration_tile_from_ms(fake_paths)
+
+    assert result == "/fake/tile_02.ms"
+
+
+def test_select_calibration_tile_counts_all_tiles_without_vla_catalog():
+    """Catalog-count fallback must consider non-central tiles too."""
+    from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
+
+    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
+
+    def fake_phase_center(ms_path):
+        idx = int(Path(ms_path).stem.split("_")[1])
+        return (float(idx), 16.1)
+
+    with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=FileNotFoundError("VLA catalog missing"),
+    ), patch(
+        "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+        side_effect=fake_phase_center,
+    ), patch(
+        "dsa110_continuum.calibration.epoch_gaincal.count_bright_sources_in_tile",
+        side_effect=lambda ra, dec, **kwargs: 20 if ra == 2.0 else 1,
+    ):
+        result = select_calibration_tile_from_ms(fake_paths)
+
+    assert result == "/fake/tile_02.ms"
+
+
 def test_select_calibration_tile_defaults_to_central_tile_on_failure():
-    """Falls back to n//2 (geometric centre) if source counting raises for both candidates."""
+    """Falls back to n//2 if source counting fails for every tile."""
     from dsa110_continuum.calibration.epoch_gaincal import select_calibration_tile_from_ms
 
     # 12 tiles: n//2 = 6
     fake_paths_12 = [f"/fake/tile_{i:02d}.ms" for i in range(12)]
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=RuntimeError("casacore unavailable"),
     ):
@@ -82,11 +164,37 @@ def test_select_calibration_tile_defaults_to_central_tile_on_failure():
     # 6 tiles: n//2 = 3
     fake_paths_6 = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
     with patch(
+        "dsa110_continuum.calibration.epoch_gaincal._find_vla_calibrator_in_ms",
+        side_effect=RuntimeError("no VLA calibrator"),
+    ), patch(
         "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
         side_effect=RuntimeError("casacore unavailable"),
     ):
         result_6 = select_calibration_tile_from_ms(fake_paths_6)
     assert result_6 == "/fake/tile_03.ms"
+
+
+def test_count_bright_sources_falls_back_to_nvss_when_vlass_missing():
+    """A missing VLASS strip database must not prevent the NVSS query."""
+    import pandas as pd
+    from dsa110_continuum.calibration.model import count_bright_sources_in_tile
+
+    calls = []
+
+    def fake_query(*, catalog_type, **kwargs):
+        calls.append(catalog_type)
+        if catalog_type == "vlass":
+            raise FileNotFoundError("missing VLASS strip database")
+        return pd.DataFrame([{"ra_deg": 343.49, "dec_deg": 16.15}])
+
+    with patch(
+        "dsa110_continuum.calibration.catalogs.query_catalog_sources",
+        side_effect=fake_query,
+    ):
+        result = count_bright_sources_in_tile(343.49, 16.15)
+
+    assert result == 1
+    assert calls[:2] == ["vlass", "nvss"]
 
 
 def _make_exists_fn(meridian_ms: str, *, ap_table: str | None = None) -> object:

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -378,6 +378,9 @@ def test_wsclean_skipped_when_ms_heavily_flagged():
             return_value={"raw_fraction": 1 / 3, "effective_fraction": 0.07,
                           "baseline_valid": True},
         ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._modeled_field_count",
+            return_value=(1, 1),
+        ), patch(
             "dsa110_continuum.calibration.casa_service.CASAService",
             return_value=mock_service,
         ), patch(
@@ -430,6 +433,9 @@ def test_wsclean_runs_when_flag_fraction_below_limit():
             return_value={"raw_fraction": 1 / 3, "effective_fraction": 0.07,
                           "baseline_valid": True},
         ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._modeled_field_count",
+            return_value=(24, 24),
+        ), patch(
             "dsa110_continuum.calibration.casa_service.CASAService",
             return_value=mock_service,
         ), patch(
@@ -480,7 +486,7 @@ def test_direct_pass_skips_preconditioner():
             return_value=mock_sky,
         ), patch(
             "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-        ), patch(
+        ) as mock_predict, patch(
             "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
             return_value=0.25,
         ), patch(
@@ -492,13 +498,16 @@ def test_direct_pass_skips_preconditioner():
                  "baseline_valid": True},
             ],
         ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._modeled_field_count",
+            return_value=(24, 24),
+        ), patch(
             "dsa110_continuum.calibration.casa_service.CASAService",
             return_value=mock_service,
         ), patch(
             "shutil.which", return_value="/usr/bin/wsclean",
         ), patch(
             "subprocess.run", return_value=wsclean_ok,
-        ), patch(
+        ) as mock_subprocess, patch(
             "os.path.exists", side_effect=_exists,
         ):
             result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
@@ -510,11 +519,11 @@ def test_direct_pass_skips_preconditioner():
     assert direct_call.kwargs["solint"] == "inf"
     assert "combine" not in direct_call.kwargs
     assert all(call.kwargs.get("solint") != "60s" for call in gaincal_calls)
-    assert ap_call.kwargs["gaintable"] == [
-        "/fake/bp.b",
-        str(Path(work_dir) / "tile_03.direct.p.G"),
-    ]
+    assert ap_call.kwargs["gaintable"] == ["/fake/bp.b"]
     assert ap_call.kwargs["calmode"] == "ap"
+    assert mock_predict.call_args_list[0].kwargs["field"] == "all"
+    image_cmd = mock_subprocess.call_args.args[0]
+    assert image_cmd[image_cmd.index("-field") + 1] == "all"
     assert result.status.value == "low_snr"
     assert "ap.G" in (result.reason or "")
 
@@ -678,7 +687,7 @@ def test_gaincal_returns_low_snr_when_p_table_heavily_flagged():
                           "baseline_valid": True},
         ), patch(
             "dsa110_continuum.calibration.epoch_gaincal._modeled_field_count",
-            return_value=(1, 24),
+            return_value=(1, 1),
         ), patch(
             "os.path.exists", side_effect=_exists,
         ):
@@ -693,5 +702,4 @@ def test_gaincal_returns_low_snr_when_p_table_heavily_flagged():
     assert "30%" in (result.reason or ""), (
         "result.reason must include the threshold so the manifest gate can quote it"
     )
-    assert "1/24 fields" in (result.reason or "")
     assert mock_service.gaincal.call_count == 1

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -308,7 +308,7 @@ def test_process_ms_force_recal_calls_applycal_even_when_data_exists():
     import importlib
     import inspect
 
-    sys.path.insert(0, "/data/dsa110-continuum/scripts")
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
     md = importlib.import_module("mosaic_day")
     sig = inspect.signature(md.process_ms)
     assert "force_recal" in sig.parameters, "process_ms must accept force_recal"

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -225,7 +225,7 @@ def test_calibrate_epoch_returns_exception_status_on_predict_failure():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_05_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_05.ap.G")
+        ap_table   = str(Path(work_dir) / "tile_05.direct_first.ap.G")
         with patch(
             "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
             return_value="/fake/tile_05.ms",
@@ -275,7 +275,7 @@ def test_calibrate_epoch_returns_low_snr_on_empty_sky_model():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_05_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_05.ap.G")
+        ap_table   = str(Path(work_dir) / "tile_05.direct_first.ap.G")
         with patch(
             "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
             return_value="/fake/tile_05.ms",
@@ -354,7 +354,7 @@ def test_wsclean_skipped_when_ms_heavily_flagged():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_03.ap.G")
+        ap_table   = str(Path(work_dir) / "tile_03.direct_first.ap.G")
         with patch(
             "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
             return_value="/fake/tile_03.ms",
@@ -373,6 +373,10 @@ def test_wsclean_skipped_when_ms_heavily_flagged():
         ) as mock_predict, patch(
             "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
             return_value=0.72,  # above 60% threshold
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._gain_flag_fractions",
+            return_value={"raw_fraction": 1 / 3, "effective_fraction": 0.07,
+                          "baseline_valid": True},
         ), patch(
             "dsa110_continuum.calibration.casa_service.CASAService",
             return_value=mock_service,
@@ -402,7 +406,7 @@ def test_wsclean_runs_when_flag_fraction_below_limit():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_03.ap.G")
+        ap_table   = str(Path(work_dir) / "tile_03.direct_first.ap.G")
         with patch(
             "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
             return_value="/fake/tile_03.ms",
@@ -422,6 +426,10 @@ def test_wsclean_runs_when_flag_fraction_below_limit():
             "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
             return_value=0.32,  # well below 60% threshold
         ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._gain_flag_fractions",
+            return_value={"raw_fraction": 1 / 3, "effective_fraction": 0.07,
+                          "baseline_valid": True},
+        ), patch(
             "dsa110_continuum.calibration.casa_service.CASAService",
             return_value=mock_service,
         ), patch(
@@ -437,8 +445,8 @@ def test_wsclean_runs_when_flag_fraction_below_limit():
     assert "wsclean" in mock_subprocess.call_args[0][0][0]
 
 
-def test_preconditioner_table_threaded_into_downstream_solves():
-    """precond.G must appear in gaintable of p.G and ap.G solves when it succeeds."""
+def test_direct_pass_skips_preconditioner():
+    """A BP-relative direct pass skips rescue, while a bad ap.G still fails."""
     import tempfile
     from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
 
@@ -450,97 +458,87 @@ def test_preconditioner_table_threaded_into_downstream_solves():
     wsclean_ok.returncode = 0
 
     with tempfile.TemporaryDirectory() as work_dir:
-        meridian_ms    = str(Path(work_dir) / "tile_03_meridian.ms")
-        precond_table  = str(Path(work_dir) / "tile_03.precond.G")
-        ap_table       = str(Path(work_dir) / "tile_03.ap.G")
+        ap_table       = str(Path(work_dir) / "tile_03.direct_first.ap.G")
 
         # os.path.exists: False for ap_table (no cache), True for everything else
-        # (meridian MS, precond table, p table all "exist" after their solves)
+        # until the ap solve has run; intermediate tables exist after their solves.
+        def _exists(p: str) -> bool:
+            return str(p) != ap_table or mock_service.gaincal.call_count >= 2
+
+        with patch(
+            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
+            return_value="/fake/tile_03.ms",
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
+            return_value=(44.89, 16.08),
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
+            return_value=mock_sky,
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
+            return_value=0.25,
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._gain_flag_fractions",
+            side_effect=[
+                {"raw_fraction": 1 / 3, "effective_fraction": 0.07,
+                 "baseline_valid": True},
+                {"raw_fraction": 0.5, "effective_fraction": 0.5,
+                 "baseline_valid": True},
+            ],
+        ), patch(
+            "dsa110_continuum.calibration.casa_service.CASAService",
+            return_value=mock_service,
+        ), patch(
+            "shutil.which", return_value="/usr/bin/wsclean",
+        ), patch(
+            "subprocess.run", return_value=wsclean_ok,
+        ), patch(
+            "os.path.exists", side_effect=_exists,
+        ):
+            result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
+
+    gaincal_calls = mock_service.gaincal.call_args_list
+    assert len(gaincal_calls) == 2
+    direct_call, ap_call = gaincal_calls
+    assert direct_call.kwargs["gaintable"] == ["/fake/bp.b"]
+    assert direct_call.kwargs["solint"] == "inf"
+    assert "combine" not in direct_call.kwargs
+    assert all(call.kwargs.get("solint") != "60s" for call in gaincal_calls)
+    assert ap_call.kwargs["gaintable"] == [
+        "/fake/bp.b",
+        str(Path(work_dir) / "tile_03.direct.p.G"),
+    ]
+    assert ap_call.kwargs["calmode"] == "ap"
+    assert result.status.value == "low_snr"
+    assert "ap.G" in (result.reason or "")
+
+
+def test_rescue_must_strictly_improve_direct_fraction():
+    """An equal-quality rescue must remain LOW_SNR and never reach ap.G."""
+    import tempfile
+    from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
+
+    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
+    mock_sky = MagicMock()
+    mock_sky.Ncomponents = 5
+    mock_service = MagicMock()
+    with tempfile.TemporaryDirectory() as work_dir:
+        ap_table      = str(Path(work_dir) / "tile_03.direct_first.ap.G")
+
         def _exists(p: str) -> bool:
             return str(p) != ap_table
 
-        with patch(
-            "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
-            return_value="/fake/tile_03.ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.phaseshift_ms",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.apply_to_target",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._read_ms_phase_center",
-            return_value=(44.89, 16.08),
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.make_unified_skymodel",
-            return_value=mock_sky,
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
-        ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.25,
-        ), patch(
-            "dsa110_continuum.calibration.casa_service.CASAService",
-            return_value=mock_service,
-        ), patch(
-            "shutil.which", return_value="/usr/bin/wsclean",
-        ), patch(
-            "subprocess.run", return_value=wsclean_ok,
-        ), patch(
-            "os.path.exists", side_effect=_exists,
-        ):
-            calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
-
-    gaincal_calls = mock_service.gaincal.call_args_list
-    assert len(gaincal_calls) == 3, f"expected 3 gaincal calls, got {len(gaincal_calls)}"
-
-    precond_call, p_call, ap_call = gaincal_calls
-
-    # Pre-conditioner solve
-    assert precond_call.kwargs["solint"] == "60s"
-    assert precond_call.kwargs["combine"] == "spw"
-    assert precond_call.kwargs["calmode"] == "p"
-    assert precond_call.kwargs["gaintable"] == ["/fake/bp.b"]
-
-    # p.G solve must include precond table
-    assert precond_table in p_call.kwargs["gaintable"], \
-        "precond table must be in p.G gaintable"
-    assert "/fake/bp.b" in p_call.kwargs["gaintable"]
-    assert p_call.kwargs["solint"] == "inf"
-
-    # ap.G solve must include both precond table and p table
-    ap_gt = ap_call.kwargs["gaintable"]
-    assert precond_table in ap_gt, "precond table must be in ap.G gaintable"
-    assert "/fake/bp.b" in ap_gt
-    assert ap_call.kwargs["calmode"] == "ap"
-
-
-def test_preconditioner_failure_does_not_abort_epoch_gaincal():
-    """If precond solve fails entirely, the main p.G and ap.G solves must still run."""
-    import tempfile
-    from dsa110_continuum.calibration.epoch_gaincal import calibrate_epoch
-
-    fake_paths = [f"/fake/tile_{i:02d}.ms" for i in range(6)]
-    mock_sky = MagicMock()
-    mock_sky.Ncomponents = 5
-    mock_service = MagicMock()
-    # Make the first gaincal call (precond) raise; subsequent calls succeed
-    call_count = {"n": 0}
-    def _gaincal_side_effect(**kw):
-        call_count["n"] += 1
-        if call_count["n"] == 1:
-            raise RuntimeError("CASA unavailable for precond")
-    mock_service.gaincal.side_effect = _gaincal_side_effect
-    wsclean_ok = MagicMock()
-    wsclean_ok.returncode = 0
-
-    with tempfile.TemporaryDirectory() as work_dir:
-        meridian_ms   = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table      = str(Path(work_dir) / "tile_03.ap.G")
-        p_table       = str(Path(work_dir) / "tile_03.p.G")
-        precond_table = str(Path(work_dir) / "tile_03.precond.G")
-
-        def _exists(p: str) -> bool:
-            # ap and precond tables never exist; meridian MS and p table exist
-            return str(p) not in (ap_table, precond_table)
+        table = MagicMock()
+        table.__enter__.return_value = table
+        table.__exit__.return_value = False
+        table.colnames.return_value = ["MODEL_DATA"]
+        table.nrows.return_value = 16
 
         with patch(
             "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
@@ -558,27 +556,32 @@ def test_preconditioner_failure_does_not_abort_epoch_gaincal():
         ), patch(
             "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
         ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.25,
-        ), patch(
             "dsa110_continuum.calibration.casa_service.CASAService",
             return_value=mock_service,
         ), patch(
-            "shutil.which", return_value="/usr/bin/wsclean",
+            "dsa110_continuum.calibration.epoch_gaincal._gain_flag_fractions",
+            side_effect=[
+                {"raw_fraction": 0.4, "effective_fraction": 0.4,
+                 "baseline_valid": True},
+                {"raw_fraction": 0.4, "effective_fraction": 0.4,
+                 "baseline_valid": True},
+            ],
         ), patch(
-            "subprocess.run", return_value=wsclean_ok,
+            "dsa110_continuum.calibration.epoch_gaincal._modeled_field_count",
+            return_value=(24, 24),
+        ), patch(
+            "dsa110_continuum.adapters.casa_tables.table",
+            return_value=table,
         ), patch(
             "os.path.exists", side_effect=_exists,
         ):
-            calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
+            result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
-    # All three gaincal calls attempted despite the first raising
     assert mock_service.gaincal.call_count == 3
-
-    # p.G and ap.G gaintables must NOT include the precond table (it doesn't exist)
-    _, p_call, ap_call = mock_service.gaincal.call_args_list
-    assert precond_table not in p_call.kwargs["gaintable"]
-    assert precond_table not in ap_call.kwargs["gaintable"]
+    assert result.status.value == "low_snr"
+    assert result.g_table is None
+    assert "did not strictly improve" in (result.reason or "")
+    assert all(call.kwargs.get("calmode") != "ap" for call in mock_service.gaincal.call_args_list)
 
 
 def test_epoch_gaincal_forwards_selected_rfi_mode():
@@ -594,7 +597,7 @@ def test_epoch_gaincal_forwards_selected_rfi_mode():
 
     with tempfile.TemporaryDirectory() as work_dir:
         meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table   = str(Path(work_dir) / "tile_03.ap.G")
+        ap_table   = str(Path(work_dir) / "tile_03.direct_first.ap.G")
         with patch(
             "dsa110_continuum.calibration.epoch_gaincal.select_calibration_tile_from_ms",
             return_value="/fake/tile_03.ms",
@@ -635,7 +638,6 @@ def test_gaincal_returns_low_snr_when_p_table_heavily_flagged():
     the manifest records the operational reason (not a code-path fall-back).
     """
     import tempfile
-    import numpy as np
     from dsa110_continuum.calibration.epoch_gaincal import (
         EpochGaincalStatus,
         calibrate_epoch,
@@ -646,17 +648,8 @@ def test_gaincal_returns_low_snr_when_p_table_heavily_flagged():
     mock_sky.Ncomponents = 5
     mock_service = MagicMock()
 
-    # Build a mock casatools.table() that returns a FLAG array that is 35% True.
-    flags_35pct = np.zeros((2, 1, 100), dtype=bool)
-    flags_35pct[:, :, :35] = True   # 35 of 100 rows flagged per pol/spw
-
-    mock_tb = MagicMock()
-    mock_tb.getcol.return_value = flags_35pct
-
     with tempfile.TemporaryDirectory() as work_dir:
-        meridian_ms = str(Path(work_dir) / "tile_03_meridian.ms")
-        ap_table    = str(Path(work_dir) / "tile_03.ap.G")
-        p_table     = str(Path(work_dir) / "tile_03.p.G")
+        ap_table    = str(Path(work_dir) / "tile_03.direct_first.ap.G")
 
         def _exists(p: str) -> bool:
             return str(p) not in (ap_table,)   # p.G "exists" after the solve
@@ -677,19 +670,19 @@ def test_gaincal_returns_low_snr_when_p_table_heavily_flagged():
         ), patch(
             "dsa110_continuum.calibration.epoch_gaincal.predict_from_skymodel_wsclean",
         ), patch(
-            "dsa110_continuum.calibration.epoch_gaincal._ms_flag_fraction",
-            return_value=0.25,
-        ), patch(
             "dsa110_continuum.calibration.casa_service.CASAService",
             return_value=mock_service,
         ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._gain_flag_fractions",
+            return_value={"raw_fraction": 0.35, "effective_fraction": 0.35,
+                          "baseline_valid": True},
+        ), patch(
+            "dsa110_continuum.calibration.epoch_gaincal._modeled_field_count",
+            return_value=(1, 24),
+        ), patch(
             "os.path.exists", side_effect=_exists,
         ):
-            import sys as _sys
-            mock_casatools = MagicMock()
-            mock_casatools.table.return_value = mock_tb
-            with patch.dict(_sys.modules, {"casatools": mock_casatools}):
-                result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
+            result = calibrate_epoch(fake_paths, "/fake/bp.b", work_dir)
 
     assert result.g_table is None, (
         "calibrate_epoch() must return g_table=None when p.G flagged fraction > 30%"
@@ -700,3 +693,5 @@ def test_gaincal_returns_low_snr_when_p_table_heavily_flagged():
     assert "30%" in (result.reason or ""), (
         "result.reason must include the threshold so the manifest gate can quote it"
     )
+    assert "1/24 fields" in (result.reason or "")
+    assert mock_service.gaincal.call_count == 1

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -523,6 +523,8 @@ def test_direct_pass_skips_preconditioner():
     assert ap_call.kwargs["calmode"] == "ap"
     assert mock_predict.call_args_list[0].kwargs["field"] == "all"
     image_cmd = mock_subprocess.call_args.args[0]
+    assert "-reorder" in image_cmd
+    assert image_cmd[image_cmd.index("-mgain") + 1] == "0.8"
     assert image_cmd[image_cmd.index("-field") + 1] == "all"
     assert image_cmd[image_cmd.index("-model-column") + 1] == "MODEL_DATA"
     assert "-update-model-required" in image_cmd

--- a/tests/test_epoch_gaincal.py
+++ b/tests/test_epoch_gaincal.py
@@ -524,6 +524,10 @@ def test_direct_pass_skips_preconditioner():
     assert mock_predict.call_args_list[0].kwargs["field"] == "all"
     image_cmd = mock_subprocess.call_args.args[0]
     assert image_cmd[image_cmd.index("-field") + 1] == "all"
+    assert image_cmd[image_cmd.index("-model-column") + 1] == "MODEL_DATA"
+    assert "-update-model-required" in image_cmd
+    assert "-save-model-column" not in image_cmd
+    assert "-no-update-model-required" not in image_cmd
     assert result.status.value == "low_snr"
     assert "ap.G" in (result.reason or "")
 

--- a/tests/test_image_metrics.py
+++ b/tests/test_image_metrics.py
@@ -1,0 +1,43 @@
+"""Tests for image-metric backend selection."""
+
+import numpy as np
+
+
+def test_gpu_allocation_failure_falls_back_to_numpy(monkeypatch):
+    from dsa110_continuum.qa import image_metrics
+
+    class BrokenGpu:
+        @staticmethod
+        def asarray(array):
+            raise RuntimeError("CUDA initialization failed")
+
+    monkeypatch.setattr(image_metrics, "get_array_module", lambda **kwargs: (BrokenGpu, True))
+    array = np.ones((2, 2))
+
+    backend_array, xp, is_gpu = image_metrics._maybe_to_gpu(array, min_elements=1)
+
+    assert backend_array is array
+    assert xp is np
+    assert is_gpu is False
+
+
+def test_gpu_kernel_failure_falls_back_to_numpy(monkeypatch):
+    from dsa110_continuum.qa import image_metrics
+
+    class BrokenGpu:
+        @staticmethod
+        def asarray(array):
+            return array
+
+        @staticmethod
+        def abs(array):
+            raise RuntimeError("NVRTC unavailable")
+
+    monkeypatch.setattr(image_metrics, "get_array_module", lambda **kwargs: (BrokenGpu, True))
+    array = np.ones((2, 2))
+
+    backend_array, xp, is_gpu = image_metrics._maybe_to_gpu(array, min_elements=1)
+
+    assert backend_array is array
+    assert xp is np
+    assert is_gpu is False

--- a/tests/test_rolling_mosaic_campaign.py
+++ b/tests/test_rolling_mosaic_campaign.py
@@ -37,11 +37,7 @@ def test_working_set_group_ids_limits_conversion_to_core_and_overlap(tmp_path, m
         )
         connection.executemany(
             "INSERT INTO hdf5_files VALUES (?, ?, ?)",
-            [
-                (timestamp, timestamp, subband)
-                for timestamp in timestamps
-                for subband in range(16)
-            ],
+            [(timestamp, timestamp, subband) for timestamp in timestamps for subband in range(16)],
         )
     monkeypatch.setattr(campaign, "DB_PATH", database)
 
@@ -62,6 +58,7 @@ def test_refresh_lightcurves_stacks_forced_photometry(tmp_path, monkeypatch):
     forced_phot = tmp_path / "mosaics/2026-01-25/2026-01-25T0500_forced_phot.csv"
     forced_phot.parent.mkdir(parents=True)
     forced_phot.touch()
+
     def run(_command):
         stacked = tmp_path / "lightcurves/lightcurves.parquet"
         stacked.parent.mkdir(parents=True)
@@ -152,8 +149,16 @@ def test_strict_qa_requires_matching_pass_epoch(tmp_path, monkeypatch):
 
 def test_preserved_metadata_requires_matching_pass_epoch(tmp_path, monkeypatch):
     monkeypatch.setattr(campaign, "CAMPAIGN_DIR", tmp_path)
+    products = tmp_path / "products"
+    monkeypatch.setattr(campaign, "PRODUCTS_MOSAIC_DIR", products)
     prefix = tmp_path / "2026-01-25T04_"
-    Path(f"{prefix}2026-01-25_manifest.json").write_text(
+    preserved_manifest = Path(f"{prefix}2026-01-25_manifest.json")
+    preserved_manifest.write_text(
+        json.dumps({"epochs": [{"hour": 5, "status": "ok", "qa_result": "PASS"}]})
+    )
+    current_manifest = products / "2026-01-25/2026-01-25_manifest.json"
+    current_manifest.parent.mkdir(parents=True)
+    current_manifest.write_text(
         json.dumps({"epochs": [{"hour": 4, "status": "ok", "qa_result": "PASS"}]})
     )
     Path(f"{prefix}2026-01-25_run_summary.json").write_text(
@@ -170,11 +175,13 @@ def test_preserved_metadata_requires_matching_pass_epoch(tmp_path, monkeypatch):
         )
     )
     report = Path(f"{prefix}run_report.md")
-    report.write_text("| 04 | ok | FAIL | 12 |\n")
+    report.write_text("| 04 | ok | PASS | 12 |\n")
 
     assert not campaign.preserved_run_metadata_complete("2026-01-25", 4)
 
-    report.write_text("| 04 | ok | PASS | 12 |\n")
+    preserved_manifest.write_text(
+        json.dumps({"epochs": [{"hour": 4, "status": "ok", "qa_result": "PASS"}]})
+    )
     assert campaign.preserved_run_metadata_complete("2026-01-25", 4)
 
 

--- a/tests/test_rolling_mosaic_campaign.py
+++ b/tests/test_rolling_mosaic_campaign.py
@@ -1,0 +1,276 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import run_rolling_mosaic_campaign as campaign
+from run_rolling_mosaic_campaign import rolling_window
+
+
+def test_rolling_window_uses_neighboring_available_hours():
+    hours = [2, 3, 9]
+
+    assert rolling_window(hours, 0) == (2, 4)
+    assert rolling_window(hours, 1) == (2, 10)
+    assert rolling_window(hours, 2) == (3, 10)
+
+
+def test_working_set_group_ids_limits_conversion_to_core_and_overlap(tmp_path, monkeypatch):
+    database = tmp_path / "pipeline.sqlite3"
+    timestamps = [
+        "2026-01-25T00:00:10",
+        "2026-01-25T00:05:19",
+        "2026-01-25T00:10:28",
+        "2026-01-25T04:03:15",
+        "2026-01-25T04:08:25",
+        "2026-01-25T11:06:05",
+        "2026-01-25T11:11:14",
+        "2026-01-25T11:16:23",
+    ]
+    with campaign.sqlite3.connect(database) as connection:
+        connection.execute(
+            "CREATE TABLE hdf5_files (group_id TEXT, timestamp_iso TEXT, subband_num INTEGER)"
+        )
+        connection.executemany(
+            "INSERT INTO hdf5_files VALUES (?, ?, ?)",
+            [
+                (timestamp, timestamp, subband)
+                for timestamp in timestamps
+                for subband in range(16)
+            ],
+        )
+    monkeypatch.setattr(campaign, "DB_PATH", database)
+
+    selected = campaign._working_set_group_ids("2026-01-25", 4, 0, 12)
+
+    assert selected == set(timestamps[1:7])
+
+
+def test_batch_command_runs_photometry_before_pruning():
+    command = campaign.batch_command("2026-01-25", 4, 0, 12)
+
+    assert "--skip-photometry" not in command
+    assert command[command.index("--photometry-workers") + 1] == "4"
+    assert command[command.index("--photometry-chunk-size") + 1] == "0"
+
+
+def test_refresh_lightcurves_stacks_forced_photometry(tmp_path, monkeypatch):
+    forced_phot = tmp_path / "mosaics/2026-01-25/2026-01-25T0500_forced_phot.csv"
+    forced_phot.parent.mkdir(parents=True)
+    forced_phot.touch()
+    run = MagicMock()
+    monkeypatch.setattr(campaign, "PRODUCTS_DIR", tmp_path)
+    monkeypatch.setattr(campaign, "run", run)
+
+    assert campaign.refresh_lightcurves()
+    run.assert_called_once_with(
+        [
+            "/opt/miniforge/envs/casa6/bin/python",
+            "scripts/stack_lightcurves.py",
+            "--products-dir",
+            str(tmp_path),
+        ]
+    )
+
+
+def test_prune_hour_removes_approved_symlink_target(tmp_path, monkeypatch):
+    stage_ms = tmp_path / "stage-ms"
+    proc_ms = tmp_path / "proc-ms"
+    images = tmp_path / "images"
+    stage_ms.mkdir()
+    proc_ms.mkdir()
+    target = proc_ms / "2026-01-25T00:00:10.ms"
+    target.mkdir()
+    (target / "table.dat").touch()
+    link = stage_ms / target.name
+    link.symlink_to(target)
+    tile = images / "mosaic_2026-01-25" / "2026-01-25T00:00:10-image-pb.fits"
+    tile.parent.mkdir(parents=True)
+    tile.touch()
+    monkeypatch.setattr(campaign, "MS_DIR", stage_ms)
+    monkeypatch.setattr(campaign, "PROC_MS_DIR", proc_ms)
+    monkeypatch.setattr(campaign, "IMAGE_DIR", images)
+
+    campaign.prune_hour("2026-01-25", 0)
+
+    assert not link.exists()
+    assert not target.exists()
+    assert not tile.exists()
+
+
+def test_prune_hour_retains_only_named_overlap_tiles(tmp_path, monkeypatch):
+    stage_ms = tmp_path / "stage-ms"
+    images = tmp_path / "images" / "mosaic_2026-01-25"
+    stage_ms.mkdir()
+    images.mkdir(parents=True)
+    keep_stem = "2026-01-25T00:55:00"
+    drop_stem = "2026-01-25T00:05:00"
+    for stem in (keep_stem, drop_stem):
+        (stage_ms / f"{stem}.ms").mkdir()
+        (images / f"{stem}-image-pb.fits").touch()
+    monkeypatch.setattr(campaign, "MS_DIR", stage_ms)
+    monkeypatch.setattr(campaign, "PROC_MS_DIR", tmp_path / "proc-ms")
+    monkeypatch.setattr(campaign, "IMAGE_DIR", tmp_path / "images")
+
+    campaign.prune_hour("2026-01-25", 0, {keep_stem})
+
+    assert (stage_ms / f"{keep_stem}.ms").exists()
+    assert (images / f"{keep_stem}-image-pb.fits").exists()
+    assert not (stage_ms / f"{drop_stem}.ms").exists()
+    assert not (images / f"{drop_stem}-image-pb.fits").exists()
+
+
+def test_strict_qa_requires_matching_pass_epoch(tmp_path, monkeypatch):
+    monkeypatch.setattr(campaign, "CAMPAIGN_DIR", tmp_path)
+    manifest = tmp_path / "2026-01-25T04_2026-01-25_manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "epochs": [
+                    {"hour": 4, "status": "ok", "qa_result": "FAIL"},
+                    {"hour": 5, "status": "ok", "qa_result": "PASS"},
+                ]
+            }
+        )
+    )
+
+    assert not campaign.strict_qa_passed("2026-01-25", 4)
+    assert not campaign.strict_qa_passed("2026-01-25", 5)
+
+    manifest.write_text(json.dumps({"epochs": [{"hour": 4, "status": "ok", "qa_result": "PASS"}]}))
+    assert campaign.strict_qa_passed("2026-01-25", 4)
+
+
+def test_failed_strict_qa_is_recorded_without_stopping_later_epochs(tmp_path, monkeypatch):
+    status_path = tmp_path / "status.json"
+    prune = MagicMock()
+    preserve = MagicMock()
+    monkeypatch.setattr(campaign, "CAMPAIGN_DIR", tmp_path)
+    monkeypatch.setattr(campaign, "STATUS_PATH", status_path)
+    monkeypatch.setattr(campaign, "index_inventory", lambda: None)
+    monkeypatch.setattr(campaign, "complete_hours", lambda: {"2026-01-25": [4, 5]})
+    monkeypatch.setattr(
+        campaign,
+        "mosaic_is_valid",
+        MagicMock(side_effect=[False, False, False, False, True]),
+    )
+    monkeypatch.setattr(campaign, "convert_window", lambda *args: None)
+    monkeypatch.setattr(campaign, "promote_working_set_to_nvme", lambda *args: None)
+    monkeypatch.setattr(campaign, "run", lambda command: None)
+    monkeypatch.setattr(campaign, "preserve_run_metadata", preserve)
+    monkeypatch.setattr(campaign, "prune_hour", prune)
+
+    campaign.run_campaign(plan_only=False)
+
+    status = json.loads(status_path.read_text())
+    assert status["state"] == "complete_with_failures"
+    assert status["completed"] == ["2026-01-25T0500"]
+    assert status["failed_epochs"] == [
+        {
+            "epoch": "2026-01-25T0400",
+            "reason": "mosaic failed product integrity or strict QA",
+        }
+    ]
+    preserve.assert_called_once_with("2026-01-25", 4)
+    prune.assert_called_once_with("2026-01-25", 5, set())
+
+
+def test_nvme_promotion_replaces_approved_symlink_atomically(tmp_path, monkeypatch):
+    stage_ms = tmp_path / "stage-ms"
+    proc_ms = tmp_path / "proc-ms"
+    stage_ms.mkdir()
+    proc_ms.mkdir()
+    target = proc_ms / "2026-01-25T04:00:00.ms"
+    target.mkdir()
+    (target / "table.dat").write_bytes(b"science")
+    link = stage_ms / target.name
+    link.symlink_to(target)
+    monkeypatch.setattr(campaign, "MS_DIR", stage_ms)
+    monkeypatch.setattr(campaign, "PROC_MS_DIR", proc_ms)
+    monkeypatch.setattr(campaign, "NVME_RESERVE_BYTES", 0)
+    monkeypatch.setattr(
+        "dsa110_continuum.calibration.epoch_gaincal._measurement_set_is_readable",
+        lambda path: True,
+    )
+
+    campaign.promote_working_set_to_nvme("2026-01-25", 4, 4, 5)
+
+    assert link.is_dir()
+    assert not link.is_symlink()
+    assert (link / "table.dat").read_bytes() == b"science"
+    assert target.exists()
+
+
+def test_nvme_promotion_refuses_to_cross_reserve(tmp_path, monkeypatch):
+    stage_ms = tmp_path / "stage-ms"
+    proc_ms = tmp_path / "proc-ms"
+    stage_ms.mkdir()
+    proc_ms.mkdir()
+    target = proc_ms / "2026-01-25T04:00:00.ms"
+    target.mkdir()
+    link = stage_ms / target.name
+    link.symlink_to(target)
+    monkeypatch.setattr(campaign, "MS_DIR", stage_ms)
+    monkeypatch.setattr(campaign, "PROC_MS_DIR", proc_ms)
+    monkeypatch.setattr(campaign, "NVME_RESERVE_BYTES", 100)
+    monkeypatch.setattr(campaign, "_allocated_bytes", lambda path: 1)
+    monkeypatch.setattr(
+        campaign.shutil,
+        "disk_usage",
+        lambda path: type("Usage", (), {"free": 100})(),
+    )
+
+    with pytest.raises(RuntimeError, match="NVMe working set needs"):
+        campaign.promote_working_set_to_nvme("2026-01-25", 4, 4, 5)
+
+    assert link.is_symlink()
+
+
+def test_inactive_nvme_ms_is_atomically_demoted(tmp_path, monkeypatch):
+    stage_ms = tmp_path / "stage-ms"
+    proc_ms = tmp_path / "proc-ms"
+    stage_ms.mkdir()
+    proc_ms.mkdir()
+    name = "2026-01-25T04:00:00.ms"
+    stage_copy = stage_ms / name
+    slow_copy = proc_ms / name
+    stage_copy.mkdir()
+    slow_copy.mkdir()
+    (stage_copy / "table.dat").write_bytes(b"nvme")
+    (slow_copy / "table.dat").write_bytes(b"slow")
+    monkeypatch.setattr(campaign, "MS_DIR", stage_ms)
+    monkeypatch.setattr(campaign, "PROC_MS_DIR", proc_ms)
+    monkeypatch.setattr(
+        "dsa110_continuum.calibration.epoch_gaincal._measurement_set_is_readable",
+        lambda path: True,
+    )
+
+    campaign.demote_inactive_nvme_ms("2026-01-25", set())
+
+    assert stage_copy.is_symlink()
+    assert stage_copy.resolve() == slow_copy
+    assert (stage_copy / "table.dat").read_bytes() == b"slow"
+
+
+def test_conversion_capacity_refuses_to_cross_reserve(tmp_path, monkeypatch):
+    stage_ms = tmp_path / "stage-ms"
+    proc_ms = tmp_path / "proc-ms"
+    stage_ms.mkdir()
+    proc_ms.mkdir()
+    (proc_ms / "2026-01-25T03:00:00.ms").mkdir()
+    monkeypatch.setattr(campaign, "MS_DIR", stage_ms)
+    monkeypatch.setattr(campaign, "PROC_MS_DIR", proc_ms)
+    monkeypatch.setattr(campaign, "NVME_RESERVE_BYTES", 100)
+    monkeypatch.setattr(campaign, "_allocated_bytes", lambda path: 10)
+    monkeypatch.setattr(
+        campaign.shutil,
+        "disk_usage",
+        lambda path: type("Usage", (), {"free": 100})(),
+    )
+
+    with pytest.raises(RuntimeError, match="conversion working set estimates"):
+        campaign.ensure_conversion_capacity({"2026-01-25T04:00:00"})

--- a/tests/test_rolling_mosaic_campaign.py
+++ b/tests/test_rolling_mosaic_campaign.py
@@ -62,12 +62,17 @@ def test_refresh_lightcurves_stacks_forced_photometry(tmp_path, monkeypatch):
     forced_phot = tmp_path / "mosaics/2026-01-25/2026-01-25T0500_forced_phot.csv"
     forced_phot.parent.mkdir(parents=True)
     forced_phot.touch()
-    run = MagicMock()
+    def run(_command):
+        stacked = tmp_path / "lightcurves/lightcurves.parquet"
+        stacked.parent.mkdir(parents=True)
+        stacked.touch()
+
+    run_mock = MagicMock(side_effect=run)
     monkeypatch.setattr(campaign, "PRODUCTS_DIR", tmp_path)
-    monkeypatch.setattr(campaign, "run", run)
+    monkeypatch.setattr(campaign, "run", run_mock)
 
     assert campaign.refresh_lightcurves()
-    run.assert_called_once_with(
+    run_mock.assert_called_once_with(
         [
             "/opt/miniforge/envs/casa6/bin/python",
             "scripts/stack_lightcurves.py",
@@ -145,23 +150,54 @@ def test_strict_qa_requires_matching_pass_epoch(tmp_path, monkeypatch):
     assert campaign.strict_qa_passed("2026-01-25", 4)
 
 
+def test_preserved_metadata_requires_matching_pass_epoch(tmp_path, monkeypatch):
+    monkeypatch.setattr(campaign, "CAMPAIGN_DIR", tmp_path)
+    prefix = tmp_path / "2026-01-25T04_"
+    Path(f"{prefix}2026-01-25_manifest.json").write_text(
+        json.dumps({"epochs": [{"hour": 4, "status": "ok", "qa_result": "PASS"}]})
+    )
+    Path(f"{prefix}2026-01-25_run_summary.json").write_text(
+        json.dumps(
+            {
+                "epochs": [
+                    {
+                        "label": "2026-01-25T0400",
+                        "status": "ok",
+                        "qa_result": "PASS",
+                    }
+                ]
+            }
+        )
+    )
+    report = Path(f"{prefix}run_report.md")
+    report.write_text("| 04 | ok | FAIL | 12 |\n")
+
+    assert not campaign.preserved_run_metadata_complete("2026-01-25", 4)
+
+    report.write_text("| 04 | ok | PASS | 12 |\n")
+    assert campaign.preserved_run_metadata_complete("2026-01-25", 4)
+
+
 def test_failed_strict_qa_is_recorded_without_stopping_later_epochs(tmp_path, monkeypatch):
     status_path = tmp_path / "status.json"
     prune = MagicMock()
     preserve = MagicMock()
+    accepted_products = MagicMock(return_value=(True, None))
     monkeypatch.setattr(campaign, "CAMPAIGN_DIR", tmp_path)
     monkeypatch.setattr(campaign, "STATUS_PATH", status_path)
     monkeypatch.setattr(campaign, "index_inventory", lambda: None)
     monkeypatch.setattr(campaign, "complete_hours", lambda: {"2026-01-25": [4, 5]})
+    monkeypatch.setattr(campaign, "accepted_artifacts_complete", lambda *args: False)
     monkeypatch.setattr(
         campaign,
         "mosaic_is_valid",
-        MagicMock(side_effect=[False, False, False, False, True]),
+        MagicMock(side_effect=[False, False, False, True]),
     )
     monkeypatch.setattr(campaign, "convert_window", lambda *args: None)
     monkeypatch.setattr(campaign, "promote_working_set_to_nvme", lambda *args: None)
     monkeypatch.setattr(campaign, "run", lambda command: None)
     monkeypatch.setattr(campaign, "preserve_run_metadata", preserve)
+    monkeypatch.setattr(campaign, "accepted_products_ready", accepted_products)
     monkeypatch.setattr(campaign, "prune_hour", prune)
 
     campaign.run_campaign(plan_only=False)
@@ -175,7 +211,7 @@ def test_failed_strict_qa_is_recorded_without_stopping_later_epochs(tmp_path, mo
             "reason": "mosaic failed product integrity or strict QA",
         }
     ]
-    preserve.assert_called_once_with("2026-01-25", 4)
+    assert accepted_products.call_count == 1
     prune.assert_called_once_with("2026-01-25", 5, set())
 
 
@@ -193,7 +229,8 @@ def test_nvme_promotion_replaces_approved_symlink_atomically(tmp_path, monkeypat
     monkeypatch.setattr(campaign, "PROC_MS_DIR", proc_ms)
     monkeypatch.setattr(campaign, "NVME_RESERVE_BYTES", 0)
     monkeypatch.setattr(
-        "dsa110_continuum.calibration.epoch_gaincal._measurement_set_is_readable",
+        campaign,
+        "_measurement_set_is_readable",
         lambda path: True,
     )
 
@@ -245,7 +282,8 @@ def test_inactive_nvme_ms_is_atomically_demoted(tmp_path, monkeypatch):
     monkeypatch.setattr(campaign, "MS_DIR", stage_ms)
     monkeypatch.setattr(campaign, "PROC_MS_DIR", proc_ms)
     monkeypatch.setattr(
-        "dsa110_continuum.calibration.epoch_gaincal._measurement_set_is_readable",
+        campaign,
+        "_measurement_set_is_readable",
         lambda path: True,
     )
 

--- a/tests/test_skymodel_phase_dir.py
+++ b/tests/test_skymodel_phase_dir.py
@@ -1,9 +1,13 @@
 """Regression tests for WSClean skymodel phase-center selection."""
 
 import numpy as np
+import pytest
 
 
-def test_predict_uses_dec_from_casa_column_major_phase_dir(tmp_path, monkeypatch):
+@pytest.mark.parametrize(("field", "expected_field"), [("0~1", "0,1"), (None, "all")])
+def test_predict_uses_dec_from_casa_column_major_phase_dir(
+    tmp_path, monkeypatch, field, expected_field
+):
     """CASA-backed PHASE_DIR shape should feed the correct Dec to WSClean."""
     from dsa110_continuum.adapters import casa_tables
     from dsa110_continuum.calibration import skymodels
@@ -69,13 +73,15 @@ def test_predict_uses_dec_from_casa_column_major_phase_dir(tmp_path, monkeypatch
     skymodels.predict_from_skymodel_wsclean(
         "fake.ms",
         FakeSkyModel(),
-        field="0~1",
+        field=field,
         wsclean_path="/bin/true",
         temp_dir=str(tmp_path),
         cleanup=False,
     )
 
     draw_cmd = next(cmd for cmd in commands if "-draw-model" in cmd)
+    predict_cmd = next(cmd for cmd in commands if "-predict" in cmd)
     centre_idx = draw_cmd.index("-draw-centre")
     assert draw_cmd[centre_idx + 1] == "12h0m0.000s"
     assert draw_cmd[centre_idx + 2] == "+22d0m0.000s"
+    assert predict_cmd[predict_cmd.index("-field") + 1] == expected_field

--- a/tests/test_stage_checkpoint.py
+++ b/tests/test_stage_checkpoint.py
@@ -184,6 +184,7 @@ class TestProcessMsSentinel:
         result = process_ms(ms_path, cfg, keep_intermediates=True)
         assert result.ok
         mock_image.assert_called_once()
+        assert mock_image.call_args.kwargs["field"] == "all"
 
     @mock.patch("mosaic_day.image_ms")
     @mock.patch("mosaic_day.apply_to_target", side_effect=RuntimeError("CASA crash"))

--- a/tests/test_stage_checkpoint.py
+++ b/tests/test_stage_checkpoint.py
@@ -9,10 +9,16 @@ from pathlib import Path
 from unittest import mock
 
 import numpy as np
+import pytest
 from astropy.io import fits
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from mosaic_day import TileConfig, _applycal_sentinel_path, _fits_is_valid
+
+
+@pytest.fixture(autouse=True)
+def _mock_field_normalization(monkeypatch):
+    monkeypatch.setattr("mosaic_day._normalize_meridian_for_imaging", mock.Mock())
 
 # ── Sentinel path helpers ────────────────────────────────────────────────────
 
@@ -126,6 +132,38 @@ class TestProcessMsSentinel:
     @mock.patch("mosaic_day.image_ms")
     @mock.patch("mosaic_day.apply_to_target")
     @mock.patch("mosaic_day.phaseshift_ms")
+    @mock.patch(
+        "dsa110_continuum.validation.image_validator.validate_image_quality",
+        return_value=(True, []),
+    )
+    def test_force_recal_rebuilds_collapsed_meridian(
+        self, _mock_qa, mock_phaseshift, _mock_applycal, mock_image, tmp_path
+    ):
+        from mosaic_day import process_ms
+
+        cfg = _make_cfg(tmp_path)
+        ms_path = os.path.join(cfg.ms_dir, "2026-01-25T21:17:33.ms")
+        meridian = ms_path.replace(".ms", "_meridian.ms")
+        _make_valid_ms(ms_path)
+        _make_valid_ms(meridian)
+        Path(_applycal_sentinel_path(meridian)).write_text("applycal completed\n")
+
+        def fake_phaseshift(**kwargs):
+            _make_valid_ms(kwargs["output_ms"])
+
+        mock_phaseshift.side_effect = fake_phaseshift
+        mock_image.side_effect = lambda **kwargs: _write_valid_fits(
+            kwargs["imagename"] + "-image.fits"
+        )
+
+        result = process_ms(ms_path, cfg, keep_intermediates=True, force_recal=True)
+
+        assert result.ok
+        mock_phaseshift.assert_called_once()
+
+    @mock.patch("mosaic_day.image_ms")
+    @mock.patch("mosaic_day.apply_to_target")
+    @mock.patch("mosaic_day.phaseshift_ms")
     @mock.patch("dsa110_continuum.validation.image_validator.validate_image_quality", return_value=(True, []))
     def test_skips_applycal_when_sentinel_exists(
         self, _mock_qa, mock_phaseshift, mock_applycal, mock_image, tmp_path
@@ -184,7 +222,7 @@ class TestProcessMsSentinel:
         result = process_ms(ms_path, cfg, keep_intermediates=True)
         assert result.ok
         mock_image.assert_called_once()
-        assert mock_image.call_args.kwargs["field"] == "all"
+        assert mock_image.call_args.kwargs["field"] == "0"
 
     @mock.patch("mosaic_day.image_ms")
     @mock.patch("mosaic_day.apply_to_target", side_effect=RuntimeError("CASA crash"))


### PR DESCRIPTION
## Summary
- select the real modeled calibrator tile and fall back to the full VLASS catalog
- evaluate epoch gain quality relative to inherited bandpass flags while preserving strict science QA
- continue after rejected epochs and retain their resumable inputs
- require matching PASS metadata, forced photometry, and a refreshed light-curve stack before completion or pruning
- honor configured host storage roots

## Validation
- 79 focused tests passed
- independent standards review: no blockers
- independent spec review: no blockers
- H17 canary: correct calibrator selected, 24 fields modeled, 12/12 tiles imaged; strict mosaic QA correctly remained fail-closed

Closes #103
Follow-up hardening for #169.